### PR TITLE
[TA-3251]: Add encoding support for Memos

### DIFF
--- a/examples/transactions/payment/main.go
+++ b/examples/transactions/payment/main.go
@@ -3,11 +3,32 @@ package main
 import (
 	"fmt"
 
+	"github.com/Peersyst/xrpl-go/xrpl"
+	"github.com/Peersyst/xrpl-go/xrpl/client/websocket"
+	"github.com/Peersyst/xrpl-go/xrpl/faucet"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 func main() {
+
+	wallet, err := xrpl.NewWalletFromSeed("sEdSMVV4dJ1JbdBxmakRR4Puu3XVZz2", "")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_, err = xrpl.NewWalletFromSeed("sEd7d8Ci9nevdLCeUMctF3uGXp9WQqJ", "")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_ = websocket.NewWebsocketClient(
+		websocket.NewWebsocketClientConfig().
+			WithHost("wss://s.altnet.rippletest.net:51233").
+			WithFaucetProvider(faucet.NewTestnetFaucetProvider()),
+	)
 
 	payment := transactions.Payment{
 		BaseTx: transactions.BaseTx{
@@ -19,8 +40,18 @@ func main() {
 			Value:    "100",
 		},
 		Destination: "r9cZA1mLK5R5AmHZiRd6CCe83ACaut34Mf",
+		DestinationTag: 100,
 	}
 
 	fmt.Println(payment)
 	fmt.Println(payment.Flatten())
+
+	txBlob, hash, err := wallet.Sign(payment.Flatten())
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(txBlob)
+	fmt.Println(hash)
 }

--- a/examples/transactions/payment/main.go
+++ b/examples/transactions/payment/main.go
@@ -39,7 +39,7 @@ func main() {
 			Issuer:   "r9cZA1mLK5R5AmHZiRd6CCe83ACaut34Mf",
 			Value:    "100",
 		},
-		Destination: "r9cZA1mLK5R5AmHZiRd6CCe83ACaut34Mf",
+		Destination:    "r9cZA1mLK5R5AmHZiRd6CCe83ACaut34Mf",
 		DestinationTag: 100,
 	}
 

--- a/examples/wallet/generate_wallet_and_sign_tx.go
+++ b/examples/wallet/generate_wallet_and_sign_tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
@@ -52,6 +53,22 @@ func main() {
 	tx := transactions.Payment{
 		BaseTx: transactions.BaseTx{
 			Account: types.Address(wallet.ClassicAddress),
+			Memos: []transactions.MemoWrapper{
+				{
+					Memo: transactions.Memo{
+						MemoData:   hex.EncodeToString([]byte("Hello, World!")),
+						MemoFormat: hex.EncodeToString([]byte("text/plain")),
+						MemoType:   hex.EncodeToString([]byte("message")),
+					},
+				},
+				{
+					Memo: transactions.Memo{
+						MemoData:   hex.EncodeToString([]byte("Hello, World 2!")),
+						MemoFormat: hex.EncodeToString([]byte("text/plain")),
+						MemoType:   hex.EncodeToString([]byte("message2")),
+					},
+				},
+			},
 		},
 		Amount: types.IssuedCurrencyAmount{
 			Issuer:   Issuer,

--- a/examples/websocket/send-payment/main.go
+++ b/examples/websocket/send-payment/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -62,6 +63,22 @@ func main() {
 	payment := transactions.Payment{
 		BaseTx: transactions.BaseTx{
 			Account: types.Address(wallet.GetAddress()),
+			Memos: []transactions.MemoWrapper{
+				{
+					Memo: transactions.Memo{
+						MemoData:   hex.EncodeToString([]byte("Hello, World!")),
+						MemoFormat: hex.EncodeToString([]byte("plain")),
+						MemoType:   hex.EncodeToString([]byte("message")),
+					},
+				},
+				{
+					Memo: transactions.Memo{
+						MemoData:   hex.EncodeToString([]byte("Hello, World 2!")),
+						MemoFormat: hex.EncodeToString([]byte("text/plain")),
+						MemoType:   hex.EncodeToString([]byte("message2")),
+					},
+				},
+			},
 		},
 		Destination: types.Address(receiverWallet.GetAddress()),
 		Amount:      types.XRPCurrencyAmount(amountUint),

--- a/xrpl/model/transactions/memo.go
+++ b/xrpl/model/transactions/memo.go
@@ -4,27 +4,23 @@ type MemoWrapper struct {
 	Memo Memo
 }
 
-type FlatMemoWrapper map[string]interface{}
-
 type Memo struct {
 	MemoData   string `json:",omitempty"`
 	MemoFormat string `json:",omitempty"`
 	MemoType   string `json:",omitempty"`
 }
 
-type FlatMemo map[string]interface{}
-
-func (mw *MemoWrapper) Flatten() FlatMemoWrapper {
+func (mw *MemoWrapper) Flatten() map[string]interface{} {
 	if mw.Memo != (Memo{}) {
-		flattened := make(FlatMemoWrapper)
+		flattened := make(map[string]interface{})
 		flattened["Memo"] = mw.Memo.Flatten()
 		return flattened
 	}
 	return nil
 }
 
-func (m *Memo) Flatten() FlatMemo {
-	flattened := make(FlatMemo)
+func (m *Memo) Flatten() map[string]interface{} {
+	flattened := make(map[string]interface{})
 
 	if m.MemoData != "" {
 		flattened["MemoData"] = m.MemoData

--- a/xrpl/model/transactions/payment.go
+++ b/xrpl/model/transactions/payment.go
@@ -93,7 +93,7 @@ func (p *Payment) Flatten() FlatTransaction {
 	}
 
 	if p.DestinationTag != 0 {
-		flattened["DestinationTag"] = p.DestinationTag
+		flattened["DestinationTag"] = int(p.DestinationTag)
 	}
 
 	if p.InvoiceID != "" {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -126,7 +126,7 @@ func (tx *BaseTx) Flatten() FlatTransaction {
 		flattened["LastLedgerSequence"] = tx.LastLedgerSequence
 	}
 	if len(tx.Memos) > 0 {
-		flattenedMemos := make([]FlatMemoWrapper, 0)
+		flattenedMemos := make([]any, 0)
 		for _, memo := range tx.Memos {
 			flattenedMemo := memo.Flatten()
 			if flattenedMemo != nil {


### PR DESCRIPTION
# [TA-3251]: Add encoding support for Memos

This PR aims to fix an issue when signing a transaction containing `Memos` field. Also, includes a fix for `DestinationTag` conversion. when flatting a transaction

## Changes

- Removed flat memo types
- `DestinationTag` field flat parsing
