### PR TITLE
[TA-3248]: Flatten Signer and SignerData

### DIFF
--- a/examples/websocket/autofill/main.go
+++ b/examples/websocket/autofill/main.go
@@ -32,6 +32,22 @@ func main() {
 	payment := transactions.Payment{
 		BaseTx: transactions.BaseTx{
 			Account: types.Address(wallet.GetAddress()),
+			Signers: []transactions.Signer{
+				{
+					SignerData: transactions.SignerData{
+						Account:       types.Address(wallet.GetAddress()),
+						SigningPubKey: wallet.PublicKey,
+						TxnSignature:  "",
+					},
+				},
+				{
+					SignerData: transactions.SignerData{
+						Account:       types.Address(wallet.GetAddress()),
+						SigningPubKey: wallet.PublicKey,
+						TxnSignature:  "",
+					},
+				},
+			},
 			Memos: []transactions.MemoWrapper{
 				{
 					Memo: transactions.Memo{

--- a/xrpl/model/transactions/signer.go
+++ b/xrpl/model/transactions/signer.go
@@ -8,8 +8,34 @@ type Signer struct {
 	SignerData SignerData `json:"Signer"`
 }
 
+type FlatSigner map[string]interface{}
+
+func (s *Signer) Flatten() FlatSigner {
+	flattened := make(FlatSigner)
+	if s.SignerData != (SignerData{}) {
+		flattened["SignerData"] = s.SignerData.Flatten()
+	}
+	return flattened
+}
+
 type SignerData struct {
 	Account       types.Address
 	TxnSignature  string
 	SigningPubKey string
+}
+
+type FlatSignerData map[string]interface{}
+
+func (sd *SignerData) Flatten() FlatSignerData {
+	flattened := make(FlatSignerData)
+	if sd.Account != "" {
+		flattened["Account"] = sd.Account.String()
+	}
+	if sd.TxnSignature != "" {
+		flattened["TxnSignature"] = sd.TxnSignature
+	}
+	if sd.SigningPubKey != "" {
+		flattened["SigningPubKey"] = sd.SigningPubKey
+	}
+	return flattened
 }

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -139,7 +139,14 @@ func (tx *BaseTx) Flatten() FlatTransaction {
 		flattened["NetworkId"] = tx.NetworkId
 	}
 	if len(tx.Signers) > 0 {
-		flattened["Signers"] = tx.Signers
+		flattenedSigners := make([]FlatSigner, 0)
+		for _, signer := range tx.Signers {
+			flattenedSigner := signer.Flatten()
+			if flattenedSigner != nil {
+				flattenedSigners = append(flattenedSigners, flattenedSigner)
+			}
+		}
+		flattened["Signers"] = flattenedSigners
 	}
 	if tx.SourceTag != 0 {
 		flattened["SourceTag"] = tx.SourceTag


### PR DESCRIPTION
# [TA-3248]: Flatten Signer and SignerData

This PR aims to add flat structures for `Signer` and `SignerData`

## Changes

- Added flat structures for `Signer` and `SignerData`
