### PR TITLE
Adding validations for all the remaining Transactions

### DIFF
--- a/pkg/map_utils/map_utils_test.go
+++ b/pkg/map_utils/map_utils_test.go
@@ -1,0 +1,35 @@
+package maputils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetKeys(t *testing.T) {
+	// Test case 1: Empty map
+	m1 := make(map[string]interface{})
+	expected1 := []string{}
+	if keys1 := GetKeys(m1); !reflect.DeepEqual(keys1, expected1) {
+		t.Errorf("Expected %v, but got %v", expected1, keys1)
+	}
+
+	// Test case 2: Map with one key-value pair
+	m2 := map[string]interface{}{
+		"key1": "value1",
+	}
+	expected2 := []string{"key1"}
+	if keys2 := GetKeys(m2); !reflect.DeepEqual(keys2, expected2) {
+		t.Errorf("Expected %v, but got %v", expected2, keys2)
+	}
+
+	// Test case 3: Map with multiple key-value pairs
+	m3 := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	expected3 := []string{"key1", "key2", "key3"}
+	if keys3 := GetKeys(m3); !reflect.DeepEqual(keys3, expected3) {
+		t.Errorf("Expected %v, but got %v", expected3, keys3)
+	}
+}

--- a/pkg/typecheck/typecheck.go
+++ b/pkg/typecheck/typecheck.go
@@ -1,6 +1,9 @@
 package typecheck
 
-import "regexp"
+import (
+	"reflect"
+	"regexp"
+)
 
 // IsString checks if the given interface is a string.
 func IsString(str interface{}) bool {
@@ -49,4 +52,10 @@ func IsHex(s string) bool {
 func IsMap(m interface{}) bool {
 	_, ok := m.(map[string]interface{})
 	return ok
+}
+
+// IsArrayOrSlice checks if the given value is an array or a slice.
+func IsArrayOrSlice(value interface{}) bool {
+	v := reflect.ValueOf(value)
+	return v.Kind() == reflect.Array || v.Kind() == reflect.Slice
 }

--- a/pkg/typecheck/typecheck.go
+++ b/pkg/typecheck/typecheck.go
@@ -44,3 +44,9 @@ func IsHex(s string) bool {
 	var validHexPattern = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 	return validHexPattern.MatchString(s)
 }
+
+// IsMap checks if the given interface is a map.
+func IsMap(m interface{}) bool {
+	_, ok := m.(map[string]interface{})
+	return ok
+}

--- a/pkg/typecheck/typecheck_test.go
+++ b/pkg/typecheck/typecheck_test.go
@@ -336,3 +336,49 @@ func TestIsMap(t *testing.T) {
 		})
 	}
 }
+func TestIsArrayOrSlice(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  bool
+	}{
+		{
+			name:  "Valid array",
+			value: [3]int{1, 2, 3},
+			want:  true,
+		},
+		{
+			name:  "Valid slice",
+			value: []string{"apple", "banana", "cherry"},
+			want:  true,
+		},
+		{
+			name:  "Invalid array",
+			value: "not an array",
+			want:  false,
+		},
+		{
+			name:  "Invalid slice",
+			value: 42,
+			want:  false,
+		},
+		{
+			name:  "Empty array",
+			value: [0]int{},
+			want:  true,
+		},
+		{
+			name:  "Empty slice",
+			value: []int{},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsArrayOrSlice(tt.value); got != tt.want {
+				t.Errorf("IsArrayOrSlice(%v) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/typecheck/typecheck_test.go
+++ b/pkg/typecheck/typecheck_test.go
@@ -300,3 +300,39 @@ func TestIsInt(t *testing.T) {
 		})
 	}
 }
+func TestIsMap(t *testing.T) {
+	tests := []struct {
+		name string
+		m    interface{}
+		want bool
+	}{
+		{
+			name: "Valid map",
+			m:    map[string]interface{}{"key": "value"},
+			want: true,
+		},
+		{
+			name: "Invalid map",
+			m:    "not a map",
+			want: false,
+		},
+		{
+			name: "Empty map",
+			m:    map[string]interface{}{},
+			want: true,
+		},
+		{
+			name: "Nil map",
+			m:    nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMap(tt.m); got != tt.want {
+				t.Errorf("IsMap(%v) = %v, want %v", tt.m, got, tt.want)
+			}
+		})
+	}
+}

--- a/xrpl/model/transactions/account_delete.go
+++ b/xrpl/model/transactions/account_delete.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -16,5 +17,20 @@ func (*AccountDelete) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AccountDelete) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateAccountDelete(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Replace IsString by a check for valid xrpl address
+	ValidateRequiredField(tx, "Destination", typecheck.IsString)
+
+	ValidateOptionalField(tx, "DestinationTag", typecheck.IsInt)
+
 	return nil
 }

--- a/xrpl/model/transactions/account_set.go
+++ b/xrpl/model/transactions/account_set.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
@@ -331,64 +332,49 @@ func ValidateAccountSet(tx FlatTransaction) error {
 		return err
 	}
 
-	// check ClearFlag is defined
-	if _, ok := tx["ClearFlag"]; ok {
-		// check if ClearFlag is a number
-		if !typecheck.IsUint(tx["ClearFlag"]) {
-			return errors.New("AccountSet: ClearFlag must be a number")
-		}
+	err = ValidateOptionalField(tx, "ClearFlag", typecheck.IsUint)
+	if err != nil {
+		return err
 	}
 
-	// check Domain is defined and a string
-	if _, ok := tx["Domain"]; ok {
-		if !typecheck.IsString(tx["Domain"]) {
-			return errors.New("AccountSet: Domain must be a string")
-		}
+	err = ValidateOptionalField(tx, "Domain", typecheck.IsString)
+	if err != nil {
+		return err
 	}
 
-	// check EmailHash is defined and a hash128/string
-	if _, ok := tx["EmailHash"]; ok {
-		if !typecheck.IsString(tx["EmailHash"]) {
-			return errors.New("AccountSet: EmailHash must be a Hash128")
-		}
+	err = ValidateOptionalField(tx, "EmailHash", typecheck.IsString)
+	if err != nil {
+		return err
 	}
 
-	// check MessageKey is defined and a string
-	if _, ok := tx["MessageKey"]; ok {
-		if !typecheck.IsString(tx["MessageKey"]) {
-			return errors.New("AccountSet: MessageKey must be a string")
-		}
+	err = ValidateOptionalField(tx, "MessageKey", typecheck.IsString)
+	if err != nil {
+		return err
 	}
 
-	// check SetFlag is defined and a number
-	if _, ok := tx["SetFlag"]; ok {
-		if !typecheck.IsUint(tx["SetFlag"]) {
-			return errors.New("AccountSet: SetFlag must be a number")
-		}
-
-		// check if SetFlag is within the valid range
-		if tx["SetFlag"].(uint) < asfRequireDest || tx["SetFlag"].(uint) > asfAllowTrustLineClawback {
-			return errors.New("AccountSet: SetFlag must be between asfRequireDest (1) and asfAllowTrustLineClawback (16)")
-		}
+	err = ValidateOptionalField(tx, "SetFlat", typecheck.IsUint)
+	if err != nil {
+		return err
 	}
 
-	// check TransferRate is defined and a number
-	if _, ok := tx["TransferRate"]; ok {
-		if !typecheck.IsUint(tx["TransferRate"]) {
-			return errors.New("AccountSet: TransferRate must be a number")
-		}
+	// check if SetFlag is within the valid range
+	if tx["SetFlag"].(uint) < asfRequireDest || tx["SetFlag"].(uint) > asfAllowTrustLineClawback {
+		return errors.New("AccountSet: SetFlag must be between asfRequireDest (1) and asfAllowTrustLineClawback (16)")
 	}
 
-	// check TickSize is defined and a number
-	if _, ok := tx["TickSize"]; ok {
-		if !typecheck.IsUint(tx["TickSize"]) {
-			return errors.New("AccountSet: TickSize must be a number")
-		}
+	err = ValidateOptionalField(tx, "TransferRate", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
 
-		// check if TickSize is within the valid range and different from 0
-		if tx["TickSize"].(uint) != 0 && (tx["TickSize"].(uint) < MIN_TICK_SIZE || tx["TickSize"].(uint) > MAX_TICK_SIZE) {
-			return errors.New("AccountSet: TickSize must be between 3 and 15")
-		}
+	err = ValidateOptionalField(tx, "TickSize", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	// check if TickSize is within the valid range and different from 0
+	if tx["TickSize"].(uint) != 0 && (tx["TickSize"].(uint) < MIN_TICK_SIZE || tx["TickSize"].(uint) > MAX_TICK_SIZE) {
+		return fmt.Errorf("AccountSet: TickSize must be between %d and %d", MIN_TICK_SIZE, MAX_TICK_SIZE)
 	}
 
 	return nil

--- a/xrpl/model/transactions/account_set.go
+++ b/xrpl/model/transactions/account_set.go
@@ -1,6 +1,9 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -315,4 +318,73 @@ func (s *AccountSet) SetAsfAllowTrustLineClawback() {
 // ClearAsfAllowTrustLineClawback clears the allow trust line clawback flag.
 func (s *AccountSet) ClearAsfAllowTrustLineClawback() {
 	s.ClearFlag = asfAllowTrustLineClawback
+}
+
+const MIN_TICK_SIZE = 3
+const MAX_TICK_SIZE = 15
+
+// Validate the AccountSet transaction fields.
+func ValidateAccountSet(tx FlatTransaction) error {
+	// validate the base transaction
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// check ClearFlag is defined
+	if _, ok := tx["ClearFlag"]; ok {
+		// check if ClearFlag is a number
+		if !typecheck.IsUint(tx["ClearFlag"]) {
+			return errors.New("AccountSet: ClearFlag must be a number")
+		}
+	}
+
+	// check Domain is defined and a string
+	if _, ok := tx["Domain"]; ok {
+		if !typecheck.IsString(tx["Domain"]) {
+			return errors.New("AccountSet: Domain must be a string")
+		}
+	}
+
+	// check EmailHash is defined and a hash128/string
+	if _, ok := tx["EmailHash"]; ok {
+		if !typecheck.IsString(tx["EmailHash"]) {
+			return errors.New("AccountSet: EmailHash must be a Hash128")
+		}
+	}
+
+	// check MessageKey is defined and a string
+	if _, ok := tx["MessageKey"]; ok {
+		if !typecheck.IsString(tx["MessageKey"]) {
+			return errors.New("AccountSet: MessageKey must be a string")
+		}
+	}
+
+	// check SetFlag is defined and a number
+	if _, ok := tx["SetFlag"]; ok {
+		if !typecheck.IsUint(tx["SetFlag"]) {
+			return errors.New("AccountSet: SetFlag must be a number")
+		}
+	}
+
+	// check TransferRate is defined and a number
+	if _, ok := tx["TransferRate"]; ok {
+		if !typecheck.IsUint(tx["TransferRate"]) {
+			return errors.New("AccountSet: TransferRate must be a number")
+		}
+	}
+
+	// check TickSize is defined and a number
+	if _, ok := tx["TickSize"]; ok {
+		if !typecheck.IsUint(tx["TickSize"]) {
+			return errors.New("AccountSet: TickSize must be a number")
+		}
+
+		// check if TickSize is within the valid range and different from 0
+		if tx["TickSize"].(uint) != 0 && (tx["TickSize"].(uint) < MIN_TICK_SIZE || tx["TickSize"].(uint) > MAX_TICK_SIZE) {
+			return errors.New("AccountSet: TickSize must be between 3 and 15")
+		}
+	}
+
+	return nil
 }

--- a/xrpl/model/transactions/account_set.go
+++ b/xrpl/model/transactions/account_set.go
@@ -365,6 +365,11 @@ func ValidateAccountSet(tx FlatTransaction) error {
 		if !typecheck.IsUint(tx["SetFlag"]) {
 			return errors.New("AccountSet: SetFlag must be a number")
 		}
+
+		// check if SetFlag is within the valid range
+		if tx["SetFlag"].(uint) < asfRequireDest || tx["SetFlag"].(uint) > asfAllowTrustLineClawback {
+			return errors.New("AccountSet: SetFlag must be between asfRequireDest (1) and asfAllowTrustLineClawback (16)")
+		}
 	}
 
 	// check TransferRate is defined and a number

--- a/xrpl/model/transactions/amm_bid.go
+++ b/xrpl/model/transactions/amm_bid.go
@@ -31,28 +31,29 @@ func ValidateAMMBid(tx FlatTransaction) error {
 		return err
 	}
 
-	if tx["Asset"] == nil {
-		return errors.New("AMMBid: missing field Asset")
+	err = ValidateRequiredField(tx, "Asset", IsAsset)
+	if err != nil {
+		return err
 	}
 
-	if !IsAsset(tx["Asset"]) {
-		return errors.New("AMMBid: Asset must be a Currency")
+	err = ValidateRequiredField(tx, "Asset2", IsAsset)
+	if err != nil {
+		return err
 	}
 
-	if tx["Asset2"] == nil {
-		return errors.New("AMMBid: missing field Asset2")
+	err = ValidateOptionalField(tx, "Amount", IsAmount)
+	if err != nil {
+		return err
 	}
 
-	if !IsAsset(tx["Asset2"]) {
-		return errors.New("AMMBid: Asset2 must be a Currency")
+	err = ValidateOptionalField(tx, "BidMin", IsAmount)
+	if err != nil {
+		return err
 	}
 
-	if tx["BidMin"] != nil && !IsAmount(tx["BidMin"]) {
-		return errors.New("AMMBid: BidMin must be an Amount")
-	}
-
-	if tx["BidMax"] != nil && !IsAmount(tx["BidMax"]) {
-		return errors.New("AMMBid: BidMax must be an Amount")
+	err = ValidateOptionalField(tx, "BidMax", IsAmount)
+	if err != nil {
+		return err
 	}
 
 	if tx["AuthAccounts"] != nil {

--- a/xrpl/model/transactions/amm_bid.go
+++ b/xrpl/model/transactions/amm_bid.go
@@ -1,5 +1,14 @@
 package transactions
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+)
+
+const MAX_AUTH_ACCOUNTS = 4
+
 // TODO: Implement AMMBid
 type AMMBid struct {
 	BaseTx
@@ -11,5 +20,80 @@ func (*AMMBid) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AMMBid) Flatten() FlatTransaction {
+	return nil
+}
+
+// ValidateAMMBid validates an AMMBid transaction.
+func ValidateAMMBid(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	if tx["Asset"] == nil {
+		return errors.New("AMMBid: missing field Asset")
+	}
+
+	if !IsAsset(tx["Asset"]) {
+		return errors.New("AMMBid: Asset must be a Currency")
+	}
+
+	if tx["Asset2"] == nil {
+		return errors.New("AMMBid: missing field Asset2")
+	}
+
+	if !IsAsset(tx["Asset2"]) {
+		return errors.New("AMMBid: Asset2 must be a Currency")
+	}
+
+	if tx["BidMin"] != nil && !IsAmount(tx["BidMin"]) {
+		return errors.New("AMMBid: BidMin must be an Amount")
+	}
+
+	if tx["BidMax"] != nil && !IsAmount(tx["BidMax"]) {
+		return errors.New("AMMBid: BidMax must be an Amount")
+	}
+
+	if tx["AuthAccounts"] != nil {
+		if !typecheck.IsArrayOrSlice(tx["AuthAccounts"]) {
+			return errors.New("AMMBid: AuthAccounts must be an array of strings")
+		}
+
+		authAccounts := tx["AuthAccounts"].([]map[string]interface{})
+
+		if len(authAccounts) > MAX_AUTH_ACCOUNTS {
+			return fmt.Errorf("AMMBid: AuthAccounts must have at most %v accounts", MAX_AUTH_ACCOUNTS)
+		}
+
+		err := validateAuthAccounts(tx["Account"].(string), authAccounts)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateAuthAccounts validates the AuthAccounts field of an AMMBid transaction.
+func validateAuthAccounts(senderAddress string, authAccounts []map[string]interface{}) error {
+	for _, account := range authAccounts {
+
+		// check if account is nil or not an object
+		if account == nil || !typecheck.IsMap(account) {
+			return errors.New("AMMBid: AuthAccounts must be an array of objects")
+		}
+
+		// check if account has the required fields, TODO: should check if Account is a valid xrpl account
+		if account["Account"] == nil || !typecheck.IsString(account["Account"]) {
+			return errors.New("AMMBid: AuthAccounts must have an Account field as valid xrpl account")
+		}
+
+		// check that the authAccount field is not the same as tx.Account
+		if account["Account"] == senderAddress {
+			return errors.New("AMMBid: AuthAccounts must not include the transaction Account")
+		}
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/amm_create.go
+++ b/xrpl/model/transactions/amm_create.go
@@ -4,30 +4,12 @@ import (
 	"fmt"
 
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
-	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 const AMM_MAX_TRADING_FEE = 1000
 
 type AMMCreate struct {
 	BaseTx
-
-	/**
-	 * The first of the two assets to fund this AMM with. This must be a positive amount.
-	 */
-	Amount types.CurrencyAmount
-
-	/**
-	* The second of the two assets to fund this AMM with. This must be a positive amount.
-	 */
-	Amount2 types.CurrencyAmount
-
-	/**
-	* The fee to charge for trades against this AMM instance, in units of 1/100,000; a value of 1 is equivalent to 0.001%.
-	* The maximum value is 1000, indicating a 1% fee.
-	* The minimum value is 0.
-	 */
-	TradingFee uint16
 }
 
 func (*AMMCreate) TxType() TxType {

--- a/xrpl/model/transactions/amm_create.go
+++ b/xrpl/model/transactions/amm_create.go
@@ -1,7 +1,6 @@
 package transactions
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
@@ -47,29 +46,19 @@ func ValidateAMMCreate(tx FlatTransaction) error {
 		return err
 	}
 
-	if tx["Amount"] == nil {
-		return errors.New("AMMCreate: missing field Amount")
+	err = ValidateRequiredField(tx, "Amount", IsAmount)
+	if err != nil {
+		return err
 	}
 
-	if !IsAmount(tx["Amount"]) {
-		return errors.New("AMMCreate: Amount must be an Amount")
+	err = ValidateRequiredField(tx, "Amount2", IsAmount)
+	if err != nil {
+		return err
 	}
 
-	if tx["Amount2"] == nil {
-		return errors.New("AMMCreate: missing field Amount2")
-	}
-
-	if !IsAmount(tx["Amount2"]) {
-		return errors.New("AMMCreate: Amount2 must be an Amount")
-	}
-
-	if tx["TradingFee"] == nil {
-		return errors.New("AMMCreate: missing field TradingFee")
-	}
-
-	// TODO: Check later if the type check is correct
-	if !typecheck.IsInt(tx["TradingFee"]) {
-		return errors.New("AMMCreate: TradingFee must be a number")
+	err = ValidateRequiredField(tx, "TradingFee", typecheck.IsInt)
+	if err != nil {
+		return err
 	}
 
 	if tx["TradingFee"].(int) < 0 || tx["TradingFee"].(int) > AMM_MAX_TRADING_FEE {

--- a/xrpl/model/transactions/amm_create.go
+++ b/xrpl/model/transactions/amm_create.go
@@ -1,7 +1,34 @@
 package transactions
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
+)
+
+const AMM_MAX_TRADING_FEE = 1000
+
 type AMMCreate struct {
 	BaseTx
+
+	/**
+	 * The first of the two assets to fund this AMM with. This must be a positive amount.
+	 */
+	Amount types.CurrencyAmount
+
+	/**
+	* The second of the two assets to fund this AMM with. This must be a positive amount.
+	 */
+	Amount2 types.CurrencyAmount
+
+	/**
+	* The fee to charge for trades against this AMM instance, in units of 1/100,000; a value of 1 is equivalent to 0.001%.
+	* The maximum value is 1000, indicating a 1% fee.
+	* The minimum value is 0.
+	 */
+	TradingFee uint16
 }
 
 func (*AMMCreate) TxType() TxType {
@@ -10,5 +37,44 @@ func (*AMMCreate) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AMMCreate) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateAMMCreate(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	if tx["Amount"] == nil {
+		return errors.New("AMMCreate: missing field Amount")
+	}
+
+	if !IsAmount(tx["Amount"]) {
+		return errors.New("AMMCreate: Amount must be an Amount")
+	}
+
+	if tx["Amount2"] == nil {
+		return errors.New("AMMCreate: missing field Amount2")
+	}
+
+	if !IsAmount(tx["Amount2"]) {
+		return errors.New("AMMCreate: Amount2 must be an Amount")
+	}
+
+	if tx["TradingFee"] == nil {
+		return errors.New("AMMCreate: missing field TradingFee")
+	}
+
+	// TODO: Check later if the type check is correct
+	if !typecheck.IsInt(tx["TradingFee"]) {
+		return errors.New("AMMCreate: TradingFee must be a number")
+	}
+
+	if tx["TradingFee"].(int) < 0 || tx["TradingFee"].(int) > AMM_MAX_TRADING_FEE {
+		return fmt.Errorf("AMMCreate: TradingFee must be between 0 and %v", AMM_MAX_TRADING_FEE)
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/amm_deposit.go
+++ b/xrpl/model/transactions/amm_deposit.go
@@ -1,5 +1,7 @@
 package transactions
 
+import "errors"
+
 type AMMDeposit struct {
 	BaseTx
 }
@@ -10,5 +12,63 @@ func (*AMMDeposit) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AMMDeposit) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateAMMDeposit(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// Check if the field Asset is set
+	if _, ok := tx["Asset"]; !ok {
+		return errors.New("AMMDeposit: missing field Asset")
+	}
+
+	// Check if the field Asset is an Asset
+	if !IsAsset(tx["Asset"]) {
+		return errors.New("AMMDeposit: Asset must be an issued currency or XRP")
+	}
+
+	// Check if the field Asset2 is set
+	if _, ok := tx["Asset2"]; !ok {
+		return errors.New("AMMDeposit: missing field Asset2")
+	}
+
+	// Check if the field Asset2 is an Asset
+	if !IsAsset(tx["Asset2"]) {
+		return errors.New("AMMDeposit: Asset2 must be an issued currency or XRP")
+	}
+
+	if tx["Amount2"] != nil && tx["Amount"] == nil {
+		return errors.New("AMMDeposit: must set Amount with Amount2")
+	} else if tx["EPrice"] != nil && tx["Amount"] == nil {
+		return errors.New("AMMDeposit: must set Amount with EPrice")
+	} else if tx["LPTokenOut"] == nil && tx["Amount"] == nil {
+		return errors.New("AMMDeposit: must set at least LPTokenOut or Amount")
+	}
+
+	// Check if the field LPTokenOut is an IssuedCurrencyAmount
+	if tx["LPTokenOut"] != nil && !IsIssuedCurrency(tx["LPTokenOut"]) {
+		return errors.New("AMMDeposit: LPTokenOut must be an IssuedCurrencyAmount")
+	}
+
+	// Check if the field Amount is an Amount
+	if tx["Amount"] != nil && !IsAmount(tx["Amount"]) {
+		return errors.New("AMMDeposit: Amount must be an Amount")
+	}
+
+	// Check if the field Amount2 is an Amount
+	if tx["Amount2"] != nil && !IsAmount(tx["Amount2"]) {
+		return errors.New("AMMDeposit: Amount2 must be an Amount")
+	}
+
+	// Check if the field EPrice is an Amount
+	if tx["EPrice"] != nil && !IsAmount(tx["EPrice"]) {
+		return errors.New("AMMDeposit: EPrice must be an Amount")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/amm_vote.go
+++ b/xrpl/model/transactions/amm_vote.go
@@ -1,5 +1,12 @@
 package transactions
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+)
+
 type AMMVote struct {
 	BaseTx
 }
@@ -10,5 +17,50 @@ func (*AMMVote) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AMMVote) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateAMMVote(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// Check if the Asset field is set
+	if _, ok := tx["Asset"]; !ok {
+		return errors.New("AMMVote: missing field Asset")
+	}
+
+	// Check if Asset is an Asset
+	if !IsAsset(tx["Asset"]) {
+		return errors.New("AMMVote: Asset must be a Currency")
+	}
+
+	// Check if the Asset2 field is set
+	if _, ok := tx["Asset2"]; !ok {
+		return errors.New("AMMVote: missing field Asset2")
+	}
+
+	// Check if Asset2 is an Asset
+	if !IsAsset(tx["Asset2"]) {
+		return errors.New("AMMVote: Asset2 must be a Currency")
+	}
+
+	// Check if the TradingFee field is set
+	if _, ok := tx["TradingFee"]; !ok {
+		return errors.New("AMMVote: missing field TradingFee")
+	}
+
+	// Check if TradingFee is a number TODO: check later if IsInt is the right check
+	if !typecheck.IsInt(tx["TradingFee"]) {
+		return errors.New("AMMVote: TradingFee must be a number")
+	}
+
+	// Check if TradingFee is between 0 and AMM_MAX_TRADING_FEE
+	if tx["TradingFee"].(int) < 0 || tx["TradingFee"].(int) > AMM_MAX_TRADING_FEE {
+		return fmt.Errorf("AMMVote: TradingFee must be between 0 and %v", AMM_MAX_TRADING_FEE)
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/amm_withdraw.go
+++ b/xrpl/model/transactions/amm_withdraw.go
@@ -1,5 +1,7 @@
 package transactions
 
+import "errors"
+
 type AMMWithdraw struct {
 	BaseTx
 }
@@ -10,5 +12,60 @@ func (*AMMWithdraw) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *AMMWithdraw) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateAMMWithdraw(tx FlatTransaction) error {
+	// Validate base transaction fields
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// Check if the Asset field is set
+	if _, ok := tx["Asset"]; !ok {
+		return errors.New("AMMWithdraw: missing field Asset")
+	}
+
+	// Chck if Asset is an Asset
+	if !IsAsset(tx["Asset"]) {
+		return errors.New("AMMWithdraw: Asset must be a Currency")
+	}
+
+	// Check if the Asset2 field is set
+	if _, ok := tx["Asset2"]; !ok {
+		return errors.New("AMMWithdraw: missing field Asset2")
+	}
+
+	// Check if Asset2 is an Asset
+	if !IsAsset(tx["Asset2"]) {
+		return errors.New("AMMWithdraw: Asset2 must be a Currency")
+	}
+
+	if tx["Amount2"] != nil && tx["Amount"] == nil {
+		return errors.New("AMMWithdraw: must set Amount with Amount2")
+	} else if tx["EPrice"] != nil && tx["Amount"] == nil {
+		return errors.New("AMMWithdraw: must set Amount with EPrice")
+	}
+
+	if tx["LPTokenIn"] != nil && !IsIssuedCurrency(tx["LPTokenIn"]) {
+		return errors.New("AMMWithdraw: must set at least LPTokenOut or Amount")
+	}
+
+	// Check if the field Amount is an Amount
+	if tx["Amount"] != nil && !IsAmount(tx["Amount"]) {
+		return errors.New("AMMWithdraw: Amount must be an Amount")
+	}
+
+	// Check if the field Amount2 is an Amount
+	if tx["Amount2"] != nil && !IsAmount(tx["Amount2"]) {
+		return errors.New("AMMWithdraw: Amount2 must be an Amount")
+	}
+
+	// Check if the field EPrice is an Amount
+	if tx["EPrice"] != nil && !IsAmount(tx["EPrice"]) {
+		return errors.New("AMMWithdraw: EPrice must be an Amount")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/amounts_utils.go
+++ b/xrpl/model/transactions/amounts_utils.go
@@ -1,0 +1,42 @@
+package transactions
+
+import (
+	"errors"
+	"strconv"
+)
+
+// Parse the value of an amount, expressed either in XRP or as an Issued Currency, into a float64 or int.
+func ParseAmountValue(amount interface{}) (float64, error) {
+	if !IsAmount(amount) {
+		return 0, errors.New("invalid amount")
+	}
+	switch v := amount.(type) {
+	case string:
+		// If amount is a string, parse it to a float or int
+		parsedFloat, err := strconv.ParseFloat(v, 64)
+		if err == nil {
+			return parsedFloat, nil
+		}
+		parsedInt, err := strconv.ParseInt(v, 10, 64)
+		if err == nil {
+			return float64(parsedInt), nil
+		}
+		return 0, errors.New("invalid string amount format")
+	case map[string]interface{}:
+		// If amount is a map, assume it has a "value" key with a string value
+		if value, ok := v["value"].(string); ok {
+			parsedFloat, err := strconv.ParseFloat(value, 64)
+			if err == nil {
+				return parsedFloat, nil
+			}
+			parsedInt, err := strconv.ParseInt(value, 10, 64)
+			if err == nil {
+				return float64(parsedInt), nil
+			}
+			return 0, errors.New("invalid amount format, the 'value' key is not a string and correct float or int")
+		}
+		return 0, errors.New("invalid amount format, no 'value' key")
+	default:
+		return 0, errors.New("unsupported amount type")
+	}
+}

--- a/xrpl/model/transactions/amounts_utils_test.go
+++ b/xrpl/model/transactions/amounts_utils_test.go
@@ -1,0 +1,73 @@
+package transactions
+
+import (
+	"testing"
+)
+
+func TestParseAmountValue(t *testing.T) {
+	// Test valid XRP amount as float
+	xrpAmountStr := "10.5"
+	expectedXrpAmount := 10.5
+	parsedXrpAmount, err := ParseAmountValue(xrpAmountStr)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if parsedXrpAmount != expectedXrpAmount {
+		t.Errorf("Expected XRP amount: %f, got: %f", expectedXrpAmount, parsedXrpAmount)
+	}
+
+	// Test valid XRP amount as int
+	xrpAmountInt := "20"
+	expectedXrpAmount = 20.0
+	parsedXrpAmount, err = ParseAmountValue(xrpAmountInt)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if parsedXrpAmount != expectedXrpAmount {
+		t.Errorf("Expected XRP amount: %f, got: %f", expectedXrpAmount, parsedXrpAmount)
+	}
+
+	// Test valid Issued Currency amount as float
+	issuedAmount := map[string]interface{}{
+		"value":    "30.75",
+		"issuer":   "rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS",
+		"currency": "USD",
+	}
+	expectedIssuedAmount := 30.75
+	parsedIssuedAmount, err := ParseAmountValue(issuedAmount)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if parsedIssuedAmount != expectedIssuedAmount {
+		t.Errorf("Expected Issued Currency amount: %f, got: %f", expectedIssuedAmount, parsedIssuedAmount)
+	}
+
+	// Test valid Issued Currency amount as int
+	issuedAmountAsInt := map[string]interface{}{
+		"value":    "30",
+		"issuer":   "rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS",
+		"currency": "USD",
+	}
+	expectedIssuedAmount2 := 30.0
+	parsedIssuedAmount2, err := ParseAmountValue(issuedAmountAsInt)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if parsedIssuedAmount2 != expectedIssuedAmount2 {
+		t.Errorf("Expected Issued Currency amount: %f, got: %f", expectedIssuedAmount2, parsedIssuedAmount2)
+	}
+
+	// Test invalid amount format
+	invalidAmount := "invalid"
+	_, err = ParseAmountValue(invalidAmount)
+	if err == nil {
+		t.Error("Expected error for invalid amount format, but got nil")
+	}
+
+	// Test unsupported amount type
+	unsupportedAmount := []int{1, 2, 3}
+	_, err = ParseAmountValue(unsupportedAmount)
+	if err == nil {
+		t.Error("Expected error for unsupported amount type, but got nil")
+	}
+}

--- a/xrpl/model/transactions/check_cancel.go
+++ b/xrpl/model/transactions/check_cancel.go
@@ -1,6 +1,9 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -15,5 +18,19 @@ func (*CheckCancel) TxType() TxType {
 }
 
 func (s *CheckCancel) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateCheckCancel(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	_, hasCheckID := tx["CheckID"]
+	if hasCheckID && !typecheck.IsString(tx["CheckID"]) {
+		return errors.New("CheckCancel: invalid CheckID, must be a string")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/check_cash.go
+++ b/xrpl/model/transactions/check_cash.go
@@ -2,14 +2,26 @@ package transactions
 
 import (
 	"encoding/json"
+	"errors"
 
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 type CheckCash struct {
 	BaseTx
-	CheckID    types.Hash256
-	Amount     types.CurrencyAmount `json:",omitempty"`
+
+	// The ID of the Check ledger object to cash as a 64-character hexadecimal string.
+	CheckID types.Hash256
+
+	// Redeem the Check for exactly this amount, if possible. The currency must
+	// match that of the SendMax of the corresponding CheckCreate transaction. You.
+	// must provide either this field or DeliverMin.
+	Amount types.CurrencyAmount `json:",omitempty"`
+
+	//Redeem the Check for at least this amount and for as much as possible. The
+	//currency must match that of the SendMax of the corresponding CheckCreate.
+	//transaction. You must provide either this field or Amount.
 	DeliverMin types.CurrencyAmount `json:",omitempty"`
 }
 
@@ -52,4 +64,42 @@ func (tx *CheckCash) UnmarshalJSON(data []byte) error {
 	tx.DeliverMin = min
 	return nil
 
+}
+
+func ValidateCheckCash(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	_, hasCheckID := tx["CheckID"]
+	_, hasAmount := tx["Amount"]
+	_, hasDeliverMin := tx["DeliverMin"]
+
+	// Check if either Amount or DeliverMin are set
+	if !hasAmount && !hasDeliverMin {
+		return errors.New("CheckCash: must provide either Amount or DeliverMin")
+	}
+
+	// Check that both Amount and DeliverMin are not set
+	if hasAmount && hasDeliverMin {
+		return errors.New("CheckCash: cannot have both Amount and DeliverMin")
+	}
+
+	// Check if the field Amount is an Amount
+	if hasAmount && !IsAmount(tx["Amount"]) {
+		return errors.New("CheckCash: Amount must be an Amount - https://xrpl.org/docs/references/protocol/data-types/basic-data-types#specifying-currency-amounts")
+	}
+
+	// Check if the field DeliverMin is an Amount
+	if hasDeliverMin && !IsAmount(tx["DeliverMin"]) {
+		return errors.New("CheckCash: DeliverMin must be an Amount - https://xrpl.org/docs/references/protocol/data-types/basic-data-types#specifying-currency-amounts")
+	}
+
+	// Check if the field CheckID is set
+	if hasCheckID && !typecheck.IsString(tx["CheckID"]) {
+		return errors.New("CheckCash: CheckID must be a string")
+	}
+
+	return nil
 }

--- a/xrpl/model/transactions/check_create.go
+++ b/xrpl/model/transactions/check_create.go
@@ -2,17 +2,29 @@ package transactions
 
 import (
 	"encoding/json"
+	"errors"
 
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 type CheckCreate struct {
 	BaseTx
-	Destination    types.Address
-	SendMax        types.CurrencyAmount
-	DestinationTag uint          `json:",omitempty"`
-	Expiration     uint          `json:",omitempty"`
-	InvoiceID      types.Hash256 `json:",omitempty"`
+	// The unique address of the account that can cash the Check.
+	Destination types.Address
+	// Maximum amount of source currency the Check is allowed to debit the
+	// sender, including transfer fees on non-XRP currencies. The Check can only
+	// credit the destination with the same currency (from the same issuer, for
+	// non-XRP currencies). For non-XRP amounts, the nested field names MUST be.
+	// lower-case.
+	SendMax types.CurrencyAmount
+	// Arbitrary tag that identifies the reason for the Check, or a hosted.
+	// recipient to pay.
+	DestinationTag uint `json:",omitempty"`
+	// Time after which the Check is no longer valid, in seconds since the Ripple Epoch.
+	Expiration uint `json:",omitempty"`
+	//  Arbitrary 256-bit hash representing a specific reason or identifier for this Check.
+	InvoiceID types.Hash256 `json:",omitempty"`
 }
 
 func (*CheckCreate) TxType() TxType {
@@ -50,6 +62,26 @@ func (c *CheckCreate) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	c.SendMax = max
+
+	return nil
+}
+
+func ValidateCheckCreate(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Update IsString by IsAccount when that function exists for the Destination check
+	ValidateRequiredField(tx, "Destination", typecheck.IsString)
+	ValidateOptionalField(tx, "DestinationTag", typecheck.IsUint)
+
+	if !typecheck.IsString(tx["SendMax"]) && IsIssuedCurrency(tx["SendMax"]) {
+		return errors.New("CheckCreate: invalid SendMax, must be an issued currency")
+	}
+
+	ValidateOptionalField(tx, "Expiration", typecheck.IsUint)
+	ValidateOptionalField(tx, "InvoiceID", typecheck.IsString)
 
 	return nil
 }

--- a/xrpl/model/transactions/deposit_preauth.go
+++ b/xrpl/model/transactions/deposit_preauth.go
@@ -1,12 +1,20 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 type DepositPreauth struct {
 	BaseTx
-	Authorize   types.Address `json:",omitempty"`
+
+	// The XRP Ledger address of the sender to preauthorize.
+	Authorize types.Address `json:",omitempty"`
+
+	//   The XRP Ledger address of a sender whose preauthorization should be.
+	//   revoked.
 	Unauthorize types.Address `json:",omitempty"`
 }
 
@@ -16,5 +24,56 @@ func (*DepositPreauth) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *DepositPreauth) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateDepositPreauth(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	_, hasAuthorize := tx["Authorize"]
+	_, hasUnauthorize := tx["Unauthorize"]
+
+	// Check if both Authorize and Unauthorize are set
+	if hasAuthorize && hasUnauthorize {
+		return errors.New("DepositPreauth: can't provide both Authorize and Unauthorize fields")
+	}
+
+	// Check if neither Authorize nor Unauthorize are set
+	if !hasAuthorize && !hasUnauthorize {
+		return errors.New("DepositPreauth: must provide either Authorize or Unauthorize field")
+	}
+
+	// Check if the field Authorize is set
+	if _, ok := tx["Authorize"]; !ok {
+		return errors.New("DepositPreauth: missing field Authorize")
+	}
+
+	if hasAuthorize {
+		// Check if the field Authorize is a string
+		if !typecheck.IsString(tx["Authorize"]) {
+			return errors.New("DepositPreauth: Authorize must be a string")
+		}
+
+		// Check if the field Authorize is not the same as the tx.Account
+		if tx["Authorize"] == tx["Account"] {
+			return errors.New("DepositPreauth: Account can't preauthorize its own address")
+		}
+	}
+
+	if hasUnauthorize {
+		// Check if the field Unauthorize is a string
+		if !typecheck.IsString(tx["Unauthorize"]) {
+			return errors.New("DepositPreauth: Unauthorize must be a string")
+		}
+
+		// Check if the field Unauthorize is not the same as the tx.Account
+		if tx["Unauthorize"] == tx["Account"] {
+			return errors.New("DepositPreauth: Account can't unauthorize its own address")
+		}
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/escrow_cancel.go
+++ b/xrpl/model/transactions/escrow_cancel.go
@@ -29,9 +29,15 @@ func ValidateEscrowCancel(tx FlatTransaction) error {
 	}
 
 	// TODO: update to IsAccount when that function exists
-	ValidateRequiredField(tx, "Owner", typecheck.IsString)
+	err = ValidateRequiredField(tx, "Owner", typecheck.IsString)
+	if err != nil {
+		return err
+	}
 
-	ValidateRequiredField(tx, "OfferSequence", typecheck.IsUint)
+	err = ValidateRequiredField(tx, "OfferSequence", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/xrpl/model/transactions/escrow_cancel.go
+++ b/xrpl/model/transactions/escrow_cancel.go
@@ -1,12 +1,15 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 type EscrowCancel struct {
 	BaseTx
-	Owner         types.Address
+	// Address of the source account that funded the escrow payment.
+	Owner types.Address
+	// Transaction sequence (or Ticket  number) of EscrowCreate transaction that created the escrow to cancel.
 	OfferSequence uint
 }
 
@@ -16,5 +19,19 @@ func (*EscrowCancel) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *EscrowCancel) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateEscrowCancel(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: update to IsAccount when that function exists
+	ValidateRequiredField(tx, "Owner", typecheck.IsString)
+
+	ValidateRequiredField(tx, "OfferSequence", typecheck.IsUint)
+
 	return nil
 }

--- a/xrpl/model/transactions/escrow_create.go
+++ b/xrpl/model/transactions/escrow_create.go
@@ -1,6 +1,9 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -20,5 +23,40 @@ func (*EscrowCreate) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *EscrowCreate) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateEscrowCreate(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "Amount", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// TODO: update to IsAccount when that function exists
+	err = ValidateRequiredField(tx, "Destination", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "DestinationTag", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	_, hasCancelAfter := tx["CancelAfter"]
+	_, hasFinishAfter := tx["FinishAfter"]
+
+	if !hasCancelAfter && !hasFinishAfter {
+		return errors.New("EscrowCreate: must provide either CancelAfter or FinishAfter field")
+	}
+
+	ValidateOptionalField(tx, "CancelAfter", typecheck.IsUint)
+	ValidateOptionalField(tx, "FinishAfter", typecheck.IsUint)
+	ValidateOptionalField(tx, "Condition", typecheck.IsString)
 	return nil
 }

--- a/xrpl/model/transactions/escrow_finish.go
+++ b/xrpl/model/transactions/escrow_finish.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -18,5 +19,34 @@ func (*EscrowFinish) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *EscrowFinish) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateEscrowFinish(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "Owner", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "OfferSequence", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "Condition", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "Fulfillment", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/nftoken_burn.go
+++ b/xrpl/model/transactions/nftoken_burn.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -16,5 +17,25 @@ func (*NFTokenBurn) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *NFTokenBurn) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateNFTokenBurn(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "NFTokenID", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// TODO: replace by IsAccount to check it's a correct xrpl account when it's implemented
+	err = ValidateOptionalField(tx, "Owner", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/nftoken_cancel_offer.go
+++ b/xrpl/model/transactions/nftoken_cancel_offer.go
@@ -1,11 +1,22 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
 type NFTokenCancelOffer struct {
 	BaseTx
+
+	// An array of identifiers of NFTokenOffer objects that should be cancelled
+	// by this transaction.
+	//
+	// It is an error if an entry in this list points to an
+	// object that is not an NFTokenOffer object. It is not an
+	// error if an entry in this list points to an object that
+	// does not exist. This field is required.
 	NFTokenOffers []types.Hash256
 }
 
@@ -15,5 +26,22 @@ func (*NFTokenCancelOffer) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *NFTokenCancelOffer) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateNFTokenCancelOffer(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	if !typecheck.IsArrayOrSlice(tx["NFTokenOffers"]) {
+		return errors.New("field 'NFTokenOffers' must be an array")
+	}
+
+	if len(tx["NFTokenOffers"].([]types.Hash256)) == 0 {
+		return errors.New("field 'NFTokenOffers' must not be empty")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/nftoken_create_offer.go
+++ b/xrpl/model/transactions/nftoken_create_offer.go
@@ -2,8 +2,11 @@ package transactions
 
 import (
 	"encoding/json"
+	"errors"
 
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
+	"github.com/Peersyst/xrpl-go/xrpl/model/utils"
 )
 
 type NFTokenCreateOffer struct {
@@ -14,6 +17,11 @@ type NFTokenCreateOffer struct {
 	Expiration  uint          `json:",omitempty"`
 	Destination types.Address `json:",omitempty"`
 }
+
+const (
+	// Transaction Flags for an NFTokenCreateOffer Transaction.
+	tfSellNFToken = 0x00000001
+)
 
 func (*NFTokenCreateOffer) TxType() TxType {
 	return NFTokenCreateOfferTx
@@ -50,5 +58,79 @@ func (n *NFTokenCreateOffer) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	n.Amount = amount
+	return nil
+}
+
+func ValidateNFTokenCreateOffer(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// check if Owner is not the same as Account
+	if tx["Owner"] == tx["Account"] {
+		return errors.New("field 'Owner' must be different from 'Account'")
+	}
+
+	err = ValidateOptionalField(tx, "Destination", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// TODO: replace by IsAccount when it's implemented
+	err = ValidateOptionalField(tx, "Owner", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "NFTokenID", IsAmount)
+	if err != nil {
+		return err
+	}
+
+	isFlagsUint := typecheck.IsUint(tx["Flags"])
+
+	if isFlagsUint && utils.IsFlagEnabled(tx["Flags"].(uint), tfSellNFToken) {
+		// validate sell offer cases
+		err = validateNFTokenSellOfferCases(tx)
+		if err != nil {
+			return err
+		}
+	} else {
+		// validate buy offer cases
+		err = validateNFTokenBuyOfferCases(tx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNFTokenSellOfferCases(tx FlatTransaction) error {
+	// check if Owner is set with a valid xrpl address. TODO: replace by IsAccount when it's implemented
+	err := ValidateRequiredField(tx, "Owner", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateNFTokenBuyOfferCases(tx FlatTransaction) error {
+	// check that Owner is set
+	if tx["Owner"] == nil {
+		return errors.New("field 'Owner' must be set for buy offers")
+	}
+
+	amount, err := ParseAmountValue((tx["Amount"]))
+	if err != nil {
+		return err
+	}
+
+	if amount <= 0 {
+		return errors.New("field 'Amount' must be set for buy offers")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/nftoken_mint.go
+++ b/xrpl/model/transactions/nftoken_mint.go
@@ -1,6 +1,9 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -18,5 +21,40 @@ func (*NFTokenMint) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *NFTokenMint) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateNFTokenMint(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// check Account and Issuer are not the same
+	if tx["Account"] == tx["Issuer"] {
+		return errors.New("field 'Issuer' and 'Account' must be different")
+	}
+
+	err = ValidateRequiredField(tx, "NFTokenTaxon", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "Issuer", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// Validate URI is a string
+	err = ValidateOptionalField(tx, "URI", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// Validate URI is a hex string
+	if !typecheck.IsHex(tx["URI"].(string)) {
+		return errors.New("URI must be a hex string")
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/offer_cancel.go
+++ b/xrpl/model/transactions/offer_cancel.go
@@ -1,5 +1,7 @@
 package transactions
 
+import "github.com/Peersyst/xrpl-go/pkg/typecheck"
+
 type OfferCancel struct {
 	BaseTx
 	OfferSequence uint
@@ -11,5 +13,19 @@ func (*OfferCancel) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *OfferCancel) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateOfferCancel(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "OfferSequence", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/offer_create.go
+++ b/xrpl/model/transactions/offer_create.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"encoding/json"
 
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -53,6 +54,35 @@ func (o *OfferCreate) UnmarshalJSON(data []byte) error {
 	}
 	o.TakerGets = gets
 	o.TakerPays = pays
+
+	return nil
+}
+
+func ValidateOfferCreate(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "TakerGets", IsAmount)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "TakerPays", IsAmount)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "Expiration", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "OfferSequence", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/xrpl/model/transactions/payment_channel_claim.go
+++ b/xrpl/model/transactions/payment_channel_claim.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -87,4 +88,20 @@ func (s *PaymentChannelClaim) SetRenewFlag() {
 // the source address.
 func (s *PaymentChannelClaim) SetCloseFlag() {
 	s.Flags |= tfClose
+}
+
+func ValidatePaymentChannelClaim(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	ValidateRequiredField(tx, "Channel", typecheck.IsString)
+
+	ValidateOptionalField(tx, "Balance", typecheck.IsString)
+	ValidateOptionalField(tx, "Amount", typecheck.IsString)
+	ValidateOptionalField(tx, "Signature", typecheck.IsString)
+	ValidateOptionalField(tx, "PublicKey", typecheck.IsString)
+
+	return nil
 }

--- a/xrpl/model/transactions/payment_channel_create.go
+++ b/xrpl/model/transactions/payment_channel_create.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -20,5 +21,46 @@ func (*PaymentChannelCreate) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *PaymentChannelCreate) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidatePaymentChannelCreate(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "Amount", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// TODO: update to IsAccount when it's implemented
+	err = ValidateRequiredField(tx, "Destination", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	// TODO: check if IsUint is correct or if it should be IsInt
+	err = ValidateRequiredField(tx, "SettleDelay", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "PublicKey", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "CancelAfter", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "DestinationTag", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/payment_channel_fund.go
+++ b/xrpl/model/transactions/payment_channel_fund.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -17,5 +18,29 @@ func (*PaymentChannelFund) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *PaymentChannelFund) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidatePaymentChannelFund(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "Channel", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "Amount", typecheck.IsString)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateOptionalField(tx, "Expiration", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/set_regular_key.go
+++ b/xrpl/model/transactions/set_regular_key.go
@@ -1,6 +1,7 @@
 package transactions
 
 import (
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -15,5 +16,16 @@ func (*SetRegularKey) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *SetRegularKey) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateSetRegularKey(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	ValidateOptionalField(tx, "RegularKey", typecheck.IsString)
+
 	return nil
 }

--- a/xrpl/model/transactions/signer_list_set.go
+++ b/xrpl/model/transactions/signer_list_set.go
@@ -1,8 +1,13 @@
 package transactions
 
 import (
+	"errors"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/ledger"
 )
+
+const MAX_SIGNERS = 32
 
 type SignerListSet struct {
 	BaseTx
@@ -16,5 +21,42 @@ func (*SignerListSet) TxType() TxType {
 
 // TODO: Implement flatten
 func (s *SignerListSet) Flatten() FlatTransaction {
+	return nil
+}
+
+func ValidateSignerListSet(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "SignerQuorum", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "SignerEntries", typecheck.IsArrayOrSlice)
+	if err != nil {
+		return err
+	}
+
+	signerEntries, _ := tx["SignerEntries"].([]interface{})
+	if len(signerEntries) == 0 {
+		return errors.New("field 'SignerEntries' must not be empty")
+	}
+
+	if len(signerEntries) > MAX_SIGNERS {
+		return errors.New("field 'SignerEntries' must not exceed 32 members")
+	}
+
+	// check the WalletLocator of a SignerEntry
+	for _, entry := range signerEntries {
+		signerEntry := entry.(map[string]interface{})
+		walletLocator, ok := signerEntry["WalletLocator"].(string)
+		if ok && !typecheck.IsHex(walletLocator) {
+			return errors.New("WalletLocator in SignerEntry must be a 256-bit (32-byte) hexadecimal value")
+		}
+	}
+
 	return nil
 }

--- a/xrpl/model/transactions/ticket_create.go
+++ b/xrpl/model/transactions/ticket_create.go
@@ -1,5 +1,14 @@
 package transactions
 
+import (
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+)
+
+// https://xrpl.org/docs/references/protocol/transactions/types/ticketcreate#ticketcreate-fields
+const MAX_TICKETS = 250
+
 // A TicketCreate transaction sets aside one or more sequence numbers as Tickets.
 type TicketCreate struct {
 	// Base transaction fields
@@ -24,4 +33,23 @@ func (t *TicketCreate) Flatten() FlatTransaction {
 	}
 
 	return flattened
+}
+
+func ValidateTicketCreate(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequiredField(tx, "TicketCount", typecheck.IsUint)
+	if err != nil {
+		return err
+	}
+
+	// check if the ticket count is between 1 and MAX_TICKETS
+	if tx["TicketCount"].(uint) < 1 || tx["TicketCount"].(uint) > MAX_TICKETS {
+		return fmt.Errorf("field 'TicketCount' must be between 1 and %v", MAX_TICKETS)
+	}
+
+	return nil
 }

--- a/xrpl/model/transactions/trust_set.go
+++ b/xrpl/model/transactions/trust_set.go
@@ -2,7 +2,9 @@ package transactions
 
 import (
 	"encoding/json"
+	"errors"
 
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/model/transactions/types"
 )
 
@@ -120,6 +122,41 @@ func (t *TrustSet) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	t.LimitAmount = limit
+
+	return nil
+}
+
+// ValidateTrustSet validates the TrustSet transaction.
+func ValidateTrustSet(tx FlatTransaction) error {
+	err := ValidateBaseTransaction(tx)
+	if err != nil {
+		return err
+	}
+
+	// Check if the field LimitAmount is set
+	if _, ok := tx["LimitAmount"]; !ok {
+		return errors.New("TrustSet: missing field LimitAmount")
+	}
+
+	if !IsAmount(tx["LimitAmount"]) {
+		return errors.New("TrustSet: invalid LimitAmount")
+	}
+
+	// If QualityIn is defined
+	if _, ok := tx["QualityIn"]; ok {
+		// Check if QualityIn is a number
+		if !typecheck.IsUint(tx["QualityIn"]) {
+			return errors.New("TrustSet: QualityIn must be a number")
+		}
+	}
+
+	// If QualityOut is defined
+	if _, ok := tx["QualityOut"]; ok {
+		// Check if QualityOut is a number
+		if !typecheck.IsUint(tx["QualityOut"]) {
+			return errors.New("TrustSet: QualityOut must be a number")
+		}
+	}
 
 	return nil
 }

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -366,6 +366,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "NFTokenCreateOffer":
+		err = ValidateNFTokenCreateOffer(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -406,6 +406,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "SetRegularKey":
+		err = ValidateSetRegularKey(tx)
+		if err != nil {
+			return err
+		}
 	case "TrustSet":
 		err = ValidateTrustSet(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -276,6 +276,11 @@ func ValidateTx(tx FlatTransaction) error {
 
 	// Validate transaction fields
 	switch tx["TransactionType"] {
+	case "AccountDelete":
+		err = ValidateAccountDelete(tx)
+		if err != nil {
+			return err
+		}
 	case "AccountSet":
 		err = ValidateAccountSet(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -336,6 +336,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "EscrowCancel":
+		err = ValidateEscrowCancel(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -416,6 +416,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "TicketCreate":
+		err = ValidateTicketCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "TrustSet":
 		err = ValidateTrustSet(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -371,6 +371,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "NFTokenMint":
+		err = ValidateNFTokenMint(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -301,6 +301,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AMMVote":
+		err = ValidateAMMVote(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -321,6 +321,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "CheckCreate":
+		err = ValidateCheckCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -376,6 +376,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "OfferCancel":
+		err = ValidateOfferCancel(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -291,6 +291,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AMMDeposit":
+		err = ValidateAMMDeposit(tx)
+		if err != nil {
+			return err
+		}
 	case "AMMCreate":
 		err = ValidateAMMCreate(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -346,6 +346,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "EscrowFinish":
+		err = ValidateEscrowFinish(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -357,7 +357,12 @@ func ValidateTx(tx FlatTransaction) error {
 			return err
 		}
 	case "NFTokenBurn":
-		err = ValidateNFTokenAcceptOffer(tx)
+		err = ValidateNFTokenBurn(tx)
+		if err != nil {
+			return err
+		}
+	case "NFTokenCancelOffer":
+		err = ValidateNFTokenCancelOffer(tx)
 		if err != nil {
 			return err
 		}

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -386,6 +386,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "PaymentChannelClaim":
+		err = ValidatePaymentChannelClaim(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -391,6 +391,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "PaymentChannelCreate":
+		err = ValidatePaymentChannelCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -411,6 +411,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "SignerListSet":
+		err = ValidateSignerListSet(tx)
+		if err != nil {
+			return err
+		}
 	case "TrustSet":
 		err = ValidateTrustSet(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -311,6 +311,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "CheckCancel":
+		err = ValidateCheckCancel(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -351,6 +351,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "NFTokenAcceptOffer":
+		err = ValidateNFTokenAcceptOffer(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -301,6 +301,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "DepositPreauth":
+		err = ValidateDepositPreauth(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -286,6 +286,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AMMBid":
+		err = ValidateAMMBid(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -291,6 +291,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AMMCreate":
+		err = ValidateAMMCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -316,6 +316,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "CheckCash":
+		err = ValidateCheckCash(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -356,6 +356,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "NFTokenBurn":
+		err = ValidateNFTokenAcceptOffer(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -381,6 +381,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "OfferCreate":
+		err = ValidateOfferCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -396,6 +396,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "PaymentChannelFund":
+		err = ValidatePaymentChannelFund(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -341,6 +341,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "EscrowCreate":
+		err = ValidateEscrowCreate(tx)
+		if err != nil {
+			return err
+		}
 	case "Payment":
 		err = ValidatePayment(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -306,6 +306,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AMMWitdraw":
+		err = ValidateAMMWithdraw(tx)
+		if err != nil {
+			return err
+		}
 	case "Clawback":
 		err = ValidateClawback(tx)
 		if err != nil {

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -286,6 +286,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "Clawback":
+		err = ValidateClawback(tx)
+		if err != nil {
+			return err
+		}
 	default:
 		return (fmt.Errorf("unsupported transaction type %s", tx["TransactionType"]))
 	}

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -281,6 +281,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "TrustSet":
+		err = ValidateTrustSet(tx)
+		if err != nil {
+			return err
+		}
 	default:
 		return (fmt.Errorf("unsupported transaction type %s", tx["TransactionType"]))
 	}

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -276,13 +276,8 @@ func ValidateTx(tx FlatTransaction) error {
 
 	// Validate transaction fields
 	switch tx["TransactionType"] {
-	case "Payment":
-		err = ValidatePayment(tx)
-		if err != nil {
-			return err
-		}
-	case "TrustSet":
-		err = ValidateTrustSet(tx)
+	case "AccountSet":
+		err = ValidateAccountSet(tx)
 		if err != nil {
 			return err
 		}
@@ -291,8 +286,13 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
-	case "AccountSet":
-		err = ValidateAccountSet(tx)
+	case "Payment":
+		err = ValidatePayment(tx)
+		if err != nil {
+			return err
+		}
+	case "TrustSet":
+		err = ValidateTrustSet(tx)
 		if err != nil {
 			return err
 		}

--- a/xrpl/model/transactions/tx.go
+++ b/xrpl/model/transactions/tx.go
@@ -291,6 +291,11 @@ func ValidateTx(tx FlatTransaction) error {
 		if err != nil {
 			return err
 		}
+	case "AccountSet":
+		err = ValidateAccountSet(tx)
+		if err != nil {
+			return err
+		}
 	default:
 		return (fmt.Errorf("unsupported transaction type %s", tx["TransactionType"]))
 	}

--- a/xrpl/model/transactions/validations_commons.go
+++ b/xrpl/model/transactions/validations_commons.go
@@ -81,14 +81,15 @@ func ValidateBaseTransaction(tx FlatTransaction) error {
 }
 
 func ValidateRequiredField(tx FlatTransaction, field string, checkValidity func(interface{}) bool) error {
+	transactionType, _ := tx["TransactionType"].(string)
+
 	// Check if the field is present in the transaction map.
 	if _, ok := tx[field]; !ok {
-		return fmt.Errorf("%s is missing", field)
+		return fmt.Errorf("%s: missing field %s", transactionType, field)
 	}
 
 	// Check if the field is valid.
 	if !checkValidity(tx[field]) {
-		transactionType, _ := tx["TransactionType"].(string)
 		return fmt.Errorf("%s: invalid field %s", transactionType, field)
 	}
 

--- a/xrpl/model/transactions/validations_commons.go
+++ b/xrpl/model/transactions/validations_commons.go
@@ -131,7 +131,7 @@ func validateMemos(tx FlatTransaction) error {
 // validateSigners validates the Signers field in the transaction map.
 func validateSigners(tx FlatTransaction) error {
 	if tx["Signers"] != nil {
-		signers, ok := tx["Signers"].([]FlatTransaction)
+		signers, ok := tx["Signers"].([]FlatSigner)
 		if !ok {
 			return fmt.Errorf("BaseTransaction: invalid Signers")
 		}

--- a/xrpl/model/transactions/validations_xrpl_objects.go
+++ b/xrpl/model/transactions/validations_xrpl_objects.go
@@ -5,6 +5,7 @@ import (
 
 	maputils "github.com/Peersyst/xrpl-go/pkg/map_utils"
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+	"github.com/Peersyst/xrpl-go/xrpl/utils"
 )
 
 const (
@@ -34,22 +35,7 @@ func IsMemo(obj map[string]interface{}) bool {
 	validFormat := memo["MemoFormat"] == nil || typecheck.IsHex(memo["MemoFormat"].(string))
 	validType := memo["MemoType"] == nil || typecheck.IsHex(memo["MemoType"].(string))
 
-	return size >= 1 && size <= MEMO_SIZE && validData && validFormat && validType && onlyHasFields(memo, []string{"MemoFormat", "MemoData", "MemoType"})
-}
-
-// onlyHasFields checks if the given object has only the specified fields or a subset of them.
-func onlyHasFields(obj map[string]interface{}, fields []string) bool {
-	fieldSet := make(map[string]struct{}, len(fields))
-	for _, field := range fields {
-		fieldSet[field] = struct{}{}
-	}
-
-	for key := range obj {
-		if _, ok := fieldSet[key]; !ok {
-			return false
-		}
-	}
-	return true
+	return size >= 1 && size <= MEMO_SIZE && validData && validFormat && validType && utils.ObjectOnlyHasFields(memo, []string{"MemoFormat", "MemoData", "MemoType"})
 }
 
 // IsSigner checks if the given object is a valid Signer object.

--- a/xrpl/model/transactions/validations_xrpl_objects.go
+++ b/xrpl/model/transactions/validations_xrpl_objects.go
@@ -88,11 +88,19 @@ func IsAmount(amount interface{}) bool {
 }
 
 // IsIssuedCurrency checks if the given object is a valid IssuedCurrency object.
-func IsIssuedCurrency(input map[string]interface{}) bool {
-	return len(maputils.GetKeys(input)) == ISSUED_CURRENCY_SIZE &&
-		typecheck.IsString(input["value"]) &&
-		typecheck.IsString(input["issuer"]) &&
-		typecheck.IsString(input["currency"])
+func IsIssuedCurrency(input interface{}) bool {
+	// Check if the input is a map.
+	if !typecheck.IsMap(input) {
+		return false
+	}
+
+	// Type the input as a map.
+	i := input.(map[string]interface{})
+
+	return len(maputils.GetKeys(i)) == ISSUED_CURRENCY_SIZE &&
+		typecheck.IsString(i["value"]) &&
+		typecheck.IsString(i["issuer"]) &&
+		typecheck.IsString(i["currency"])
 }
 
 // IsPathStep checks if the given map is a valid PathStep.

--- a/xrpl/model/transactions/validations_xrpl_objects_test.go
+++ b/xrpl/model/transactions/validations_xrpl_objects_test.go
@@ -113,6 +113,13 @@ func TestIsIssuedCurrency(t *testing.T) {
 			t.Errorf("Expected IsIssuedCurrency to return false, but got true")
 		}
 	})
+
+	t.Run("A number", func(t *testing.T) {
+		obj6 := 5
+		if IsIssuedCurrency(obj6) {
+			t.Errorf("Expected IsIssuedCurrency to return false, but got true")
+		}
+	})
 }
 
 func TestCheckIssuedCurrencyIsNotXrp(t *testing.T) {

--- a/xrpl/utils/objects.go
+++ b/xrpl/utils/objects.go
@@ -1,7 +1,7 @@
 package utils
 
 // OnlyHasFields checks if the given object has only the specified fields or a subset of them.
-func OnlyHasFields(obj map[string]interface{}, fields []string) bool {
+func ObjectOnlyHasFields(obj map[string]interface{}, fields []string) bool {
 	// if obj is nil, return false
 	if obj == nil {
 		return false

--- a/xrpl/utils/objects.go
+++ b/xrpl/utils/objects.go
@@ -1,0 +1,31 @@
+package utils
+
+// OnlyHasFields checks if the given object has only the specified fields or a subset of them.
+func OnlyHasFields(obj map[string]interface{}, fields []string) bool {
+	// if obj is nil, return false
+	if obj == nil {
+		return false
+	}
+
+	// if obj is empty but not fields, return false
+	if len(obj) == 0 && len(fields) > 0 {
+		return false
+	}
+
+	// if fields is empty, return true
+	if len(fields) == 0 {
+		return true
+	}
+
+	fieldSet := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		fieldSet[field] = struct{}{}
+	}
+
+	for key := range obj {
+		if _, ok := fieldSet[key]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/xrpl/utils/objects_test.go
+++ b/xrpl/utils/objects_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import "testing"
+
+func TestOnlyHasFields(t *testing.T) {
+	t.Run("Object has only specified fields", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"field1": "value1",
+			"field2": "value2",
+			"field3": "value3",
+		}
+		fields := []string{"field1", "field2", "field3"}
+		if !OnlyHasFields(obj, fields) {
+			t.Errorf("Expected OnlyHasFields to return true, but got false")
+		}
+	})
+
+	t.Run("Object has a subset of specified fields", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"field1": "value1",
+			"field2": "value2",
+		}
+		fields := []string{"field1", "field2", "field3"}
+		if !OnlyHasFields(obj, fields) {
+			t.Errorf("Expected OnlyHasFields to return true, but got false")
+		}
+	})
+
+	t.Run("Object has extra fields", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"field1": "value1",
+			"field2": "value2",
+			"field3": "value3",
+			"field4": "value4",
+		}
+		fields := []string{"field1", "field2", "field3"}
+		if OnlyHasFields(obj, fields) {
+			t.Errorf("Expected OnlyHasFields to return false, but got true")
+		}
+	})
+
+	t.Run("Object has no fields", func(t *testing.T) {
+		obj := map[string]interface{}{}
+		fields := []string{"field1", "field2", "field3"}
+		if OnlyHasFields(obj, fields) {
+			t.Errorf("Expected OnlyHasFields to return false, but got true")
+		}
+	})
+
+	t.Run("Empty object and empty fields", func(t *testing.T) {
+		obj := map[string]interface{}{}
+		fields := []string{}
+		if !OnlyHasFields(obj, fields) {
+			t.Errorf("Expected OnlyHasFields to return true, but got false")
+		}
+	})
+}

--- a/xrpl/utils/objects_test.go
+++ b/xrpl/utils/objects_test.go
@@ -10,7 +10,7 @@ func TestOnlyHasFields(t *testing.T) {
 			"field3": "value3",
 		}
 		fields := []string{"field1", "field2", "field3"}
-		if !OnlyHasFields(obj, fields) {
+		if !ObjectOnlyHasFields(obj, fields) {
 			t.Errorf("Expected OnlyHasFields to return true, but got false")
 		}
 	})
@@ -21,7 +21,7 @@ func TestOnlyHasFields(t *testing.T) {
 			"field2": "value2",
 		}
 		fields := []string{"field1", "field2", "field3"}
-		if !OnlyHasFields(obj, fields) {
+		if !ObjectOnlyHasFields(obj, fields) {
 			t.Errorf("Expected OnlyHasFields to return true, but got false")
 		}
 	})
@@ -34,7 +34,7 @@ func TestOnlyHasFields(t *testing.T) {
 			"field4": "value4",
 		}
 		fields := []string{"field1", "field2", "field3"}
-		if OnlyHasFields(obj, fields) {
+		if ObjectOnlyHasFields(obj, fields) {
 			t.Errorf("Expected OnlyHasFields to return false, but got true")
 		}
 	})
@@ -42,7 +42,7 @@ func TestOnlyHasFields(t *testing.T) {
 	t.Run("Object has no fields", func(t *testing.T) {
 		obj := map[string]interface{}{}
 		fields := []string{"field1", "field2", "field3"}
-		if OnlyHasFields(obj, fields) {
+		if ObjectOnlyHasFields(obj, fields) {
 			t.Errorf("Expected OnlyHasFields to return false, but got true")
 		}
 	})
@@ -50,7 +50,7 @@ func TestOnlyHasFields(t *testing.T) {
 	t.Run("Empty object and empty fields", func(t *testing.T) {
 		obj := map[string]interface{}{}
 		fields := []string{}
-		if !OnlyHasFields(obj, fields) {
+		if !ObjectOnlyHasFields(obj, fields) {
 			t.Errorf("Expected OnlyHasFields to return true, but got false")
 		}
 	})


### PR DESCRIPTION
This PR needs to be reviewed after #25 .

This PR adds validations for all the remaining transaction types which are not immediately needed.

It also updates the validations for AccountSet to use `ValidateOptionalField` and ValidateRequiredField`.

It also adds`IsArrayOrSlice`, `IsMap`, `ParseAmountValue`, `GetKeys` helper functions.