### PR TITLE
AMMDeposit

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -333,7 +333,7 @@
 				
 				<option value="file138">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_delete.go (100.0%)</option>
 				
-				<option value="file139">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_deposit.go (0.0%)</option>
+				<option value="file139">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_deposit.go (100.0%)</option>
 				
 				<option value="file140">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_vote.go (0.0%)</option>
 				
@@ -397,7 +397,7 @@
 				
 				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/trust_set.go (73.0%)</option>
 				
-				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (82.4%)</option>
+				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (81.6%)</option>
 				
 				<option value="file172">github.com/Peersyst/xrpl-go/xrpl/transaction/tx_type.go (100.0%)</option>
 				
@@ -8268,18 +8268,181 @@ func (a *AMMDelete) Validate() (bool, error) <span class="cov8" title="1">{
 		
 		<pre class="file" id="file139" style="display: none">package transaction
 
+import (
+        "errors"
+
+        "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+        "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+// Deposit funds into an Automated Market Maker (AMM) instance and receive the AMM's liquidity provider tokens (LP Tokens) in exchange.
+// You can deposit one or both of the assets in the AMM's pool.
+// If successful, this transaction creates a trust line to the AMM Account (limit 0) to hold the LP Tokens.
+//
+// Example:
+//
+//        {
+//            "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+//            "Amount" : {
+//                "currency" : "TST",
+//                "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+//                "value" : "2.5"
+//            },
+//            "Amount2" : "30000000",
+//            "Asset" : {
+//                "currency" : "TST",
+//                "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+//            },
+//            "Asset2" : {
+//                "currency" : "XRP"
+//            },
+//            "Fee" : "10",
+//            "Flags" : 1048576,
+//            "Sequence" : 7,
+//            "TransactionType" : "AMMDeposit"
+//        }
 type AMMDeposit struct {
         BaseTx
+        // The definition for one of the assets in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+        Asset ledger.Asset
+        // The definition for the other asset in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+        Asset2 ledger.Asset
+        // The amount of one asset to deposit to the AMM. If present, this must match the type of one of the assets (tokens or XRP) in the AMM's pool.
+        Amount types.CurrencyAmount `json:",omitempty"`
+        // The amount of another asset to add to the AMM. If present, this must match the type of the other asset in the AMM's pool and cannot be the same asset as Amount.
+        Amount2 types.CurrencyAmount `json:",omitempty"`
+        // The maximum effective price, in the deposit asset, to pay for each LP Token received.
+        EPrice types.CurrencyAmount `json:",omitempty"`
+        // How many of the AMM's LP Tokens to buy.
+        LPTokenOut types.CurrencyAmount `json:",omitempty"`
+        // Submit a vote for the AMM's trading fee, in units of 1/100,000; a value of 1 is equivalent to 0.001%. The maximum value is 1000, indicating a 1% fee.
+        TradingFee uint16 `json:",omitempty"`
 }
 
-func (*AMMDeposit) TxType() TxType <span class="cov0" title="0">{
+// ****************************
+// AMMDeposit Flags
+// ****************************
+
+// You must specify exactly one of these flags, plus any global flags.
+const (
+        // Perform a double-asset deposit and receive the specified amount of LP Tokens.
+        tfLPToken uint = 65536
+        // Perform a single-asset deposit with a specified amount of the asset to deposit.
+        tfSingleAsset uint = 524288
+        // Perform a double-asset deposit with specified amounts of both assets.
+        tfTwoAsset uint = 1048576
+        // Perform a single-asset deposit and receive the specified amount of LP Tokens.
+        tfOneAssetLPToken uint = 2097152
+        // Perform a single-asset deposit with a specified effective price.
+        tfLimitLPToken uint = 4194304
+        // Perform a special double-asset deposit to an AMM with an empty pool.
+        tfTwoAssetIfEmpty uint = 8388608
+)
+
+// Perform a double-asset deposit and receive the specified amount of LP Tokens.
+func (a *AMMDeposit) SetLPTokentFlag() <span class="cov8" title="1">{
+        a.Flags |= tfLPToken
+}</span>
+
+// Perform a single-asset deposit with a specified amount of the asset to deposit.
+func (a *AMMDeposit) SetSingleAssetFlag() <span class="cov8" title="1">{
+        a.Flags |= tfSingleAsset
+}</span>
+
+// Perform a double-asset deposit with specified amounts of both assets.
+func (a *AMMDeposit) SetTwoAssetFlag() <span class="cov8" title="1">{
+        a.Flags |= tfTwoAsset
+}</span>
+
+// Perform a single-asset deposit and receive the specified amount of LP Tokens.
+func (a *AMMDeposit) SetOneAssetLPTokenFlag() <span class="cov8" title="1">{
+        a.Flags |= tfOneAssetLPToken
+}</span>
+
+// Perform a single-asset deposit with a specified effective price.
+func (a *AMMDeposit) SetLimitLPTokenFlag() <span class="cov8" title="1">{
+        a.Flags |= tfLimitLPToken
+}</span>
+
+// Perform a special double-asset deposit to an AMM with an empty pool.
+func (a *AMMDeposit) SetTwoAssetIfEmptyFlag() <span class="cov8" title="1">{
+        a.Flags |= tfTwoAssetIfEmpty
+}</span>
+
+func (*AMMDeposit) TxType() TxType <span class="cov8" title="1">{
         return AMMDepositTx
 }</span>
 
-// TODO: Implement flatten
-func (s *AMMDeposit) Flatten() FlatTransaction <span class="cov0" title="0">{
-        return nil
-}</span>
+func (a *AMMDeposit) Flatten() FlatTransaction <span class="cov8" title="1">{
+
+        // Add BaseTx fields
+        flattened := a.BaseTx.Flatten()
+
+        // Add AMMDeposit-specific fields
+        flattened["TransactionType"] = "AMMDeposit"
+
+        flattened["Asset"] = a.Asset.Flatten()
+        flattened["Asset2"] = a.Asset2.Flatten()
+
+        if a.Amount != nil </span><span class="cov8" title="1">{
+                flattened["Amount"] = a.Amount.Flatten()
+        }</span>
+
+        <span class="cov8" title="1">if a.Amount2 != nil </span><span class="cov8" title="1">{
+                flattened["Amount2"] = a.Amount2.Flatten()
+        }</span>
+
+        <span class="cov8" title="1">if a.EPrice != nil </span><span class="cov8" title="1">{
+                flattened["EPrice"] = a.EPrice.Flatten()
+        }</span>
+
+        <span class="cov8" title="1">if a.LPTokenOut != nil </span><span class="cov8" title="1">{
+                flattened["LPTokenOut"] = a.LPTokenOut.Flatten()
+        }</span>
+
+        <span class="cov8" title="1">if a.TradingFee != 0 </span><span class="cov8" title="1">{
+                flattened["TradingFee"] = a.TradingFee
+        }</span>
+
+        <span class="cov8" title="1">return flattened</span>
+}
+
+func (a *AMMDeposit) Validate() (bool, error) <span class="cov8" title="1">{
+        _, err := a.BaseTx.Validate()
+        if err != nil </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAsset(a.Asset); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAsset(a.Asset2); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if a.Amount2 != nil &amp;&amp; a.Amount == nil </span><span class="cov8" title="1">{
+                return false, errors.New("ammDeposit: must set Amount with Amount2")
+        }</span> else<span class="cov8" title="1"> if a.EPrice != nil &amp;&amp; a.Amount == nil </span><span class="cov8" title="1">{
+                return false, errors.New("ammDeposit: must set Amount with EPrice")
+        }</span> else<span class="cov8" title="1"> if a.LPTokenOut == nil &amp;&amp; a.Amount == nil </span><span class="cov8" title="1">{
+                return false, errors.New("ammDeposit:  must set at least LPTokenOut or Amount")
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.Amount, fieldName: "Amount", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.Amount2, fieldName: "Amount", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.EPrice, fieldName: "EPrice", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">return true, nil</span>
+}
 </pre>
 		
 		<pre class="file" id="file140" style="display: none">package transaction
@@ -9952,7 +10115,7 @@ func UnmarshalTx(data json.RawMessage) (Tx, error) <span class="cov8" title="1">
                 tx = &amp;AMMBid{}</span>
         case AMMCreateTx:<span class="cov0" title="0">
                 tx = &amp;AMMCreate{}</span>
-        case AMMDepositTx:<span class="cov8" title="1">
+        case AMMDepositTx:<span class="cov0" title="0">
                 tx = &amp;AMMDeposit{}</span>
         case AMMVoteTx:<span class="cov8" title="1">
                 tx = &amp;AMMVote{}</span>
@@ -10550,6 +10713,10 @@ func IsAsset(asset ledger.Asset) (bool, error) <span class="cov8" title="1">{
 
         <span class="cov8" title="1">if strings.ToUpper(asset.Currency) == "XRP" &amp;&amp; strings.TrimSpace(asset.Issuer.String()) == "" </span><span class="cov8" title="1">{
                 return true, nil
+        }</span>
+
+        <span class="cov8" title="1">if strings.ToUpper(asset.Currency) == "XRP" &amp;&amp; asset.Issuer != "" </span><span class="cov8" title="1">{
+                return false, errors.New("issuer field should be omitted for XRP currency")
         }</span>
 
         <span class="cov8" title="1">if asset.Currency != "" &amp;&amp; !addresscodec.IsValidClassicAddress(asset.Issuer.String()) </span><span class="cov8" title="1">{

--- a/xrpl/transaction/amm_deposit.go
+++ b/xrpl/transaction/amm_deposit.go
@@ -1,14 +1,138 @@
 package transaction
 
+import (
+	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+// Deposit funds into an Automated Market Maker (AMM) instance and receive the AMM's liquidity provider tokens (LP Tokens) in exchange.
+// You can deposit one or both of the assets in the AMM's pool.
+// If successful, this transaction creates a trust line to the AMM Account (limit 0) to hold the LP Tokens.
+//
+// Example:
+//
+//	{
+//	    "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+//	    "Amount" : {
+//	        "currency" : "TST",
+//	        "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+//	        "value" : "2.5"
+//	    },
+//	    "Amount2" : "30000000",
+//	    "Asset" : {
+//	        "currency" : "TST",
+//	        "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+//	    },
+//	    "Asset2" : {
+//	        "currency" : "XRP"
+//	    },
+//	    "Fee" : "10",
+//	    "Flags" : 1048576,
+//	    "Sequence" : 7,
+//	    "TransactionType" : "AMMDeposit"
+//	}
 type AMMDeposit struct {
 	BaseTx
+	// The definition for one of the assets in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+	Asset ledger.Asset
+	// The definition for the other asset in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+	Asset2 ledger.Asset
+	// The amount of one asset to deposit to the AMM. If present, this must match the type of one of the assets (tokens or XRP) in the AMM's pool.
+	Amount types.CurrencyAmount `json:",omitempty"`
+	// The amount of another asset to add to the AMM. If present, this must match the type of the other asset in the AMM's pool and cannot be the same asset as Amount.
+	Amount2 types.CurrencyAmount `json:",omitempty"`
+	// The maximum effective price, in the deposit asset, to pay for each LP Token received.
+	EPrice types.CurrencyAmount `json:",omitempty"`
+	// How many of the AMM's LP Tokens to buy.
+	LPTokenOut types.CurrencyAmount `json:",omitempty"`
+	// Submit a vote for the AMM's trading fee, in units of 1/100,000; a value of 1 is equivalent to 0.001%. The maximum value is 1000, indicating a 1% fee.
+	TradingFee uint16 `json:",omitempty"`
+}
+
+// ****************************
+// AMMDeposit Flags
+// ****************************
+
+// You must specify exactly one of these flags, plus any global flags.
+const (
+	// Perform a double-asset deposit and receive the specified amount of LP Tokens.
+	tfLPToken uint = 65536
+	// Perform a single-asset deposit with a specified amount of the asset to deposit.
+	tfSingleAsset uint = 524288
+	// Perform a double-asset deposit with specified amounts of both assets.
+	tfTwoAsset uint = 1048576
+	// Perform a single-asset deposit and receive the specified amount of LP Tokens.
+	tfOneAssetLPToken uint = 2097152
+	// Perform a single-asset deposit with a specified effective price.
+	tfLimitLPToken uint = 4194304
+	// Perform a special double-asset deposit to an AMM with an empty pool.
+	tfTwoAssetIfEmpty uint = 8388608
+)
+
+// Perform a double-asset deposit and receive the specified amount of LP Tokens.
+func (a *AMMDeposit) SetLPTokentFlag() {
+	a.Flags |= tfLPToken
+}
+
+// Perform a single-asset deposit with a specified amount of the asset to deposit.
+func (a *AMMDeposit) SetSingleAssetFlag() {
+	a.Flags |= tfSingleAsset
+}
+
+// Perform a double-asset deposit with specified amounts of both assets.
+func (a *AMMDeposit) SetTwoAssetFlag() {
+	a.Flags |= tfTwoAsset
+}
+
+// Perform a single-asset deposit and receive the specified amount of LP Tokens.
+func (a *AMMDeposit) SetOneAssetLPTokenFlag() {
+	a.Flags |= tfOneAssetLPToken
+}
+
+// Perform a single-asset deposit with a specified effective price.
+func (a *AMMDeposit) SetLimitLPTokenFlag() {
+	a.Flags |= tfLimitLPToken
+}
+
+// Perform a special double-asset deposit to an AMM with an empty pool.
+func (a *AMMDeposit) SetTwoAssetIfEmptyFlag() {
+	a.Flags |= tfTwoAssetIfEmpty
 }
 
 func (*AMMDeposit) TxType() TxType {
 	return AMMDepositTx
 }
 
-// TODO: Implement flatten
-func (s *AMMDeposit) Flatten() FlatTransaction {
-	return nil
+func (a *AMMDeposit) Flatten() FlatTransaction {
+
+	// Add BaseTx fields
+	flattened := a.BaseTx.Flatten()
+
+	// Add AMMDeposit-specific fields
+	flattened["TransactionType"] = "AMMDeposit"
+
+	flattened["Asset"] = a.Asset.Flatten()
+	flattened["Asset2"] = a.Asset2.Flatten()
+
+	if a.Amount != nil {
+		flattened["Amount"] = a.Amount.Flatten()
+	}
+
+	if a.Amount2 != nil {
+		flattened["Amount2"] = a.Amount2.Flatten()
+	}
+
+	if a.EPrice != nil {
+		flattened["EPrice"] = a.EPrice.Flatten()
+	}
+
+	if a.LPTokenOut != nil {
+		flattened["LPTokenOut"] = a.LPTokenOut.Flatten()
+	}
+
+	if a.TradingFee != 0 {
+		flattened["TradingFee"] = a.TradingFee
+	}
+
+	return flattened
 }

--- a/xrpl/transaction/amm_deposit_test.go
+++ b/xrpl/transaction/amm_deposit_test.go
@@ -86,3 +86,64 @@ func TestAMMDeposit_Flatten(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestAMMDeposit_Flags(t *testing.T) {
+	tests := []struct {
+		name     string
+		setter   func(*AMMDeposit)
+		expected uint
+	}{
+		{
+			name: "SetLPTokentFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetLPTokentFlag()
+			},
+			expected: tfLPToken,
+		},
+		{
+			name: "SetSingleAssetFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetSingleAssetFlag()
+			},
+			expected: tfSingleAsset,
+		},
+		{
+			name: "SetTwoAssetFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetTwoAssetFlag()
+			},
+			expected: tfTwoAsset,
+		},
+		{
+			name: "SetOneAssetLPTokenFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetOneAssetLPTokenFlag()
+			},
+			expected: tfOneAssetLPToken,
+		},
+		{
+			name: "SetLimitLPTokenFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetLimitLPTokenFlag()
+			},
+			expected: tfLimitLPToken,
+		},
+		{
+			name: "SetTwoAssetIfEmptyFlag",
+			setter: func(a *AMMDeposit) {
+				a.SetTwoAssetIfEmptyFlag()
+			},
+			expected: tfTwoAssetIfEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AMMDeposit{}
+			tt.setter(a)
+			if a.Flags != tt.expected {
+				t.Errorf("Expected AMMDeposit Flags to be %d, got %d", tt.expected, a.Flags)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/amm_deposit_test.go
+++ b/xrpl/transaction/amm_deposit_test.go
@@ -1,44 +1,88 @@
 package transaction
 
 import (
-	"encoding/json"
-	"reflect"
 	"testing"
 
+	ledger "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAMMDepositTransaction(t *testing.T) {
-	s := AMMDeposit{
+func TestAMMDeposit_TxType(t *testing.T) {
+	tx := &AMMDeposit{}
+	assert.Equal(t, AMMDepositTx, tx.TxType())
+}
+func TestAMMDeposit_Flatten(t *testing.T) {
+	tx := &AMMDeposit{
 		BaseTx: BaseTx{
-			Account:         "abcdef",
-			TransactionType: AMMDepositTx,
-			Fee:             types.XRPCurrencyAmount(1),
-			Sequence:        1234,
-			SigningPubKey:   "ghijk",
-			TxnSignature:    "A1B2C3D4E5F6",
+			Account:  "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+			Fee:      types.XRPCurrencyAmount(10),
+			Flags:    1048576,
+			Sequence: 7,
 		},
+		Asset: ledger.Asset{
+			Currency: "TST",
+			Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+		},
+		Asset2: ledger.Asset{
+			Currency: "XRP",
+		},
+		Amount: types.IssuedCurrencyAmount{
+			Value:    "2.5",
+			Currency: "TST",
+			Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+		},
+		Amount2: types.XRPCurrencyAmount(30000000),
+		EPrice: types.IssuedCurrencyAmount{
+			Value:    "1.5",
+			Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+			Currency: "TST",
+		},
+		LPTokenOut: types.IssuedCurrencyAmount{
+			Value:    "100",
+			Currency: "TST",
+			Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+		},
+		TradingFee: 10,
 	}
 
-	j := `{
-	"Account": "abcdef",
+	flattened := tx.Flatten()
+
+	expected := `{
+	"Account":         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+	"Fee":             "10",
+	"Flags":           1048576,
+	"Sequence":        7,
 	"TransactionType": "AMMDeposit",
-	"Fee": "1",
-	"Sequence": 1234,
-	"SigningPubKey": "ghijk",
-	"TxnSignature": "A1B2C3D4E5F6"
+	"Asset": {
+		"currency": "TST",
+		"issuer":   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+	},
+	"Asset2": {
+		"currency": "XRP"
+	},
+	"Amount": {
+		"issuer":   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+		"value":    "2.5",
+		"currency": "TST"
+	},
+	"Amount2": "30000000",
+	"EPrice": {
+		"value": "1.5",
+		"issuer": "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+		"currency": "TST"
+	},
+	"LPTokenOut": {
+		"value": "100",
+		"currency": "TST",
+		"issuer": "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+	},
+	"TradingFee": 10
 }`
 
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
-	}
-
-	tx, err := UnmarshalTx(json.RawMessage(j))
+	err := testutil.CompareFlattenAndExpected(flattened, []byte(expected))
 	if err != nil {
-		t.Errorf("UnmarshalTx error: %s", err.Error())
-	}
-	if !reflect.DeepEqual(tx, &s) {
-		t.Error("UnmarshalTx result differs from expected")
+		t.Error(err)
 	}
 }

--- a/xrpl/transaction/amm_deposit_test.go
+++ b/xrpl/transaction/amm_deposit_test.go
@@ -147,3 +147,315 @@ func TestAMMDeposit_Flags(t *testing.T) {
 		})
 	}
 }
+func TestAMMDeposit_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		tx       *AMMDeposit
+		expected bool
+	}{
+		{
+			name: "Valid AMMDeposit with Amount and Amount2",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "2.5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.XRPCurrencyAmount(30000000),
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid AMMDeposit BaseTx without TransactionType",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:  "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					Fee:      types.XRPCurrencyAmount(10),
+					Flags:    1048576,
+					Sequence: 7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "2.5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.XRPCurrencyAmount(30000000),
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit with Amount2 but no Amount",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount2: types.XRPCurrencyAmount(30000000),
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit with EPrice but no Amount",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "1.5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit with no LPTokenOut or Amount",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Valid AMMDeposit with LPTokenOut",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid AMMDeposit, invalid Asset",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit, invalid Asset2",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit, invalid Amount",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value: "1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit, invalid Amount2",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "USD",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value: "1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid AMMDeposit, invalid EPrice",
+			tx: &AMMDeposit{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMDeposit",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        7,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				LPTokenOut: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "USD",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "USD",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value: "1",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := tt.tx.Validate()
+			if valid != tt.expected {
+				t.Errorf("Expected validation result to be %v, got %v", tt.expected, valid)
+			}
+			if err != nil && tt.expected {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -211,6 +211,10 @@ func IsAsset(asset ledger.Asset) (bool, error) {
 		return true, nil
 	}
 
+	if strings.ToUpper(asset.Currency) == "XRP" && asset.Issuer != "" {
+		return false, errors.New("issuer field should be omitted for XRP currency")
+	}
+
 	if asset.Currency != "" && !addresscodec.IsValidClassicAddress(asset.Issuer.String()) {
 		return false, errors.New("issuer field must be a valid XRPL classic address")
 	}

--- a/xrpl/transaction/validations_xrpl_objects_test.go
+++ b/xrpl/transaction/validations_xrpl_objects_test.go
@@ -254,6 +254,19 @@ func TestIsAsset(t *testing.T) {
 		}
 	})
 
+	t.Run("Invalid Asset object with currency XRP and an issuer defined", func(t *testing.T) {
+		obj := ledger.Asset{
+			Currency: "xrP", // will be converted to XRP in the Validate function
+			Issuer:   "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+		}
+
+		ok, err := IsAsset(obj)
+
+		if ok {
+			t.Errorf("Expected IsAsset to return true, but got false with error: %v", err)
+		}
+	})
+
 	t.Run("Invalid Asset object with currency only and different than XRP", func(t *testing.T) {
 		obj := ledger.Asset{
 			Currency: "USD", // missing issuer


### PR DESCRIPTION
# Title

This PR aims to:

- Add the AMMDeposit transaction type
- Add a `Flatten` and `Validate` method
- Add all the relevant tests
- Update the `IsAsset` func to handle the case when the Currency is XRP and the issuer is set (invalid)
- Add a test for the new IsAsset check

`AMMDeposit` and `validations_xrpl_objects` have both 100% test coverage.

![image](https://github.com/user-attachments/assets/f1337bfc-b03e-44bb-b110-8352ebb99f5d)

![image](https://github.com/user-attachments/assets/2e85660a-47d4-43f0-80e4-0cfaeb75c55d)
