### PR TITLE
[TA-3219]: xrp/drops conversion

### DIFF
--- a/xrpl/client/websocket/utils.go
+++ b/xrpl/client/websocket/utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/Peersyst/xrpl-go/xrpl/client"
 	"github.com/Peersyst/xrpl-go/xrpl/model/client/account"
@@ -139,15 +138,12 @@ func (c *WebsocketClient) calculateFeePerTransactionType(tx *map[string]interfac
 		return err
 	}
 
-	// TODO: Replace with XrpToDrops util when implemented
-	feeFloat, err := strconv.ParseFloat(fee, 64)
+	feeDrops, err := utils.XrpToDrops(fee)
 	if err != nil {
 		return err
 	}
-	feeDrops := feeFloat * utils.DROPS_PER_XRP
 
-	roundedFee := math.Ceil(feeDrops)
-	(*tx)["Fee"] = fmt.Sprintf("%.0f", roundedFee)
+	(*tx)["Fee"] = feeDrops
 
 	return nil
 }

--- a/xrpl/utils/xrp_drops.go
+++ b/xrpl/utils/xrp_drops.go
@@ -1,15 +1,40 @@
 package utils
 
-const (
-	DROPS_PER_XRP float64 = 1000000
+import (
+	"errors"
+	"strconv"
+	"strings"
 )
 
-// TODO: Implement this
-func XrpToDrops(xrpAmount float32) float32 {
-	return 0
+const (
+	DROPS_PER_XRP       float64 = 1000000
+	max_fraction_length uint    = 6
+)
+
+// Convert an amount in XRP to an amount in drops.
+func XrpToDrops(value string) (string, error) {
+	if i := strings.IndexByte(value, '.'); i != -1 && len(value[i+1:]) > int(max_fraction_length) {
+		return "", errors.New("xrp to drops: value has too many decimals")
+	}
+
+	xrpFloat, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return "", err
+	}
+
+	dropsFloat := xrpFloat * DROPS_PER_XRP
+	return strconv.FormatFloat(dropsFloat, 'f', -1, 64), nil
+
 }
 
-// TODO: Implement this
-func DropsToXrp(dropsAmount float32) float32 {
-	return 0
+// Convert an amount of drops into an amount of xrp
+func DropsToXrp(value string) (string, error) {
+	dropUint, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return "", err
+	}
+
+	xrpFloat := float64(dropUint) / DROPS_PER_XRP
+
+	return strconv.FormatFloat(xrpFloat, 'f', -1, 64), nil
 }

--- a/xrpl/utils/xrp_drops_test.go
+++ b/xrpl/utils/xrp_drops_test.go
@@ -1,0 +1,146 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestXrpToDrops(t *testing.T) {
+	tt := []struct{
+		name string
+		xrp string
+		drops string
+		expectedErr error
+	}{
+		{
+			name: "XRP to Drops (no decimals)",
+			xrp: "1",
+			drops: "1000000",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (decimals)(1)",
+			xrp: "3.456789",
+			drops: "3456789",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (decimals)(2)",
+			xrp: "0.000001",
+			drops: "1",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (decimals)(3)",
+			xrp: "0.000000",
+			drops: "0",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (decimals)(4)",
+			xrp: "3.400000",
+			drops: "3400000",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (scientific notation)",
+			xrp: "1e-6",
+			drops: "1",
+			expectedErr: nil,
+		},
+		{
+			name: "XRP to Drops (too many decimals)",
+			xrp: "0.0000001",
+			drops: "1",
+			expectedErr: errors.New("xrp to drops: value has too many decimals"),
+		},
+		{
+			name: "XRP to Drops (invalid input)",
+			xrp: "abc",
+			drops: "",
+			expectedErr: errors.New("strconv.ParseFloat: parsing \"abc\": invalid syntax"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			drops, err := XrpToDrops(tc.xrp)
+			if tc.expectedErr != nil {
+				if err == nil || err.Error() != tc.expectedErr.Error() {
+					t.Errorf("Expected error: %v, got: %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if drops != tc.drops {
+					t.Errorf("Expected %s drops, got %s", tc.drops, drops)
+				}
+			}
+		})
+	}
+}
+
+func TestDropsToXrp(t *testing.T) {
+	tt := []struct {
+		name        string
+		drops       string
+		xrp         string
+		expectedErr error
+	}{
+		{
+			name:        "Drops to XRP (whole number)",
+			drops:       "1000000",
+			xrp:         "1",
+			expectedErr: nil,
+		},
+		{
+			name:        "Drops to XRP (decimal)",
+			drops:       "1234567",
+			xrp:         "1.234567",
+			expectedErr: nil,
+		},
+		{
+			name:        "Drops to XRP (zero)",
+			drops:       "0",
+			xrp:         "0",
+			expectedErr: nil,
+		},
+		{
+			name:        "Drops to XRP (small amount)",
+			drops:       "1",
+			xrp:         "0.000001",
+			expectedErr: nil,
+		},
+		{
+			name:        "Drops to XRP (large amount)",
+			drops:       "123456789000000",
+			xrp:         "123456789",
+			expectedErr: nil,
+		},
+		{
+			name:        "Drops to XRP (invalid input)",
+			drops:       "abc",
+			xrp:         "",
+			expectedErr: errors.New("strconv.ParseUint: parsing \"abc\": invalid syntax"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			xrp, err := DropsToXrp(tc.drops)
+			if tc.expectedErr != nil {
+				if err == nil || err.Error() != tc.expectedErr.Error() {
+					t.Errorf("Expected error: %v, got: %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if xrp != tc.xrp {
+					t.Errorf("Expected %s XRP, got %s", tc.xrp, xrp)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# [TA-3219]: xrp/drops conversion

This PR aims to implenent `xrp` and `drops` conversion safely. Also, updates the `calculateFeePerTransactionType` websocket client method with the new safe conversion.

## Changes

- `XrpToDrops` function
- `DropsToXrp` function
- Provided testing for both methods
- Updated `calculateFeePerTransactionType` with drops conversion

