### PR TITLE
[TA-3400]: XChainBridge type

### DIFF
--- a/binary-codec/types/errors/json.go
+++ b/binary-codec/types/errors/json.go
@@ -1,0 +1,9 @@
+package errors
+
+// ErrNotValidJson is an error that occurs when the json is not valid.
+type ErrNotValidJson struct{}
+
+// Error returns the error message for the ErrNotValidJson error.
+func (e *ErrNotValidJson) Error() string {
+	return "not a valid json"
+}

--- a/binary-codec/types/serialized_type.go
+++ b/binary-codec/types/serialized_type.go
@@ -49,6 +49,8 @@ func GetSerializedType(t string) SerializedType {
 		return &STArray{}
 	case "PathSet":
 		return &PathSet{}
+	case "XChainBridge":
+		return &XChainBridge{}
 	}
 	return nil
 }

--- a/binary-codec/types/xchain_bridge.go
+++ b/binary-codec/types/xchain_bridge.go
@@ -14,7 +14,7 @@ import (
 // xchain bridge objectis not valid.
 type ErrNotValidXChainBridge struct{}
 
-// Error returns the error message. 
+// Error returns the error message.
 func (e *ErrNotValidXChainBridge) Error() string {
 	return "not a valid xchain bridge"
 }
@@ -27,7 +27,7 @@ func (e *ErrReadBytes) Error() string {
 	return "read bytes error"
 }
 
-// ErrDecodeClassicAddress is an error that occurs 
+// ErrDecodeClassicAddress is an error that occurs
 // when trying to decode a classic address.
 type ErrDecodeClassicAddress struct{}
 

--- a/binary-codec/types/xchain_bridge.go
+++ b/binary-codec/types/xchain_bridge.go
@@ -1,0 +1,108 @@
+package types
+
+import (
+	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+	"github.com/Peersyst/xrpl-go/binary-codec/types/errors"
+	"github.com/Peersyst/xrpl-go/binary-codec/types/interfaces"
+)
+
+// ===============================
+// Errors
+// ===============================
+
+// ErrNotValidXChainBridge is an error that occurs when the
+// xchain bridge objectis not valid.
+type ErrNotValidXChainBridge struct{}
+
+// Error returns the error message. 
+func (e *ErrNotValidXChainBridge) Error() string {
+	return "not a valid xchain bridge"
+}
+
+// ErrReadBytes is an error that occurs when trying to read bytes with a parser.
+type ErrReadBytes struct{}
+
+// Error returns the error message.
+func (e *ErrReadBytes) Error() string {
+	return "read bytes error"
+}
+
+// ErrDecodeClassicAddress is an error that occurs 
+// when trying to decode a classic address.
+type ErrDecodeClassicAddress struct{}
+
+// Error returns the error message.
+func (e *ErrDecodeClassicAddress) Error() string {
+	return "decode classic address error"
+}
+
+// ===============================
+// XChainBridge
+// ===============================
+
+// XChainBridge is a struct that represents an xchain bridge.
+type XChainBridge struct{}
+
+// FromJson converts a json XChainBridge object to its byte slice representation.
+// It returns an error if the json is not valid or if the classic addresses are not valid.
+func (x *XChainBridge) FromJson(json any) ([]byte, error) {
+	v, ok := json.(map[string]any)
+	if !ok {
+		return nil, &errors.ErrNotValidJson{}
+	}
+
+	if v["LockingChainDoor"] == nil || v["LockingChainIssue"] == nil || v["IssuingChainDoor"] == nil || v["IssuingChainIssue"] == nil {
+		return nil, &ErrNotValidXChainBridge{}
+	}
+
+	_, lockingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainDoor"].(string))
+	if err != nil {
+		return nil, &ErrDecodeClassicAddress{}
+	}
+
+	_, lockingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainIssue"].(string))
+	if err != nil {
+		return nil, &ErrDecodeClassicAddress{}
+	}
+
+	_, issuingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainDoor"].(string))
+	if err != nil {
+		return nil, &ErrDecodeClassicAddress{}
+	}
+
+	_, issuingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainIssue"].(string))
+	if err != nil {
+		return nil, &ErrDecodeClassicAddress{}
+	}
+
+	bytes := make([]byte, 0, 80)
+
+	bytes = append(bytes, lockingChainDoor...)
+	bytes = append(bytes, lockingChainIssue...)
+	bytes = append(bytes, issuingChainDoor...)
+	bytes = append(bytes, issuingChainIssue...)
+
+	return bytes, nil
+}
+
+// ToJson converts a byte slice representation of an XChainBridge object to its json representation.
+// It returns an error if the bytes are not valid or if the classic addresses are not valid.
+func (x *XChainBridge) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) {
+	if opts == nil {
+		return nil, ErrNoLengthPrefix
+	}
+
+	bytes, err := p.ReadBytes(opts[0])
+	if err != nil {
+		return nil, &ErrReadBytes{}
+	}
+
+	json := make(map[string]string)
+
+	json["LockingChainDoor"] = addresscodec.Encode(bytes[:20], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+	json["LockingChainIssue"] = addresscodec.Encode(bytes[20:40], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+	json["IssuingChainDoor"] = addresscodec.Encode(bytes[40:60], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+	json["IssuingChainIssue"] = addresscodec.Encode(bytes[60:80], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+
+	return json, nil
+}

--- a/binary-codec/types/xchain_bridge_test.go
+++ b/binary-codec/types/xchain_bridge_test.go
@@ -1,0 +1,193 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	typeerrors "github.com/Peersyst/xrpl-go/binary-codec/types/errors"
+	"github.com/Peersyst/xrpl-go/binary-codec/types/testutil"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXChainBridge_FromJson(t *testing.T) {
+	tt := []struct {
+		name string
+		json any
+		want []byte
+		err  error
+	}{
+		{
+			name: "valid xchain bridge",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18},
+			err:  nil,
+		},
+		{
+			name: "invalid LockingChainDoor classic address",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p1",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  &ErrDecodeClassicAddress{},
+		},
+		{
+			name: "invalid LockingChainIssue classic address",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p1",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  &ErrDecodeClassicAddress{},
+		},
+		{
+			name: "invalid IssuingChainDoor classic address",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p1",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  &ErrDecodeClassicAddress{},
+		},
+		{
+			name: "invalid IssuingChainIssue classic address",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p1",
+			},
+			want: nil,
+			err:  &ErrDecodeClassicAddress{},
+		},
+		{
+			name: "not a valid json",
+			json: "not a valid json",
+			want: nil,
+			err:  &typeerrors.ErrNotValidJson{},
+		},
+		{
+			name: "invalid xchain bridge",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  &ErrNotValidXChainBridge{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			xcb := &XChainBridge{}
+			got, err := xcb.FromJson(tc.json)
+			if err != tc.err {
+				t.Errorf("FromJson() error = %v, want %v", err.Error(), tc.err.Error())
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("FromJson() got = %v, want %v", got, tc.want)
+			}
+
+		})
+	}
+}
+
+func TestXChainBridge_ToJson(t *testing.T) {
+	tt := []struct {
+		name  string
+		input []byte
+		opts  []int
+		want  map[string]string
+		err   error
+		setup func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser)
+	}{
+		{
+			name:  "Valid xchain bridge",
+			input: []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18},
+			opts:  []int{80},
+			want: map[string]string{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			err: nil,
+			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+				ctrl := gomock.NewController(t)
+				mock := testutil.NewMockBinaryParser(ctrl)
+				mock.EXPECT().ReadBytes(80).Return([]byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18}, nil)
+				return &XChainBridge{}, mock
+			},
+		},
+		{
+			name:  "No length prefix",
+			input: []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18},
+			opts:  nil,
+			want:  nil,
+			err:   ErrNoLengthPrefix,
+			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+				return &XChainBridge{}, nil
+			},
+		},
+		{
+			name:  "ReadBytes error",
+			input: []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18},
+			opts:  []int{80},
+			want:  nil,
+			err:   &ErrReadBytes{},
+			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+				ctrl := gomock.NewController(t)
+				mock := testutil.NewMockBinaryParser(ctrl)
+				mock.EXPECT().ReadBytes(80).Return([]byte{}, errors.New("read bytes error"))
+				return &XChainBridge{}, mock
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			xcb, mock := tc.setup(t)
+			got, err := xcb.ToJson(mock, tc.opts...)
+			if err != tc.err {
+				t.Errorf("ToJson() error = %v, want %v", err.Error(), tc.err.Error())
+			} else if tc.err == nil && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ToJson() got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrNotValidXChainBridge_Error(t *testing.T) {
+	err := &ErrNotValidXChainBridge{}
+	require.Equal(t, "not a valid xchain bridge", err.Error())
+}
+
+func TestErrNotValidJson_Error(t *testing.T) {
+	err := &typeerrors.ErrNotValidJson{}
+	require.Equal(t, "not a valid json", err.Error())
+}
+
+func TestErrDecodeClassicAddress_Error(t *testing.T) {
+	err := &ErrDecodeClassicAddress{}
+	require.Equal(t, "decode classic address error", err.Error())
+}
+
+func TestErrReadBytes_Error(t *testing.T) {
+	err := &ErrReadBytes{}
+	require.Equal(t, "read bytes error", err.Error())
+}

--- a/coverage.html
+++ b/coverage.html
@@ -55,7 +55,7 @@
 			<div id="nav">
 				<select id="files">
 				
-				<option value="file0">github.com/Peersyst/xrpl-go/address-codec/address_codec.go (94.0%)</option>
+				<option value="file0">github.com/Peersyst/xrpl-go/address-codec/address_codec.go (93.9%)</option>
 				
 				<option value="file1">github.com/Peersyst/xrpl-go/address-codec/base58.go (98.0%)</option>
 				
@@ -83,339 +83,341 @@
 				
 				<option value="file13">github.com/Peersyst/xrpl-go/binary-codec/types/blob.go (100.0%)</option>
 				
-				<option value="file14">github.com/Peersyst/xrpl-go/binary-codec/types/hash.go (100.0%)</option>
+				<option value="file14">github.com/Peersyst/xrpl-go/binary-codec/types/errors/json.go (100.0%)</option>
 				
-				<option value="file15">github.com/Peersyst/xrpl-go/binary-codec/types/hash128.go (100.0%)</option>
+				<option value="file15">github.com/Peersyst/xrpl-go/binary-codec/types/hash.go (100.0%)</option>
 				
-				<option value="file16">github.com/Peersyst/xrpl-go/binary-codec/types/hash160.go (100.0%)</option>
+				<option value="file16">github.com/Peersyst/xrpl-go/binary-codec/types/hash128.go (100.0%)</option>
 				
-				<option value="file17">github.com/Peersyst/xrpl-go/binary-codec/types/hash256.go (100.0%)</option>
+				<option value="file17">github.com/Peersyst/xrpl-go/binary-codec/types/hash160.go (100.0%)</option>
 				
-				<option value="file18">github.com/Peersyst/xrpl-go/binary-codec/types/pathset.go (55.2%)</option>
+				<option value="file18">github.com/Peersyst/xrpl-go/binary-codec/types/hash256.go (100.0%)</option>
 				
-				<option value="file19">github.com/Peersyst/xrpl-go/binary-codec/types/serialized_type.go (56.2%)</option>
+				<option value="file19">github.com/Peersyst/xrpl-go/binary-codec/types/pathset.go (55.2%)</option>
 				
-				<option value="file20">github.com/Peersyst/xrpl-go/binary-codec/types/st_array.go (83.9%)</option>
+				<option value="file20">github.com/Peersyst/xrpl-go/binary-codec/types/serialized_type.go (52.9%)</option>
 				
-				<option value="file21">github.com/Peersyst/xrpl-go/binary-codec/types/st_object.go (80.0%)</option>
+				<option value="file21">github.com/Peersyst/xrpl-go/binary-codec/types/st_array.go (83.9%)</option>
 				
-				<option value="file22">github.com/Peersyst/xrpl-go/binary-codec/types/uint16.go (81.2%)</option>
+				<option value="file22">github.com/Peersyst/xrpl-go/binary-codec/types/st_object.go (80.0%)</option>
 				
-				<option value="file23">github.com/Peersyst/xrpl-go/binary-codec/types/uint32.go (77.8%)</option>
+				<option value="file23">github.com/Peersyst/xrpl-go/binary-codec/types/uint16.go (81.2%)</option>
 				
-				<option value="file24">github.com/Peersyst/xrpl-go/binary-codec/types/uint64.go (59.3%)</option>
+				<option value="file24">github.com/Peersyst/xrpl-go/binary-codec/types/uint32.go (77.8%)</option>
 				
-				<option value="file25">github.com/Peersyst/xrpl-go/binary-codec/types/uint8.go (61.1%)</option>
+				<option value="file25">github.com/Peersyst/xrpl-go/binary-codec/types/uint64.go (59.3%)</option>
 				
-				<option value="file26">github.com/Peersyst/xrpl-go/binary-codec/types/vector256.go (31.6%)</option>
+				<option value="file26">github.com/Peersyst/xrpl-go/binary-codec/types/uint8.go (61.1%)</option>
 				
-				<option value="file27">github.com/Peersyst/xrpl-go/keypairs/crypto.go (44.4%)</option>
+				<option value="file27">github.com/Peersyst/xrpl-go/binary-codec/types/vector256.go (31.6%)</option>
 				
-				<option value="file28">github.com/Peersyst/xrpl-go/keypairs/keypairs.go (75.9%)</option>
+				<option value="file28">github.com/Peersyst/xrpl-go/binary-codec/types/xchain_bridge.go (100.0%)</option>
 				
-				<option value="file29">github.com/Peersyst/xrpl-go/main.go (0.0%)</option>
+				<option value="file29">github.com/Peersyst/xrpl-go/keypairs/crypto.go (44.4%)</option>
 				
-				<option value="file30">github.com/Peersyst/xrpl-go/pkg/big-decimal/big_decimal.go (96.6%)</option>
+				<option value="file30">github.com/Peersyst/xrpl-go/keypairs/keypairs.go (75.9%)</option>
 				
-				<option value="file31">github.com/Peersyst/xrpl-go/pkg/crypto/der.go (85.7%)</option>
+				<option value="file31">github.com/Peersyst/xrpl-go/pkg/big-decimal/big_decimal.go (96.6%)</option>
 				
-				<option value="file32">github.com/Peersyst/xrpl-go/pkg/crypto/ed25519.go (78.6%)</option>
+				<option value="file32">github.com/Peersyst/xrpl-go/pkg/crypto/der.go (85.7%)</option>
 				
-				<option value="file33">github.com/Peersyst/xrpl-go/pkg/crypto/secp256k1.go (90.3%)</option>
+				<option value="file33">github.com/Peersyst/xrpl-go/pkg/crypto/ed25519.go (78.6%)</option>
 				
-				<option value="file34">github.com/Peersyst/xrpl-go/pkg/crypto/sha512.go (100.0%)</option>
+				<option value="file34">github.com/Peersyst/xrpl-go/pkg/crypto/secp256k1.go (90.3%)</option>
 				
-				<option value="file35">github.com/Peersyst/xrpl-go/pkg/crypto/types.go (0.0%)</option>
+				<option value="file35">github.com/Peersyst/xrpl-go/pkg/crypto/sha512.go (100.0%)</option>
 				
-				<option value="file36">github.com/Peersyst/xrpl-go/pkg/map_utils/map_utils.go (100.0%)</option>
+				<option value="file36">github.com/Peersyst/xrpl-go/pkg/crypto/types.go (0.0%)</option>
 				
-				<option value="file37">github.com/Peersyst/xrpl-go/pkg/random/main.go (80.0%)</option>
+				<option value="file37">github.com/Peersyst/xrpl-go/pkg/map_utils/map_utils.go (100.0%)</option>
 				
-				<option value="file38">github.com/Peersyst/xrpl-go/pkg/typecheck/typecheck.go (100.0%)</option>
+				<option value="file38">github.com/Peersyst/xrpl-go/pkg/random/main.go (80.0%)</option>
 				
-				<option value="file39">github.com/Peersyst/xrpl-go/xrpl/currency/native.go (100.0%)</option>
+				<option value="file39">github.com/Peersyst/xrpl-go/pkg/typecheck/typecheck.go (100.0%)</option>
 				
-				<option value="file40">github.com/Peersyst/xrpl-go/xrpl/currency/non-standard.go (95.0%)</option>
+				<option value="file40">github.com/Peersyst/xrpl-go/xrpl/currency/native.go (100.0%)</option>
 				
-				<option value="file41">github.com/Peersyst/xrpl-go/xrpl/hash/tx.go (85.7%)</option>
+				<option value="file41">github.com/Peersyst/xrpl-go/xrpl/currency/non-standard.go (95.0%)</option>
 				
-				<option value="file42">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/account_root.go (0.0%)</option>
+				<option value="file42">github.com/Peersyst/xrpl-go/xrpl/hash/tx.go (85.7%)</option>
 				
-				<option value="file43">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/amendments.go (0.0%)</option>
+				<option value="file43">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/account_root.go (0.0%)</option>
 				
-				<option value="file44">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/amm.go (76.2%)</option>
+				<option value="file44">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/amendments.go (0.0%)</option>
 				
-				<option value="file45">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/check.go (0.0%)</option>
+				<option value="file45">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/amm.go (76.2%)</option>
 				
-				<option value="file46">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/deposit_preauth.go (0.0%)</option>
+				<option value="file46">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/check.go (0.0%)</option>
 				
-				<option value="file47">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/directory_node.go (0.0%)</option>
+				<option value="file47">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/deposit_preauth.go (0.0%)</option>
 				
-				<option value="file48">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/escrow.go (0.0%)</option>
+				<option value="file48">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/directory_node.go (0.0%)</option>
 				
-				<option value="file49">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/fee_settings.go (0.0%)</option>
+				<option value="file49">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/escrow.go (0.0%)</option>
 				
-				<option value="file50">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ledger_hashes.go (0.0%)</option>
+				<option value="file50">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/fee_settings.go (0.0%)</option>
 				
-				<option value="file51">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ledger_object.go (0.0%)</option>
+				<option value="file51">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ledger_hashes.go (0.0%)</option>
 				
-				<option value="file52">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/negative_unl.go (0.0%)</option>
+				<option value="file52">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ledger_object.go (0.0%)</option>
 				
-				<option value="file53">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/nftoken_offer.go (72.7%)</option>
+				<option value="file53">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/negative_unl.go (0.0%)</option>
 				
-				<option value="file54">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/nftoken_page.go (0.0%)</option>
+				<option value="file54">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/nftoken_offer.go (72.7%)</option>
 				
-				<option value="file55">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/offer.go (73.3%)</option>
+				<option value="file55">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/nftoken_page.go (0.0%)</option>
 				
-				<option value="file56">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/pay_channel.go (0.0%)</option>
+				<option value="file56">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/offer.go (73.3%)</option>
 				
-				<option value="file57">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ripple_state.go (0.0%)</option>
+				<option value="file57">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/pay_channel.go (0.0%)</option>
 				
-				<option value="file58">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/signer_list.go (0.0%)</option>
+				<option value="file58">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ripple_state.go (0.0%)</option>
 				
-				<option value="file59">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ticket.go (0.0%)</option>
+				<option value="file59">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/signer_list.go (0.0%)</option>
 				
-				<option value="file60">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_channels_request.go (71.4%)</option>
+				<option value="file60">github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types/ticket.go (0.0%)</option>
 				
-				<option value="file61">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_currencies_request.go (72.7%)</option>
+				<option value="file61">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_channels_request.go (71.4%)</option>
 				
-				<option value="file62">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_info_request.go (66.7%)</option>
+				<option value="file62">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_currencies_request.go (72.7%)</option>
 				
-				<option value="file63">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_lines_request.go (66.7%)</option>
+				<option value="file63">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_info_request.go (66.7%)</option>
 				
-				<option value="file64">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_nfts_request.go (72.7%)</option>
+				<option value="file64">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_lines_request.go (66.7%)</option>
 				
-				<option value="file65">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_objects_request.go (66.7%)</option>
+				<option value="file65">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_nfts_request.go (72.7%)</option>
 				
-				<option value="file66">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_offers_request.go (72.7%)</option>
+				<option value="file66">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_objects_request.go (66.7%)</option>
 				
-				<option value="file67">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_transactions_request.go (0.0%)</option>
+				<option value="file67">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_offers_request.go (72.7%)</option>
 				
-				<option value="file68">github.com/Peersyst/xrpl-go/xrpl/queries/account/offer_result.go (81.2%)</option>
+				<option value="file68">github.com/Peersyst/xrpl-go/xrpl/queries/account/account_transactions_request.go (0.0%)</option>
 				
-				<option value="file69">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/can_delete_request.go (75.0%)</option>
+				<option value="file69">github.com/Peersyst/xrpl-go/xrpl/queries/account/offer_result.go (81.2%)</option>
 				
-				<option value="file70">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/crawl_shards_request.go (0.0%)</option>
+				<option value="file70">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/can_delete_request.go (75.0%)</option>
 				
-				<option value="file71">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/download_shard_request.go (0.0%)</option>
+				<option value="file71">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/crawl_shards_request.go (0.0%)</option>
 				
-				<option value="file72">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_cleaner_request.go (0.0%)</option>
+				<option value="file72">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/download_shard_request.go (0.0%)</option>
 				
-				<option value="file73">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_request_request.go (0.0%)</option>
+				<option value="file73">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_cleaner_request.go (0.0%)</option>
 				
-				<option value="file74">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_request_response.go (77.8%)</option>
+				<option value="file74">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_request_request.go (0.0%)</option>
 				
-				<option value="file75">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/log_level_request.go (0.0%)</option>
+				<option value="file75">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/ledger_request_response.go (77.8%)</option>
 				
-				<option value="file76">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/logrotate_request.go (0.0%)</option>
+				<option value="file76">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/log_level_request.go (0.0%)</option>
 				
-				<option value="file77">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/node_to_shard_request.go (0.0%)</option>
+				<option value="file77">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/logrotate_request.go (0.0%)</option>
 				
-				<option value="file78">github.com/Peersyst/xrpl-go/xrpl/queries/admin/key/validation_create_request.go (0.0%)</option>
+				<option value="file78">github.com/Peersyst/xrpl-go/xrpl/queries/admin/data/node_to_shard_request.go (0.0%)</option>
 				
-				<option value="file79">github.com/Peersyst/xrpl-go/xrpl/queries/admin/key/wallet_propose_request.go (0.0%)</option>
+				<option value="file79">github.com/Peersyst/xrpl-go/xrpl/queries/admin/key/validation_create_request.go (0.0%)</option>
 				
-				<option value="file80">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/connect_request.go (0.0%)</option>
+				<option value="file80">github.com/Peersyst/xrpl-go/xrpl/queries/admin/key/wallet_propose_request.go (0.0%)</option>
 				
-				<option value="file81">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_add_request.go (0.0%)</option>
+				<option value="file81">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/connect_request.go (0.0%)</option>
 				
-				<option value="file82">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_del_request.go (0.0%)</option>
+				<option value="file82">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_add_request.go (0.0%)</option>
 				
-				<option value="file83">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_list_request.go (0.0%)</option>
+				<option value="file83">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_del_request.go (0.0%)</option>
 				
-				<option value="file84">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peers_request.go (0.0%)</option>
+				<option value="file84">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peer_reservations_list_request.go (0.0%)</option>
 				
-				<option value="file85">github.com/Peersyst/xrpl-go/xrpl/queries/admin/server/ledger_accept_request.go (0.0%)</option>
+				<option value="file85">github.com/Peersyst/xrpl-go/xrpl/queries/admin/peer/peers_request.go (0.0%)</option>
 				
-				<option value="file86">github.com/Peersyst/xrpl-go/xrpl/queries/admin/server/stop_request.go (0.0%)</option>
+				<option value="file86">github.com/Peersyst/xrpl-go/xrpl/queries/admin/server/ledger_accept_request.go (0.0%)</option>
 				
-				<option value="file87">github.com/Peersyst/xrpl-go/xrpl/queries/admin/signing/sign_for_request.go (0.0%)</option>
+				<option value="file87">github.com/Peersyst/xrpl-go/xrpl/queries/admin/server/stop_request.go (0.0%)</option>
 				
-				<option value="file88">github.com/Peersyst/xrpl-go/xrpl/queries/admin/signing/sign_request.go (0.0%)</option>
+				<option value="file88">github.com/Peersyst/xrpl-go/xrpl/queries/admin/signing/sign_for_request.go (0.0%)</option>
 				
-				<option value="file89">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/consensus_info_request.go (0.0%)</option>
+				<option value="file89">github.com/Peersyst/xrpl-go/xrpl/queries/admin/signing/sign_request.go (0.0%)</option>
 				
-				<option value="file90">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/feature_request.go (0.0%)</option>
+				<option value="file90">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/consensus_info_request.go (0.0%)</option>
 				
-				<option value="file91">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/fetch_info_request.go (0.0%)</option>
+				<option value="file91">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/feature_request.go (0.0%)</option>
 				
-				<option value="file92">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/get_counts_request.go (0.0%)</option>
+				<option value="file92">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/fetch_info_request.go (0.0%)</option>
 				
-				<option value="file93">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validator_info_request.go (0.0%)</option>
+				<option value="file93">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/get_counts_request.go (0.0%)</option>
 				
-				<option value="file94">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validator_list_sites_request.go (0.0%)</option>
+				<option value="file94">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validator_info_request.go (0.0%)</option>
 				
-				<option value="file95">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validators_request.go (0.0%)</option>
+				<option value="file95">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validator_list_sites_request.go (0.0%)</option>
 				
-				<option value="file96">github.com/Peersyst/xrpl-go/xrpl/queries/channel/channel_authorize_request.go (0.0%)</option>
+				<option value="file96">github.com/Peersyst/xrpl-go/xrpl/queries/admin/status/validators_request.go (0.0%)</option>
 				
-				<option value="file97">github.com/Peersyst/xrpl-go/xrpl/queries/channel/channel_verify_request.go (0.0%)</option>
+				<option value="file97">github.com/Peersyst/xrpl-go/xrpl/queries/channel/channel_authorize_request.go (0.0%)</option>
 				
-				<option value="file98">github.com/Peersyst/xrpl-go/xrpl/queries/clio/ledger_request.go (72.7%)</option>
+				<option value="file98">github.com/Peersyst/xrpl-go/xrpl/queries/channel/channel_verify_request.go (0.0%)</option>
 				
-				<option value="file99">github.com/Peersyst/xrpl-go/xrpl/queries/clio/nft_info_request.go (77.8%)</option>
+				<option value="file99">github.com/Peersyst/xrpl-go/xrpl/queries/clio/ledger_request.go (72.7%)</option>
 				
-				<option value="file100">github.com/Peersyst/xrpl-go/xrpl/queries/clio/server_info_request.go (0.0%)</option>
+				<option value="file100">github.com/Peersyst/xrpl-go/xrpl/queries/clio/nft_info_request.go (77.8%)</option>
 				
-				<option value="file101">github.com/Peersyst/xrpl-go/xrpl/queries/common/ledger.go (73.7%)</option>
+				<option value="file101">github.com/Peersyst/xrpl-go/xrpl/queries/clio/server_info_request.go (0.0%)</option>
 				
-				<option value="file102">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_closed_request.go (0.0%)</option>
+				<option value="file102">github.com/Peersyst/xrpl-go/xrpl/queries/common/ledger.go (73.7%)</option>
 				
-				<option value="file103">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_current_request.go (0.0%)</option>
+				<option value="file103">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_closed_request.go (0.0%)</option>
 				
-				<option value="file104">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_data_request.go (80.0%)</option>
+				<option value="file104">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_current_request.go (0.0%)</option>
 				
-				<option value="file105">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_entry_request.go (70.6%)</option>
+				<option value="file105">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_data_request.go (80.0%)</option>
 				
-				<option value="file106">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_request.go (66.7%)</option>
+				<option value="file106">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_entry_request.go (70.6%)</option>
 				
-				<option value="file107">github.com/Peersyst/xrpl-go/xrpl/queries/path/book_offers_request.go (76.9%)</option>
+				<option value="file107">github.com/Peersyst/xrpl-go/xrpl/queries/ledger/ledger_request.go (66.7%)</option>
 				
-				<option value="file108">github.com/Peersyst/xrpl-go/xrpl/queries/path/book_offers_response.go (80.0%)</option>
+				<option value="file108">github.com/Peersyst/xrpl-go/xrpl/queries/path/book_offers_request.go (76.9%)</option>
 				
-				<option value="file109">github.com/Peersyst/xrpl-go/xrpl/queries/path/deposit_authorized_request.go (76.9%)</option>
+				<option value="file109">github.com/Peersyst/xrpl-go/xrpl/queries/path/book_offers_response.go (80.0%)</option>
 				
-				<option value="file110">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_buy_offers_request.go (76.9%)</option>
+				<option value="file110">github.com/Peersyst/xrpl-go/xrpl/queries/path/deposit_authorized_request.go (76.9%)</option>
 				
-				<option value="file111">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_offer.go (83.3%)</option>
+				<option value="file111">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_buy_offers_request.go (76.9%)</option>
 				
-				<option value="file112">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_sell_offers_request.go (76.9%)</option>
+				<option value="file112">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_offer.go (83.3%)</option>
 				
-				<option value="file113">github.com/Peersyst/xrpl-go/xrpl/queries/path/path_find_request.go (76.5%)</option>
+				<option value="file113">github.com/Peersyst/xrpl-go/xrpl/queries/path/nftoken_sell_offers_request.go (76.9%)</option>
 				
-				<option value="file114">github.com/Peersyst/xrpl-go/xrpl/queries/path/path_find_response.go (80.8%)</option>
+				<option value="file114">github.com/Peersyst/xrpl-go/xrpl/queries/path/path_find_request.go (76.5%)</option>
 				
-				<option value="file115">github.com/Peersyst/xrpl-go/xrpl/queries/path/ripple_path_find_request.go (77.3%)</option>
+				<option value="file115">github.com/Peersyst/xrpl-go/xrpl/queries/path/path_find_response.go (80.8%)</option>
 				
-				<option value="file116">github.com/Peersyst/xrpl-go/xrpl/queries/server/fee_request.go (0.0%)</option>
+				<option value="file116">github.com/Peersyst/xrpl-go/xrpl/queries/path/ripple_path_find_request.go (77.3%)</option>
 				
-				<option value="file117">github.com/Peersyst/xrpl-go/xrpl/queries/server/manifest_request.go (0.0%)</option>
+				<option value="file117">github.com/Peersyst/xrpl-go/xrpl/queries/server/fee_request.go (0.0%)</option>
 				
-				<option value="file118">github.com/Peersyst/xrpl-go/xrpl/queries/server/server_info_request.go (0.0%)</option>
+				<option value="file118">github.com/Peersyst/xrpl-go/xrpl/queries/server/manifest_request.go (0.0%)</option>
 				
-				<option value="file119">github.com/Peersyst/xrpl-go/xrpl/queries/server/server_state_request.go (0.0%)</option>
+				<option value="file119">github.com/Peersyst/xrpl-go/xrpl/queries/server/server_info_request.go (0.0%)</option>
 				
-				<option value="file120">github.com/Peersyst/xrpl-go/xrpl/queries/subscription/subscribe_request.go (0.0%)</option>
+				<option value="file120">github.com/Peersyst/xrpl-go/xrpl/queries/server/server_state_request.go (0.0%)</option>
 				
-				<option value="file121">github.com/Peersyst/xrpl-go/xrpl/queries/subscription/unsubscribe_request.go (0.0%)</option>
+				<option value="file121">github.com/Peersyst/xrpl-go/xrpl/queries/subscription/subscribe_request.go (0.0%)</option>
 				
-				<option value="file122">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/submit_multisigned_request.go (0.0%)</option>
+				<option value="file122">github.com/Peersyst/xrpl-go/xrpl/queries/subscription/unsubscribe_request.go (0.0%)</option>
 				
-				<option value="file123">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/submit_request.go (0.0%)</option>
+				<option value="file123">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/submit_multisigned_request.go (0.0%)</option>
 				
-				<option value="file124">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/transaction_entry_request.go (0.0%)</option>
+				<option value="file124">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/submit_request.go (0.0%)</option>
 				
-				<option value="file125">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/tx_request.go (0.0%)</option>
+				<option value="file125">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/transaction_entry_request.go (0.0%)</option>
 				
-				<option value="file126">github.com/Peersyst/xrpl-go/xrpl/queries/utility/ping_request.go (0.0%)</option>
+				<option value="file126">github.com/Peersyst/xrpl-go/xrpl/queries/transactions/tx_request.go (0.0%)</option>
 				
-				<option value="file127">github.com/Peersyst/xrpl-go/xrpl/queries/utility/random_request.go (0.0%)</option>
+				<option value="file127">github.com/Peersyst/xrpl-go/xrpl/queries/utility/ping_request.go (0.0%)</option>
 				
-				<option value="file128">github.com/Peersyst/xrpl-go/xrpl/rpc/client.go (83.1%)</option>
+				<option value="file128">github.com/Peersyst/xrpl-go/xrpl/queries/utility/random_request.go (0.0%)</option>
 				
-				<option value="file129">github.com/Peersyst/xrpl-go/xrpl/rpc/config.go (100.0%)</option>
+				<option value="file129">github.com/Peersyst/xrpl-go/xrpl/rpc/client.go (83.1%)</option>
 				
-				<option value="file130">github.com/Peersyst/xrpl-go/xrpl/rpc/queries.go (0.0%)</option>
+				<option value="file130">github.com/Peersyst/xrpl-go/xrpl/rpc/config.go (100.0%)</option>
 				
-				<option value="file131">github.com/Peersyst/xrpl-go/xrpl/rpc/response.go (85.7%)</option>
+				<option value="file131">github.com/Peersyst/xrpl-go/xrpl/rpc/queries.go (0.0%)</option>
 				
-				<option value="file132">github.com/Peersyst/xrpl-go/xrpl/transaction/account_delete.go (0.0%)</option>
+				<option value="file132">github.com/Peersyst/xrpl-go/xrpl/rpc/response.go (85.7%)</option>
 				
-				<option value="file133">github.com/Peersyst/xrpl-go/xrpl/transaction/account_set.go (53.0%)</option>
+				<option value="file133">github.com/Peersyst/xrpl-go/xrpl/transaction/account_delete.go (0.0%)</option>
 				
-				<option value="file134">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_bid.go (0.0%)</option>
+				<option value="file134">github.com/Peersyst/xrpl-go/xrpl/transaction/account_set.go (53.0%)</option>
 				
-				<option value="file135">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_create.go (85.7%)</option>
+				<option value="file135">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_bid.go (0.0%)</option>
 				
-				<option value="file136">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_deposit.go (0.0%)</option>
+				<option value="file136">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_create.go (85.7%)</option>
 				
-				<option value="file137">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_vote.go (0.0%)</option>
+				<option value="file137">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_deposit.go (0.0%)</option>
 				
-				<option value="file138">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_withdraw.go (0.0%)</option>
+				<option value="file138">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_vote.go (0.0%)</option>
 				
-				<option value="file139">github.com/Peersyst/xrpl-go/xrpl/transaction/check_cancel.go (0.0%)</option>
+				<option value="file139">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_withdraw.go (0.0%)</option>
 				
-				<option value="file140">github.com/Peersyst/xrpl-go/xrpl/transaction/check_cash.go (72.2%)</option>
+				<option value="file140">github.com/Peersyst/xrpl-go/xrpl/transaction/check_cancel.go (0.0%)</option>
 				
-				<option value="file141">github.com/Peersyst/xrpl-go/xrpl/transaction/check_create.go (66.7%)</option>
+				<option value="file141">github.com/Peersyst/xrpl-go/xrpl/transaction/check_cash.go (72.2%)</option>
 				
-				<option value="file142">github.com/Peersyst/xrpl-go/xrpl/transaction/clawback.go (85.7%)</option>
+				<option value="file142">github.com/Peersyst/xrpl-go/xrpl/transaction/check_create.go (66.7%)</option>
 				
-				<option value="file143">github.com/Peersyst/xrpl-go/xrpl/transaction/deposit_preauth.go (0.0%)</option>
+				<option value="file143">github.com/Peersyst/xrpl-go/xrpl/transaction/clawback.go (85.7%)</option>
 				
-				<option value="file144">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_cancel.go (0.0%)</option>
+				<option value="file144">github.com/Peersyst/xrpl-go/xrpl/transaction/deposit_preauth.go (0.0%)</option>
 				
-				<option value="file145">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_create.go (0.0%)</option>
+				<option value="file145">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_cancel.go (0.0%)</option>
 				
-				<option value="file146">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_finish.go (0.0%)</option>
+				<option value="file146">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_create.go (0.0%)</option>
 				
-				<option value="file147">github.com/Peersyst/xrpl-go/xrpl/transaction/flags.go (100.0%)</option>
+				<option value="file147">github.com/Peersyst/xrpl-go/xrpl/transaction/escrow_finish.go (0.0%)</option>
 				
-				<option value="file148">github.com/Peersyst/xrpl-go/xrpl/transaction/flat_tx.go (0.0%)</option>
+				<option value="file148">github.com/Peersyst/xrpl-go/xrpl/transaction/flags.go (100.0%)</option>
 				
-				<option value="file149">github.com/Peersyst/xrpl-go/xrpl/transaction/memo.go (92.3%)</option>
+				<option value="file149">github.com/Peersyst/xrpl-go/xrpl/transaction/flat_tx.go (0.0%)</option>
 				
-				<option value="file150">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_accept_offer.go (66.7%)</option>
+				<option value="file150">github.com/Peersyst/xrpl-go/xrpl/transaction/memo.go (92.3%)</option>
 				
-				<option value="file151">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_burn.go (0.0%)</option>
+				<option value="file151">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_accept_offer.go (66.7%)</option>
 				
-				<option value="file152">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_cancel_offer.go (0.0%)</option>
+				<option value="file152">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_burn.go (0.0%)</option>
 				
-				<option value="file153">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_create_offer.go (66.7%)</option>
+				<option value="file153">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_cancel_offer.go (0.0%)</option>
 				
-				<option value="file154">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_mint.go (0.0%)</option>
+				<option value="file154">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_create_offer.go (66.7%)</option>
 				
-				<option value="file155">github.com/Peersyst/xrpl-go/xrpl/transaction/offer_cancel.go (0.0%)</option>
+				<option value="file155">github.com/Peersyst/xrpl-go/xrpl/transaction/nftoken_mint.go (0.0%)</option>
 				
-				<option value="file156">github.com/Peersyst/xrpl-go/xrpl/transaction/offer_create.go (72.2%)</option>
+				<option value="file156">github.com/Peersyst/xrpl-go/xrpl/transaction/offer_cancel.go (0.0%)</option>
 				
-				<option value="file157">github.com/Peersyst/xrpl-go/xrpl/transaction/path_step.go (100.0%)</option>
+				<option value="file157">github.com/Peersyst/xrpl-go/xrpl/transaction/offer_create.go (72.2%)</option>
 				
-				<option value="file158">github.com/Peersyst/xrpl-go/xrpl/transaction/payment.go (79.8%)</option>
+				<option value="file158">github.com/Peersyst/xrpl-go/xrpl/transaction/path_step.go (100.0%)</option>
 				
-				<option value="file159">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_claim.go (12.5%)</option>
+				<option value="file159">github.com/Peersyst/xrpl-go/xrpl/transaction/payment.go (79.8%)</option>
 				
-				<option value="file160">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (0.0%)</option>
+				<option value="file160">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_claim.go (12.5%)</option>
 				
-				<option value="file161">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_fund.go (0.0%)</option>
+				<option value="file161">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (0.0%)</option>
 				
-				<option value="file162">github.com/Peersyst/xrpl-go/xrpl/transaction/set_regular_key.go (0.0%)</option>
+				<option value="file162">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_fund.go (0.0%)</option>
 				
-				<option value="file163">github.com/Peersyst/xrpl-go/xrpl/transaction/signer.go (100.0%)</option>
+				<option value="file163">github.com/Peersyst/xrpl-go/xrpl/transaction/set_regular_key.go (0.0%)</option>
 				
-				<option value="file164">github.com/Peersyst/xrpl-go/xrpl/transaction/signer_list_set.go (0.0%)</option>
+				<option value="file164">github.com/Peersyst/xrpl-go/xrpl/transaction/signer.go (100.0%)</option>
 				
-				<option value="file165">github.com/Peersyst/xrpl-go/xrpl/transaction/ticket_create.go (83.3%)</option>
+				<option value="file165">github.com/Peersyst/xrpl-go/xrpl/transaction/signer_list_set.go (0.0%)</option>
 				
-				<option value="file166">github.com/Peersyst/xrpl-go/xrpl/transaction/transaction_metadata.go (0.0%)</option>
+				<option value="file166">github.com/Peersyst/xrpl-go/xrpl/transaction/ticket_create.go (83.3%)</option>
 				
-				<option value="file167">github.com/Peersyst/xrpl-go/xrpl/transaction/trust_set.go (73.0%)</option>
+				<option value="file167">github.com/Peersyst/xrpl-go/xrpl/transaction/transaction_metadata.go (0.0%)</option>
 				
-				<option value="file168">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (83.8%)</option>
+				<option value="file168">github.com/Peersyst/xrpl-go/xrpl/transaction/trust_set.go (73.0%)</option>
 				
-				<option value="file169">github.com/Peersyst/xrpl-go/xrpl/transaction/tx_type.go (100.0%)</option>
+				<option value="file169">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (83.8%)</option>
 				
-				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/types/address.go (100.0%)</option>
+				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/tx_type.go (100.0%)</option>
 				
-				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/types/currency_amount.go (84.6%)</option>
+				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/types/address.go (100.0%)</option>
 				
-				<option value="file172">github.com/Peersyst/xrpl-go/xrpl/transaction/types/hash128.go (100.0%)</option>
+				<option value="file172">github.com/Peersyst/xrpl-go/xrpl/transaction/types/currency_amount.go (84.6%)</option>
 				
-				<option value="file173">github.com/Peersyst/xrpl-go/xrpl/transaction/types/hash256.go (100.0%)</option>
+				<option value="file173">github.com/Peersyst/xrpl-go/xrpl/transaction/types/hash128.go (100.0%)</option>
 				
-				<option value="file174">github.com/Peersyst/xrpl-go/xrpl/transaction/validations_commons.go (81.0%)</option>
+				<option value="file174">github.com/Peersyst/xrpl-go/xrpl/transaction/types/hash256.go (100.0%)</option>
 				
-				<option value="file175">github.com/Peersyst/xrpl-go/xrpl/transaction/validations_xrpl_objects.go (65.4%)</option>
+				<option value="file175">github.com/Peersyst/xrpl-go/xrpl/transaction/validations_commons.go (81.0%)</option>
 				
-				<option value="file176">github.com/Peersyst/xrpl-go/xrpl/wallet.go (68.6%)</option>
+				<option value="file176">github.com/Peersyst/xrpl-go/xrpl/transaction/validations_xrpl_objects.go (65.4%)</option>
 				
-				<option value="file177">github.com/Peersyst/xrpl-go/xrpl/websocket/client.go (48.8%)</option>
+				<option value="file177">github.com/Peersyst/xrpl-go/xrpl/wallet.go (68.6%)</option>
 				
-				<option value="file178">github.com/Peersyst/xrpl-go/xrpl/websocket/config.go (0.0%)</option>
+				<option value="file178">github.com/Peersyst/xrpl-go/xrpl/websocket/client.go (48.8%)</option>
 				
-				<option value="file179">github.com/Peersyst/xrpl-go/xrpl/websocket/queries.go (87.2%)</option>
+				<option value="file179">github.com/Peersyst/xrpl-go/xrpl/websocket/config.go (0.0%)</option>
 				
-				<option value="file180">github.com/Peersyst/xrpl-go/xrpl/websocket/response.go (75.0%)</option>
+				<option value="file180">github.com/Peersyst/xrpl-go/xrpl/websocket/queries.go (87.2%)</option>
+				
+				<option value="file181">github.com/Peersyst/xrpl-go/xrpl/websocket/response.go (75.0%)</option>
 				
 				</select>
 			</div>
@@ -536,7 +538,6 @@ func EncodeClassicAddressFromPublicKeyHex(pubkeyhex string) (string, error) <spa
 // Returns the decoded 'accountID' byte slice of the classic address.
 func DecodeClassicAddressToAccountID(cAddress string) (typePrefix, accountID []byte, err error) <span class="cov8" title="1">{
 
-        fmt.Println(len(DecodeBase58(cAddress)))
         if len(DecodeBase58(cAddress)) != 25 </span><span class="cov8" title="1">{
                 return nil, nil, &amp;InvalidClassicAddressError{Input: cAddress}
         }</span>
@@ -2201,7 +2202,18 @@ func (b *Blob) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <span
 }
 </pre>
 		
-		<pre class="file" id="file14" style="display: none">package types
+		<pre class="file" id="file14" style="display: none">package errors
+
+// ErrNotValidJson is an error that occurs when the json is not valid.
+type ErrNotValidJson struct{}
+
+// Error returns the error message for the ErrNotValidJson error.
+func (e *ErrNotValidJson) Error() string <span class="cov8" title="1">{
+        return "not a valid json"
+}</span>
+</pre>
+		
+		<pre class="file" id="file15" style="display: none">package types
 
 import (
         "encoding/hex"
@@ -2216,7 +2228,7 @@ type ErrInvalidHashLength struct {
         Expected int
 }
 
-type ErrInvalidHashType struct {}
+type ErrInvalidHashType struct{}
 
 type ErrInvalidHexString struct {
         Err error
@@ -2286,7 +2298,7 @@ func (h hash) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <span 
 }
 </pre>
 		
-		<pre class="file" id="file15" style="display: none">package types
+		<pre class="file" id="file16" style="display: none">package types
 
 // Hash128 struct represents a 128-bit hash.
 type Hash128 struct {
@@ -2301,7 +2313,7 @@ func NewHash128() *Hash128 <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file16" style="display: none">package types
+		<pre class="file" id="file17" style="display: none">package types
 
 // Hash160 struct represents a 160-bit hash.
 type Hash160 struct {
@@ -2316,7 +2328,7 @@ func NewHash160() *Hash160 <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file17" style="display: none">package types
+		<pre class="file" id="file18" style="display: none">package types
 
 // Hash256 struct represents a 256-bit hash.
 type Hash256 struct {
@@ -2331,7 +2343,7 @@ func NewHash256() *Hash256 <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file18" style="display: none">package types
+		<pre class="file" id="file19" style="display: none">package types
 
 import (
         "errors"
@@ -2562,7 +2574,7 @@ func parsePath(parser interfaces.BinaryParser) ([]any, error) <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file19" style="display: none">package types
+		<pre class="file" id="file20" style="display: none">package types
 
 import (
         "github.com/Peersyst/xrpl-go/binary-codec/types/interfaces"
@@ -2613,12 +2625,14 @@ func GetSerializedType(t string) SerializedType <span class="cov8" title="1">{
                 return &amp;STArray{}</span>
         case "PathSet":<span class="cov0" title="0">
                 return &amp;PathSet{}</span>
+        case "XChainBridge":<span class="cov0" title="0">
+                return &amp;XChainBridge{}</span>
         }
         <span class="cov0" title="0">return nil</span>
 }
 </pre>
 		
-		<pre class="file" id="file20" style="display: none">package types
+		<pre class="file" id="file21" style="display: none">package types
 
 import (
         "errors"
@@ -2694,7 +2708,7 @@ func (t *STArray) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <s
 }
 </pre>
 		
-		<pre class="file" id="file21" style="display: none">package types
+		<pre class="file" id="file22" style="display: none">package types
 
 import (
         "fmt"
@@ -2850,7 +2864,7 @@ func enumToStr(fieldType string, value any) (any, error) <span class="cov8" titl
 }
 </pre>
 		
-		<pre class="file" id="file22" style="display: none">package types
+		<pre class="file" id="file23" style="display: none">package types
 
 import (
         "bytes"
@@ -2900,7 +2914,7 @@ func (u *UInt16) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <sp
 }
 </pre>
 		
-		<pre class="file" id="file23" style="display: none">package types
+		<pre class="file" id="file24" style="display: none">package types
 
 import (
         "bytes"
@@ -2936,7 +2950,7 @@ func (u *UInt32) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <sp
 }
 </pre>
 		
-		<pre class="file" id="file24" style="display: none">package types
+		<pre class="file" id="file25" style="display: none">package types
 
 import (
         "bytes"
@@ -3010,7 +3024,7 @@ func isNumeric(s string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file25" style="display: none">package types
+		<pre class="file" id="file26" style="display: none">package types
 
 import (
         "bytes"
@@ -3064,7 +3078,7 @@ func (u *UInt8) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <spa
 }
 </pre>
 		
-		<pre class="file" id="file26" style="display: none">package types
+		<pre class="file" id="file27" style="display: none">package types
 
 import (
         "encoding/hex"
@@ -3140,7 +3154,117 @@ func (v *Vector256) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) 
 }
 </pre>
 		
-		<pre class="file" id="file27" style="display: none">package keypairs
+		<pre class="file" id="file28" style="display: none">package types
+
+import (
+        addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+        "github.com/Peersyst/xrpl-go/binary-codec/types/errors"
+        "github.com/Peersyst/xrpl-go/binary-codec/types/interfaces"
+)
+
+// ===============================
+// Errors
+// ===============================
+
+// ErrNotValidXChainBridge is an error that occurs when the
+// xchain bridge objectis not valid.
+type ErrNotValidXChainBridge struct{}
+
+// Error returns the error message.
+func (e *ErrNotValidXChainBridge) Error() string <span class="cov8" title="1">{
+        return "not a valid xchain bridge"
+}</span>
+
+// ErrReadBytes is an error that occurs when trying to read bytes with a parser.
+type ErrReadBytes struct{}
+
+// Error returns the error message.
+func (e *ErrReadBytes) Error() string <span class="cov8" title="1">{
+        return "read bytes error"
+}</span>
+
+// ErrDecodeClassicAddress is an error that occurs
+// when trying to decode a classic address.
+type ErrDecodeClassicAddress struct{}
+
+// Error returns the error message.
+func (e *ErrDecodeClassicAddress) Error() string <span class="cov8" title="1">{
+        return "decode classic address error"
+}</span>
+
+// ===============================
+// XChainBridge
+// ===============================
+
+// XChainBridge is a struct that represents an xchain bridge.
+type XChainBridge struct{}
+
+// FromJson converts a json XChainBridge object to its byte slice representation.
+// It returns an error if the json is not valid or if the classic addresses are not valid.
+func (x *XChainBridge) FromJson(json any) ([]byte, error) <span class="cov8" title="1">{
+        v, ok := json.(map[string]any)
+        if !ok </span><span class="cov8" title="1">{
+                return nil, &amp;errors.ErrNotValidJson{}
+        }</span>
+
+        <span class="cov8" title="1">if v["LockingChainDoor"] == nil || v["LockingChainIssue"] == nil || v["IssuingChainDoor"] == nil || v["IssuingChainIssue"] == nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrNotValidXChainBridge{}
+        }</span>
+
+        <span class="cov8" title="1">_, lockingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainDoor"].(string))
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrDecodeClassicAddress{}
+        }</span>
+
+        <span class="cov8" title="1">_, lockingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainIssue"].(string))
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrDecodeClassicAddress{}
+        }</span>
+
+        <span class="cov8" title="1">_, issuingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainDoor"].(string))
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrDecodeClassicAddress{}
+        }</span>
+
+        <span class="cov8" title="1">_, issuingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainIssue"].(string))
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrDecodeClassicAddress{}
+        }</span>
+
+        <span class="cov8" title="1">bytes := make([]byte, 0, 80)
+
+        bytes = append(bytes, lockingChainDoor...)
+        bytes = append(bytes, lockingChainIssue...)
+        bytes = append(bytes, issuingChainDoor...)
+        bytes = append(bytes, issuingChainIssue...)
+
+        return bytes, nil</span>
+}
+
+// ToJson converts a byte slice representation of an XChainBridge object to its json representation.
+// It returns an error if the bytes are not valid or if the classic addresses are not valid.
+func (x *XChainBridge) ToJson(p interfaces.BinaryParser, opts ...int) (any, error) <span class="cov8" title="1">{
+        if opts == nil </span><span class="cov8" title="1">{
+                return nil, ErrNoLengthPrefix
+        }</span>
+
+        <span class="cov8" title="1">bytes, err := p.ReadBytes(opts[0])
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, &amp;ErrReadBytes{}
+        }</span>
+
+        <span class="cov8" title="1">json := make(map[string]string)
+
+        json["LockingChainDoor"] = addresscodec.Encode(bytes[:20], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+        json["LockingChainIssue"] = addresscodec.Encode(bytes[20:40], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+        json["IssuingChainDoor"] = addresscodec.Encode(bytes[40:60], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+        json["IssuingChainIssue"] = addresscodec.Encode(bytes[60:80], []byte{addresscodec.AccountAddressPrefix}, addresscodec.AccountAddressLength)
+
+        return json, nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file29" style="display: none">package keypairs
 
 import (
         "encoding/hex"
@@ -3180,7 +3304,7 @@ func getCryptoImplementationFromKey(k string) CryptoImplementation <span class="
 }
 </pre>
 		
-		<pre class="file" id="file28" style="display: none">package keypairs
+		<pre class="file" id="file30" style="display: none">package keypairs
 
 import (
         "crypto/rand"
@@ -3258,41 +3382,7 @@ func (e *InvalidSignatureError) Error() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file29" style="display: none">package main
-
-import (
-        "fmt"
-
-        "github.com/Peersyst/xrpl-go/binary-codec/types"
-)
-
-func main() <span class="cov0" title="0">{
-
-        st := &amp;types.STArray{}
-
-        bytes, err := st.FromJson([]any{
-                                map[string]any{
-                                        "NFToken": map[string]any{
-                                                "NFTokenID": "000913881D8CE533B1355B905B5C75F85B1F9A5149B94D7BABAF4475000011D9",
-                                                "URI":       "68747470733A2F2F697066732E696F2F697066732F516D57356232715736744D3975615659376E555162774356334D63514B566E6D5659516A6A4368784E65656B476B",
-                                        },
-                                },
-                                map[string]any{
-                                        "Signer": map[string]any{
-                                                "NFTokenID": "000913881D8CE533B1355B905B5C75F85B1F9A5149B94D7BAF373F1C00001382",
-                                                "URI":       "68747470733A2F2F697066732E696F2F697066732F516D57356232715736744D3975615659376E555162774356334D63514B566E6D5659516A6A4368784E65656B476B",
-                                        },
-                },
-        },)
-        if err != nil </span><span class="cov0" title="0">{
-                panic(err)</span>
-        }
-
-        <span class="cov0" title="0">fmt.Println(bytes)</span>
-}
-</pre>
-		
-		<pre class="file" id="file30" style="display: none">package bigdecimal
+		<pre class="file" id="file31" style="display: none">package bigdecimal
 
 import (
         "errors"
@@ -3448,7 +3538,7 @@ func bigDecimalRegEx(value string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file31" style="display: none">package crypto
+		<pre class="file" id="file32" style="display: none">package crypto
 
 import (
         "encoding/hex"
@@ -3563,7 +3653,7 @@ func DERHexToSig(hexSignature string) ([]byte, []byte, error) <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file32" style="display: none">package crypto
+		<pre class="file" id="file33" style="display: none">package crypto
 
 import (
         "bytes"
@@ -3639,7 +3729,7 @@ func (e *ed25519ValidatorError) Error() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file33" style="display: none">package crypto
+		<pre class="file" id="file34" style="display: none">package crypto
 
 import (
         "crypto/sha512"
@@ -3804,7 +3894,7 @@ func (c secp256K1CryptoAlgorithm) Validate(msg, pubkey, sig string) bool <span c
 }
 </pre>
 		
-		<pre class="file" id="file34" style="display: none">package crypto
+		<pre class="file" id="file35" style="display: none">package crypto
 
 import "crypto/sha512"
 
@@ -3815,7 +3905,7 @@ func Sha512Half(msg []byte) []byte <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file35" style="display: none">package crypto
+		<pre class="file" id="file36" style="display: none">package crypto
 
 type CryptoAlgorithm struct {
         prefix           uint8
@@ -3843,7 +3933,7 @@ func (c CryptoAlgorithm) Validate(msg, pubkey, sig string) bool <span class="cov
 }</span>
 </pre>
 		
-		<pre class="file" id="file36" style="display: none">package maputils
+		<pre class="file" id="file37" style="display: none">package maputils
 
 // GetKeys returns the keys of the given map.
 func GetKeys(m map[string]interface{}) []string <span class="cov8" title="1">{
@@ -3855,7 +3945,7 @@ func GetKeys(m map[string]interface{}) []string <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file37" style="display: none">package random
+		<pre class="file" id="file38" style="display: none">package random
 
 import "io"
 
@@ -3873,7 +3963,7 @@ func (r *Randomizer) GenerateBytes(n int) ([]byte, error) <span class="cov8" tit
 }
 </pre>
 		
-		<pre class="file" id="file38" style="display: none">package typecheck
+		<pre class="file" id="file39" style="display: none">package typecheck
 
 import (
         "regexp"
@@ -3936,7 +4026,7 @@ func IsFloat64(s string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file39" style="display: none">package currency
+		<pre class="file" id="file40" style="display: none">package currency
 
 import (
         "errors"
@@ -3978,7 +4068,7 @@ func DropsToXrp(value string) (string, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file40" style="display: none">package currency
+		<pre class="file" id="file41" style="display: none">package currency
 
 import (
         "encoding/hex"
@@ -4047,7 +4137,7 @@ func padEnd(s string, length int, padChar string) string <span class="cov8" titl
 }
 </pre>
 		
-		<pre class="file" id="file41" style="display: none">package hash
+		<pre class="file" id="file42" style="display: none">package hash
 
 import (
         "encoding/binary"
@@ -4093,7 +4183,7 @@ func HashTxBlob(txBlob string) (string, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file42" style="display: none">package ledger
+		<pre class="file" id="file43" style="display: none">package ledger
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -4128,7 +4218,7 @@ func (*AccountRoot) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file43" style="display: none">package ledger
+		<pre class="file" id="file44" style="display: none">package ledger
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -4155,7 +4245,7 @@ type Majority struct {
 }
 </pre>
 		
-		<pre class="file" id="file44" style="display: none">package ledger
+		<pre class="file" id="file45" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -4315,7 +4405,7 @@ func (s *AuctionSlot) UnmarshalJSON(data []byte) error <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file45" style="display: none">package ledger
+		<pre class="file" id="file46" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4342,7 +4432,7 @@ func (*Check) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file46" style="display: none">package ledger
+		<pre class="file" id="file47" style="display: none">package ledger
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -4363,7 +4453,7 @@ func (*DepositPreauthObj) EntryType() LedgerEntryType <span class="cov0" title="
 }</span>
 </pre>
 		
-		<pre class="file" id="file47" style="display: none">package ledger
+		<pre class="file" id="file48" style="display: none">package ledger
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -4388,7 +4478,7 @@ func (*DirectoryNode) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file48" style="display: none">package ledger
+		<pre class="file" id="file49" style="display: none">package ledger
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -4416,7 +4506,7 @@ func (*Escrow) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file49" style="display: none">package ledger
+		<pre class="file" id="file50" style="display: none">package ledger
 
 type FeeSettings struct {
         BaseFee           string
@@ -4432,7 +4522,7 @@ func (*FeeSettings) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file50" style="display: none">package ledger
+		<pre class="file" id="file51" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4449,7 +4539,7 @@ func (*LedgerHashes) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file51" style="display: none">package ledger
+		<pre class="file" id="file52" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -4584,7 +4674,7 @@ func UnmarshalLedgerObject(data []byte) (LedgerObject, error) <span class="cov0"
 }
 </pre>
 		
-		<pre class="file" id="file52" style="display: none">package ledger
+		<pre class="file" id="file53" style="display: none">package ledger
 
 type NegativeUNL struct {
         DisabledValidators  []DisabledValidatorEntry `json:",omitempty"`
@@ -4608,7 +4698,7 @@ type DisabledValidator struct {
 }
 </pre>
 		
-		<pre class="file" id="file53" style="display: none">package ledger
+		<pre class="file" id="file54" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -4674,7 +4764,7 @@ func (n *NFTokenOffer) UnmarshalJSON(data []byte) error <span class="cov8" title
 }
 </pre>
 		
-		<pre class="file" id="file54" style="display: none">package ledger
+		<pre class="file" id="file55" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4692,7 +4782,7 @@ func (*NFTokenPage) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file55" style="display: none">package ledger
+		<pre class="file" id="file56" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -4771,7 +4861,7 @@ func (o *Offer) UnmarshalJSON(data []byte) error <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file56" style="display: none">package ledger
+		<pre class="file" id="file57" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4799,7 +4889,7 @@ func (*PayChannel) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file57" style="display: none">package ledger
+		<pre class="file" id="file58" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4826,7 +4916,7 @@ func (*RippleState) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file58" style="display: none">package ledger
+		<pre class="file" id="file59" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4862,7 +4952,7 @@ func (*SignerList) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file59" style="display: none">package ledger
+		<pre class="file" id="file60" style="display: none">package ledger
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -4881,7 +4971,7 @@ func (*Ticket) EntryType() LedgerEntryType <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file60" style="display: none">package account
+		<pre class="file" id="file61" style="display: none">package account
 
 import (
         "encoding/json"
@@ -4943,7 +5033,7 @@ func (r *AccountChannelsRequest) UnmarshalJSON(data []byte) error <span class="c
 }
 </pre>
 		
-		<pre class="file" id="file61" style="display: none">package account
+		<pre class="file" id="file62" style="display: none">package account
 
 import (
         "encoding/json"
@@ -4989,7 +5079,7 @@ func (r *AccountCurrenciesRequest) UnmarshalJSON(data []byte) error <span class=
 }
 </pre>
 		
-		<pre class="file" id="file62" style="display: none">package account
+		<pre class="file" id="file63" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5045,7 +5135,7 @@ func (r *AccountInfoRequest) UnmarshalJSON(data []byte) error <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file63" style="display: none">package account
+		<pre class="file" id="file64" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5101,7 +5191,7 @@ func (r *AccountLinesRequest) UnmarshalJSON(data []byte) error <span class="cov8
 }
 </pre>
 		
-		<pre class="file" id="file64" style="display: none">package account
+		<pre class="file" id="file65" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5150,7 +5240,7 @@ func (r *AccountNFTsRequest) UnmarshalJSON(data []byte) error <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file65" style="display: none">package account
+		<pre class="file" id="file66" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5224,7 +5314,7 @@ func (r *AccountObjectsRequest) UnmarshalJSON(data []byte) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file66" style="display: none">package account
+		<pre class="file" id="file67" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5276,7 +5366,7 @@ func (r *AccountOffersRequest) UnmarshalJSON(data []byte) error <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file67" style="display: none">package account
+		<pre class="file" id="file68" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5337,7 +5427,7 @@ func (r *AccountTransactionsRequest) UnmarshalJSON(data []byte) error <span clas
 }
 </pre>
 		
-		<pre class="file" id="file68" style="display: none">package account
+		<pre class="file" id="file69" style="display: none">package account
 
 import (
         "encoding/json"
@@ -5393,7 +5483,7 @@ func (r *OfferResult) UnmarshalJSON(data []byte) error <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file69" style="display: none">package data
+		<pre class="file" id="file70" style="display: none">package data
 
 import (
         "encoding/json"
@@ -5424,7 +5514,7 @@ func (r *CanDeleteRequest) UnmarshalJSON(data []byte) error <span class="cov8" t
 }
 </pre>
 		
-		<pre class="file" id="file70" style="display: none">package data
+		<pre class="file" id="file71" style="display: none">package data
 
 type CrawlShardsRequest struct {
         PublicKey bool `json:"public_key,omitempty"`
@@ -5436,7 +5526,7 @@ func (*CrawlShardsRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file71" style="display: none">package data
+		<pre class="file" id="file72" style="display: none">package data
 
 import "github.com/Peersyst/xrpl-go/xrpl/queries/common"
 
@@ -5454,7 +5544,7 @@ func (*DownloadShardRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file72" style="display: none">package data
+		<pre class="file" id="file73" style="display: none">package data
 
 import "github.com/Peersyst/xrpl-go/xrpl/queries/common"
 
@@ -5473,7 +5563,7 @@ func (*LedgerCleanerRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file73" style="display: none">package data
+		<pre class="file" id="file74" style="display: none">package data
 
 import "github.com/Peersyst/xrpl-go/xrpl/queries/common"
 
@@ -5487,7 +5577,7 @@ func (*LedgerRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file74" style="display: none">package data
+		<pre class="file" id="file75" style="display: none">package data
 
 import (
         "encoding/json"
@@ -5559,7 +5649,7 @@ func (r *LedgerRequestResponse) UnmarshalJSON(data []byte) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file75" style="display: none">package data
+		<pre class="file" id="file76" style="display: none">package data
 
 type LogLevelRequest struct {
         Severity  string `json:"severity,omitempty"`
@@ -5571,7 +5661,7 @@ func (*LogLevelRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file76" style="display: none">package data
+		<pre class="file" id="file77" style="display: none">package data
 
 type LogrotateRequest struct {
 }
@@ -5581,7 +5671,7 @@ func (*LogrotateRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file77" style="display: none">package data
+		<pre class="file" id="file78" style="display: none">package data
 
 type NodeToShardRequest struct {
         Action string `json:"action"`
@@ -5592,7 +5682,7 @@ func (*NodeToShardRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file78" style="display: none">package key
+		<pre class="file" id="file79" style="display: none">package key
 
 type ValidationCreateRequest struct {
         Secret string `json:"secret,omitempty"`
@@ -5603,7 +5693,7 @@ func (*ValidationCreateRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file79" style="display: none">package key
+		<pre class="file" id="file80" style="display: none">package key
 
 type WalletProposeRequest struct {
         KeyType    string `json:"key_type,omitempty"`
@@ -5617,7 +5707,7 @@ func (*WalletProposeRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file80" style="display: none">package peer
+		<pre class="file" id="file81" style="display: none">package peer
 
 type ConnectRequest struct {
         IP   string `json:"ip"`
@@ -5629,7 +5719,7 @@ func (*ConnectRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file81" style="display: none">package peer
+		<pre class="file" id="file82" style="display: none">package peer
 
 type PeerReservationAddRequest struct {
         PublicKey   string `json:"public_key"`
@@ -5641,7 +5731,7 @@ func (*PeerReservationAddRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file82" style="display: none">package peer
+		<pre class="file" id="file83" style="display: none">package peer
 
 type PeerReservationDelRequest struct {
         PublicKey string `json:"public_key"`
@@ -5652,7 +5742,7 @@ func (*PeerReservationDelRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file83" style="display: none">package peer
+		<pre class="file" id="file84" style="display: none">package peer
 
 type PeerReservationsListRequest struct {
 }
@@ -5662,7 +5752,7 @@ func (*PeerReservationsListRequest) Method() string <span class="cov0" title="0"
 }</span>
 </pre>
 		
-		<pre class="file" id="file84" style="display: none">package peer
+		<pre class="file" id="file85" style="display: none">package peer
 
 type PeersRequest struct {
 }
@@ -5672,7 +5762,7 @@ func (*PeersRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file85" style="display: none">package server
+		<pre class="file" id="file86" style="display: none">package server
 
 type LedgerAcceptRequest struct {
 }
@@ -5682,7 +5772,7 @@ func (*LedgerAcceptRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file86" style="display: none">package server
+		<pre class="file" id="file87" style="display: none">package server
 
 type StopRequest struct {
 }
@@ -5692,7 +5782,7 @@ func (*StopRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file87" style="display: none">package signing
+		<pre class="file" id="file88" style="display: none">package signing
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction"
@@ -5714,7 +5804,7 @@ func (*SignForRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file88" style="display: none">package signing
+		<pre class="file" id="file89" style="display: none">package signing
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction"
 
@@ -5736,7 +5826,7 @@ func (*SignRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file89" style="display: none">package status
+		<pre class="file" id="file90" style="display: none">package status
 
 type ConsensusInfoRequest struct {
 }
@@ -5746,7 +5836,7 @@ func (*ConsensusInfoRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file90" style="display: none">package status
+		<pre class="file" id="file91" style="display: none">package status
 
 type FeatureRequest struct {
         Feature string `json:"feature,omitempty"`
@@ -5758,7 +5848,7 @@ func (*FeatureRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file91" style="display: none">package status
+		<pre class="file" id="file92" style="display: none">package status
 
 type FetchInfoRequest struct {
         Clear bool `json:"clear"`
@@ -5769,7 +5859,7 @@ func (*FetchInfoRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file92" style="display: none">package status
+		<pre class="file" id="file93" style="display: none">package status
 
 type GetCountsRequest struct {
         MinCount int `json:"min_count,omitempty"`
@@ -5780,7 +5870,7 @@ func (*GetCountsRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file93" style="display: none">package status
+		<pre class="file" id="file94" style="display: none">package status
 
 type ValidatorInfoRequest struct {
 }
@@ -5790,7 +5880,7 @@ func (*ValidatorInfoRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file94" style="display: none">package status
+		<pre class="file" id="file95" style="display: none">package status
 
 type ValidatorListSitesRequest struct {
 }
@@ -5800,7 +5890,7 @@ func (*ValidatorListSitesRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file95" style="display: none">package status
+		<pre class="file" id="file96" style="display: none">package status
 
 type ValidatorsRequest struct {
 }
@@ -5810,7 +5900,7 @@ func (*ValidatorsRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file96" style="display: none">package channel
+		<pre class="file" id="file97" style="display: none">package channel
 
 import (
         "fmt"
@@ -5848,7 +5938,7 @@ func (c *ChannelAuthorizeRequest) Format(s fmt.State, v rune) <span class="cov0"
 }</span>
 </pre>
 		
-		<pre class="file" id="file97" style="display: none">package channel
+		<pre class="file" id="file98" style="display: none">package channel
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -5864,7 +5954,7 @@ func (*ChannelVerifyRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file98" style="display: none">package clio
+		<pre class="file" id="file99" style="display: none">package clio
 
 import (
         "encoding/json"
@@ -5927,7 +6017,7 @@ func (r *LedgerRequest) UnmarshalJSON(data []byte) error <span class="cov8" titl
 }
 </pre>
 		
-		<pre class="file" id="file99" style="display: none">package clio
+		<pre class="file" id="file100" style="display: none">package clio
 
 import (
         "encoding/json"
@@ -5966,7 +6056,7 @@ func (r *NFTInfoRequest) UnmarshalJSON(data []byte) error <span class="cov8" tit
 }
 </pre>
 		
-		<pre class="file" id="file100" style="display: none">package clio
+		<pre class="file" id="file101" style="display: none">package clio
 
 type ServerInfoRequest struct {
 }
@@ -5976,7 +6066,7 @@ func (*ServerInfoRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file101" style="display: none">package common
+		<pre class="file" id="file102" style="display: none">package common
 
 import (
         "encoding/json"
@@ -6045,7 +6135,7 @@ func (l LedgerTitle) Ledger() string <span class="cov8" title="1">{
 type LedgerHash string
 </pre>
 		
-		<pre class="file" id="file102" style="display: none">package ledger
+		<pre class="file" id="file103" style="display: none">package ledger
 
 type LedgerClosedRequest struct {
 }
@@ -6055,7 +6145,7 @@ func (*LedgerClosedRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file103" style="display: none">package ledger
+		<pre class="file" id="file104" style="display: none">package ledger
 
 type LedgerCurrentRequest struct {
 }
@@ -6065,7 +6155,7 @@ func (*LedgerCurrentRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file104" style="display: none">package ledger
+		<pre class="file" id="file105" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -6113,7 +6203,7 @@ func (r *LedgerDataRequest) UnmarshalJSON(data []byte) error <span class="cov8" 
 }
 </pre>
 		
-		<pre class="file" id="file105" style="display: none">package ledger
+		<pre class="file" id="file106" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -6261,7 +6351,7 @@ func (r *LedgerEntryRequest) UnmarshalJSON(data []byte) error <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file106" style="display: none">package ledger
+		<pre class="file" id="file107" style="display: none">package ledger
 
 import (
         "encoding/json"
@@ -6327,7 +6417,7 @@ func (r *LedgerRequest) UnmarshalJSON(data []byte) error <span class="cov8" titl
 }
 </pre>
 		
-		<pre class="file" id="file107" style="display: none">package path
+		<pre class="file" id="file108" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6380,7 +6470,7 @@ func (r *BookOffersRequest) UnmarshalJSON(data []byte) error <span class="cov8" 
 }
 </pre>
 		
-		<pre class="file" id="file108" style="display: none">package path
+		<pre class="file" id="file109" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6443,7 +6533,7 @@ func (o *BookOffer) UnmarshalJSON(data []byte) error <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file109" style="display: none">package path
+		<pre class="file" id="file110" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6490,7 +6580,7 @@ func (r *DepositAuthorizedRequest) UnmarshalJSON(data []byte) error <span class=
 }
 </pre>
 		
-		<pre class="file" id="file110" style="display: none">package path
+		<pre class="file" id="file111" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6540,7 +6630,7 @@ func (r *NFTokenBuyOffersRequest) UnmarshalJSON(data []byte) error <span class="
 }
 </pre>
 		
-		<pre class="file" id="file111" style="display: none">package path
+		<pre class="file" id="file112" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6583,7 +6673,7 @@ func (o *NFTokenOffer) UnmarshalJSON(data []byte) error <span class="cov8" title
 }
 </pre>
 		
-		<pre class="file" id="file112" style="display: none">package path
+		<pre class="file" id="file113" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6633,7 +6723,7 @@ func (r *NFTokenSellOffersRequest) UnmarshalJSON(data []byte) error <span class=
 }
 </pre>
 		
-		<pre class="file" id="file113" style="display: none">package path
+		<pre class="file" id="file114" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6701,7 +6791,7 @@ func (r *PathFindRequest) UnmarshalJSON(data []byte) error <span class="cov8" ti
 }
 </pre>
 		
-		<pre class="file" id="file114" style="display: none">package path
+		<pre class="file" id="file115" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6789,7 +6879,7 @@ func (p *PathAlternative) UnmarshalJSON(data []byte) error <span class="cov8" ti
 }
 </pre>
 		
-		<pre class="file" id="file115" style="display: none">package path
+		<pre class="file" id="file116" style="display: none">package path
 
 import (
         "encoding/json"
@@ -6858,7 +6948,7 @@ func (r *RipplePathFindRequest) UnmarshalJSON(data []byte) error <span class="co
 }
 </pre>
 		
-		<pre class="file" id="file116" style="display: none">package server
+		<pre class="file" id="file117" style="display: none">package server
 
 type FeeRequest struct {
 }
@@ -6868,7 +6958,7 @@ func (*FeeRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file117" style="display: none">package server
+		<pre class="file" id="file118" style="display: none">package server
 
 type ManifestRequest struct {
         PublicKey string `json:"public_key"`
@@ -6879,7 +6969,7 @@ func (*ManifestRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file118" style="display: none">package server
+		<pre class="file" id="file119" style="display: none">package server
 
 type ServerInfoRequest struct {
 }
@@ -6894,7 +6984,7 @@ func (*ServerInfoRequest) Validate() error <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file119" style="display: none">package server
+		<pre class="file" id="file120" style="display: none">package server
 
 type ServerStateRequest struct {
 }
@@ -6904,7 +6994,7 @@ func (*ServerStateRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file120" style="display: none">package subscribe
+		<pre class="file" id="file121" style="display: none">package subscribe
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -6931,7 +7021,7 @@ type SubscribeOrderBook struct {
 }
 </pre>
 		
-		<pre class="file" id="file121" style="display: none">package subscribe
+		<pre class="file" id="file122" style="display: none">package subscribe
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
@@ -6953,7 +7043,7 @@ type UnsubscribeOrderBook struct {
 }
 </pre>
 		
-		<pre class="file" id="file122" style="display: none">package transaction
+		<pre class="file" id="file123" style="display: none">package transaction
 
 import "github.com/Peersyst/xrpl-go/xrpl/transaction"
 
@@ -6967,7 +7057,7 @@ func (*SubmitMultisignedRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file123" style="display: none">package transaction
+		<pre class="file" id="file124" style="display: none">package transaction
 
 import "errors"
 
@@ -6988,7 +7078,7 @@ func (req *SubmitRequest) Validate() error <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file124" style="display: none">package transaction
+		<pre class="file" id="file125" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -7030,7 +7120,7 @@ func (t *TransactionEntryRequest) UnmarshalJSON(data []byte) error <span class="
 }
 </pre>
 		
-		<pre class="file" id="file125" style="display: none">package transaction
+		<pre class="file" id="file126" style="display: none">package transaction
 
 import "github.com/Peersyst/xrpl-go/xrpl/queries/common"
 
@@ -7046,7 +7136,7 @@ func (*TxRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file126" style="display: none">package utility
+		<pre class="file" id="file127" style="display: none">package utility
 
 type PingRequest struct{}
 
@@ -7059,7 +7149,7 @@ func (*PingRequest) Validate() error <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file127" style="display: none">package utility
+		<pre class="file" id="file128" style="display: none">package utility
 
 type RandomRequest struct{}
 
@@ -7068,7 +7158,7 @@ func (*RandomRequest) Method() string <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file128" style="display: none">package rpc
+		<pre class="file" id="file129" style="display: none">package rpc
 
 import (
         "bytes"
@@ -7261,7 +7351,7 @@ func CheckForError(res *http.Response) (JsonRpcResponse, error) <span class="cov
 }
 </pre>
 		
-		<pre class="file" id="file129" style="display: none">package rpc
+		<pre class="file" id="file130" style="display: none">package rpc
 
 import (
         "errors"
@@ -7316,7 +7406,7 @@ func NewJsonRpcConfig(url string, opts ...JsonRpcConfigOpt) (*JsonRpcConfig, err
 }
 </pre>
 		
-		<pre class="file" id="file130" style="display: none">package rpc
+		<pre class="file" id="file131" style="display: none">package rpc
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/currency"
@@ -7437,7 +7527,7 @@ func (r *JsonRpcClient) GetServerInfo(req *server.ServerInfoRequest) (*server.Se
 }
 </pre>
 		
-		<pre class="file" id="file131" style="display: none">package rpc
+		<pre class="file" id="file132" style="display: none">package rpc
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction"
@@ -7484,7 +7574,7 @@ type JsonRpcXRPLResponse interface {
 }
 </pre>
 		
-		<pre class="file" id="file132" style="display: none">package transaction
+		<pre class="file" id="file133" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -7506,7 +7596,7 @@ func (s *AccountDelete) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file133" style="display: none">package transaction
+		<pre class="file" id="file134" style="display: none">package transaction
 
 import (
         "errors"
@@ -7910,7 +8000,7 @@ func (s *AccountSet) Validate() (bool, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file134" style="display: none">package transaction
+		<pre class="file" id="file135" style="display: none">package transaction
 
 // TODO: Implement AMMBid
 type AMMBid struct {
@@ -7927,7 +8017,7 @@ func (s *AMMBid) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file135" style="display: none">package transaction
+		<pre class="file" id="file136" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8029,7 +8119,7 @@ func (a *AMMCreate) Validate() (bool, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file136" style="display: none">package transaction
+		<pre class="file" id="file137" style="display: none">package transaction
 
 type AMMDeposit struct {
         BaseTx
@@ -8045,7 +8135,7 @@ func (s *AMMDeposit) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file137" style="display: none">package transaction
+		<pre class="file" id="file138" style="display: none">package transaction
 
 type AMMVote struct {
         BaseTx
@@ -8061,7 +8151,7 @@ func (s *AMMVote) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file138" style="display: none">package transaction
+		<pre class="file" id="file139" style="display: none">package transaction
 
 type AMMWithdraw struct {
         BaseTx
@@ -8077,7 +8167,7 @@ func (s *AMMWithdraw) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file139" style="display: none">package transaction
+		<pre class="file" id="file140" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8098,7 +8188,7 @@ func (s *CheckCancel) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file140" style="display: none">package transaction
+		<pre class="file" id="file141" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8155,7 +8245,7 @@ func (tx *CheckCash) UnmarshalJSON(data []byte) error <span class="cov8" title="
 }
 </pre>
 		
-		<pre class="file" id="file141" style="display: none">package transaction
+		<pre class="file" id="file142" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8212,7 +8302,7 @@ func (c *CheckCreate) UnmarshalJSON(data []byte) error <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file142" style="display: none">package transaction
+		<pre class="file" id="file143" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8315,7 +8405,7 @@ func (c *Clawback) Validate() (bool, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file143" style="display: none">package transaction
+		<pre class="file" id="file144" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8337,7 +8427,7 @@ func (s *DepositPreauth) Flatten() FlatTransaction <span class="cov0" title="0">
 }</span>
 </pre>
 		
-		<pre class="file" id="file144" style="display: none">package transaction
+		<pre class="file" id="file145" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8359,7 +8449,7 @@ func (s *EscrowCancel) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file145" style="display: none">package transaction
+		<pre class="file" id="file146" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8385,7 +8475,7 @@ func (s *EscrowCreate) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file146" style="display: none">package transaction
+		<pre class="file" id="file147" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8409,7 +8499,7 @@ func (s *EscrowFinish) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file147" style="display: none">package transaction
+		<pre class="file" id="file148" style="display: none">package transaction
 
 import "math/big"
 
@@ -8424,7 +8514,7 @@ func IsFlagEnabled(flags uint, checkFlag uint) bool <span class="cov8" title="1"
 }</span>
 </pre>
 		
-		<pre class="file" id="file148" style="display: none">package transaction
+		<pre class="file" id="file149" style="display: none">package transaction
 
 var _ Tx = (*FlatTransaction)(nil)
 
@@ -8439,7 +8529,7 @@ func (f FlatTransaction) TxType() TxType <span class="cov0" title="0">{
 }
 </pre>
 		
-		<pre class="file" id="file149" style="display: none">package transaction
+		<pre class="file" id="file150" style="display: none">package transaction
 
 type MemoWrapper struct {
         Memo Memo
@@ -8479,7 +8569,7 @@ func (m *Memo) Flatten() map[string]interface{} <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file150" style="display: none">package transaction
+		<pre class="file" id="file151" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8529,7 +8619,7 @@ func (s *NFTokenAcceptOffer) Flatten() FlatTransaction <span class="cov0" title=
 }</span>
 </pre>
 		
-		<pre class="file" id="file151" style="display: none">package transaction
+		<pre class="file" id="file152" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8551,7 +8641,7 @@ func (s *NFTokenBurn) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file152" style="display: none">package transaction
+		<pre class="file" id="file153" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8572,7 +8662,7 @@ func (s *NFTokenCancelOffer) Flatten() FlatTransaction <span class="cov0" title=
 }</span>
 </pre>
 		
-		<pre class="file" id="file153" style="display: none">package transaction
+		<pre class="file" id="file154" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8628,7 +8718,7 @@ func (n *NFTokenCreateOffer) UnmarshalJSON(data []byte) error <span class="cov8"
 }
 </pre>
 		
-		<pre class="file" id="file154" style="display: none">package transaction
+		<pre class="file" id="file155" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8652,7 +8742,7 @@ func (s *NFTokenMint) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file155" style="display: none">package transaction
+		<pre class="file" id="file156" style="display: none">package transaction
 
 type OfferCancel struct {
         BaseTx
@@ -8669,7 +8759,7 @@ func (s *OfferCancel) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file156" style="display: none">package transaction
+		<pre class="file" id="file157" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -8729,7 +8819,7 @@ func (o *OfferCreate) UnmarshalJSON(data []byte) error <span class="cov8" title=
 }
 </pre>
 		
-		<pre class="file" id="file157" style="display: none">package transaction
+		<pre class="file" id="file158" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -8761,7 +8851,7 @@ func (p *PathStep) Flatten() map[string]interface{} <span class="cov8" title="1"
 }
 </pre>
 		
-		<pre class="file" id="file158" style="display: none">package transaction
+		<pre class="file" id="file159" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -9048,7 +9138,7 @@ func checkPartialPayment(tx *Payment) (bool, error) <span class="cov8" title="1"
 }
 </pre>
 		
-		<pre class="file" id="file159" style="display: none">package transaction
+		<pre class="file" id="file160" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -9140,7 +9230,7 @@ func (s *PaymentChannelClaim) SetCloseFlag() <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file160" style="display: none">package transaction
+		<pre class="file" id="file161" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -9166,7 +9256,7 @@ func (s *PaymentChannelCreate) Flatten() FlatTransaction <span class="cov0" titl
 }</span>
 </pre>
 		
-		<pre class="file" id="file161" style="display: none">package transaction
+		<pre class="file" id="file162" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -9189,7 +9279,7 @@ func (s *PaymentChannelFund) Flatten() FlatTransaction <span class="cov0" title=
 }</span>
 </pre>
 		
-		<pre class="file" id="file162" style="display: none">package transaction
+		<pre class="file" id="file163" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -9210,7 +9300,7 @@ func (s *SetRegularKey) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file163" style="display: none">package transaction
+		<pre class="file" id="file164" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -9253,7 +9343,7 @@ func (sd *SignerData) Flatten() FlatSignerData <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file164" style="display: none">package transaction
+		<pre class="file" id="file165" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
@@ -9275,7 +9365,7 @@ func (s *SignerListSet) Flatten() FlatTransaction <span class="cov0" title="0">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file165" style="display: none">package transaction
+		<pre class="file" id="file166" style="display: none">package transaction
 
 // A TicketCreate transaction sets aside one or more sequence numbers as Tickets.
 type TicketCreate struct {
@@ -9304,7 +9394,7 @@ func (t *TicketCreate) Flatten() FlatTransaction <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file166" style="display: none">package transaction
+		<pre class="file" id="file167" style="display: none">package transaction
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
@@ -9353,7 +9443,7 @@ type DeletedNode struct {
 }
 </pre>
 		
-		<pre class="file" id="file167" style="display: none">package transaction
+		<pre class="file" id="file168" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -9512,7 +9602,7 @@ func (tx *TrustSet) Validate() (bool, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file168" style="display: none">package transaction
+		<pre class="file" id="file169" style="display: none">package transaction
 
 import (
         "encoding/json"
@@ -9855,7 +9945,7 @@ func (tx *BaseTx) Validate() (bool, error) <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file169" style="display: none">package transaction
+		<pre class="file" id="file170" style="display: none">package transaction
 
 type TxType string
 
@@ -9899,7 +9989,7 @@ func (t TxType) String() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file170" style="display: none">package types
+		<pre class="file" id="file171" style="display: none">package types
 
 type Address string
 
@@ -9908,7 +9998,7 @@ func (a Address) String() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file171" style="display: none">package types
+		<pre class="file" id="file172" style="display: none">package types
 
 import (
         "encoding/json"
@@ -10021,7 +10111,7 @@ func (a *XRPCurrencyAmount) UnmarshalText(data []byte) error <span class="cov8" 
 }
 </pre>
 		
-		<pre class="file" id="file172" style="display: none">package types
+		<pre class="file" id="file173" style="display: none">package types
 
 type Hash128 string
 
@@ -10030,7 +10120,7 @@ func (h *Hash128) String() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file173" style="display: none">package types
+		<pre class="file" id="file174" style="display: none">package types
 
 type Hash256 string
 
@@ -10039,7 +10129,7 @@ func (h *Hash256) String() string <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file174" style="display: none">package transaction
+		<pre class="file" id="file175" style="display: none">package transaction
 
 import (
         "fmt"
@@ -10101,7 +10191,7 @@ func validateSigners(signers []Signer) error <span class="cov8" title="1">{
 }
 </pre>
 		
-		<pre class="file" id="file175" style="display: none">package transaction
+		<pre class="file" id="file176" style="display: none">package transaction
 
 import (
         "errors"
@@ -10316,7 +10406,7 @@ func IsPaths(pathsteps [][]PathStep) (bool, error) <span class="cov8" title="1">
 }
 </pre>
 		
-		<pre class="file" id="file176" style="display: none">package xrpl
+		<pre class="file" id="file177" style="display: none">package xrpl
 
 import (
         "encoding/hex"
@@ -10496,7 +10586,7 @@ func (w *Wallet) GetAddress() string <span class="cov0" title="0">{
 // }
 </pre>
 		
-		<pre class="file" id="file177" style="display: none">package websocket
+		<pre class="file" id="file178" style="display: none">package websocket
 
 import (
         "bytes"
@@ -10886,7 +10976,7 @@ func (c *WebsocketClient) setTransactionFlags(tx *transaction.FlatTransaction) e
 }
 </pre>
 		
-		<pre class="file" id="file178" style="display: none">package websocket
+		<pre class="file" id="file179" style="display: none">package websocket
 
 type WebsocketClientConfig struct {
         // Connection config
@@ -10937,7 +11027,7 @@ func (wc WebsocketClientConfig) WithFaucetProvider(fp FaucetProvider) WebsocketC
 }</span>
 </pre>
 		
-		<pre class="file" id="file179" style="display: none">package websocket
+		<pre class="file" id="file180" style="display: none">package websocket
 
 import (
         "github.com/Peersyst/xrpl-go/xrpl/currency"
@@ -11048,7 +11138,7 @@ func (c *WebsocketClient) GetServerInfo(req *server.ServerInfoRequest) (*server.
 }
 </pre>
 		
-		<pre class="file" id="file180" style="display: none">package websocket
+		<pre class="file" id="file181" style="display: none">package websocket
 
 import (
         "fmt"


### PR DESCRIPTION
# [TA-3400]: XChainBridge type

This PR aims to add the missing `XChainBridge` on the `binary-codec` package. This PR includes the new XChainBridge type parsing with a 100% test coverage.

## Changes

- New `XChainBridge` type
- `XChainBridge` testing
- Added common `types/errors` package

