### PR TITLE
AMMWithdraw

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -403,7 +403,7 @@
 				
 				<option value="file173">github.com/Peersyst/xrpl-go/xrpl/transaction/types/address.go (100.0%)</option>
 				
-				<option value="file174">github.com/Peersyst/xrpl-go/xrpl/transaction/types/currency_amount.go (84.6%)</option>
+				<option value="file174">github.com/Peersyst/xrpl-go/xrpl/transaction/types/currency_amount.go (85.0%)</option>
 				
 				<option value="file175">github.com/Peersyst/xrpl-go/xrpl/transaction/types/hash128.go (100.0%)</option>
 				
@@ -8523,6 +8523,8 @@ func (a *AMMVote) Validate() (bool, error) <span class="cov8" title="1">{
 		<pre class="file" id="file141" style="display: none">package transaction
 
 import (
+        "errors"
+
         "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
@@ -8568,7 +8570,7 @@ type AMMWithdraw struct {
         // The minimum effective price, in LP Token returned, to pay per unit of the asset to withdraw.
         EPrice types.CurrencyAmount `json:",omitempty"`
         // How many of the AMM's LP Tokens to redeem.
-        LPTokenIn types.CurrencyAmount `json:",omitempty"`
+        LPTokenIn types.IssuedCurrencyAmount `json:",omitempty"`
 }
 
 // ****************************
@@ -8640,11 +8642,50 @@ func (a *AMMWithdraw) Flatten() FlatTransaction <span class="cov8" title="1">{
         <span class="cov8" title="1">if a.EPrice != nil </span><span class="cov8" title="1">{
                 flattened["EPrice"] = a.EPrice.Flatten()
         }</span>
-        <span class="cov8" title="1">if a.LPTokenIn != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if !a.LPTokenIn.IsZero() </span><span class="cov8" title="1">{
                 flattened["LPTokenIn"] = a.LPTokenIn.Flatten()
         }</span>
 
         <span class="cov8" title="1">return flattened</span>
+}
+
+func (a *AMMWithdraw) Validate() (bool, error) <span class="cov8" title="1">{
+        _, err := a.BaseTx.Validate()
+        if err != nil </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAsset(a.Asset); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAsset(a.Asset2); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if a.Amount2 != nil &amp;&amp; a.Amount == nil </span><span class="cov8" title="1">{
+                return false, errors.New("ammWithdraw: must set Amount with Amount2")
+        }</span> else<span class="cov8" title="1"> if a.EPrice != nil &amp;&amp; a.Amount == nil </span><span class="cov8" title="1">{
+                return false, errors.New("ammWithdraw: must set Amount with EPrice")
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.Amount, fieldName: "Amount", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.Amount2, fieldName: "Amount2", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsAmount(IsAmountArgs{field: a.EPrice, fieldName: "EPrice", isFieldRequired: false}); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if ok, err := IsIssuedCurrency(a.LPTokenIn); !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">return true, nil</span>
 }
 </pre>
 		
@@ -10545,6 +10586,11 @@ func (i IssuedCurrencyAmount) Flatten() interface{} <span class="cov8" title="1"
         }</span>
         <span class="cov8" title="1">return json</span>
 }
+
+// IsZero returns true if the IssuedCurrencyAmount is the zero value (empty object).
+func (i IssuedCurrencyAmount) IsZero() bool <span class="cov8" title="1">{
+        return i == IssuedCurrencyAmount{}
+}</span>
 
 type XRPCurrencyAmount uint64
 

--- a/coverage.html
+++ b/coverage.html
@@ -337,7 +337,7 @@
 				
 				<option value="file140">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_vote.go (100.0%)</option>
 				
-				<option value="file141">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_withdraw.go (0.0%)</option>
+				<option value="file141">github.com/Peersyst/xrpl-go/xrpl/transaction/amm_withdraw.go (100.0%)</option>
 				
 				<option value="file142">github.com/Peersyst/xrpl-go/xrpl/transaction/check_cancel.go (0.0%)</option>
 				
@@ -397,7 +397,7 @@
 				
 				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/trust_set.go (73.0%)</option>
 				
-				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (80.9%)</option>
+				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/tx.go (80.1%)</option>
 				
 				<option value="file172">github.com/Peersyst/xrpl-go/xrpl/transaction/tx_type.go (100.0%)</option>
 				
@@ -8329,16 +8329,6 @@ type AMMDeposit struct {
 
 // You must specify exactly one of these flags, plus any global flags.
 const (
-        // Perform a double-asset deposit and receive the specified amount of LP Tokens.
-        tfLPToken uint = 65536
-        // Perform a single-asset deposit with a specified amount of the asset to deposit.
-        tfSingleAsset uint = 524288
-        // Perform a double-asset deposit with specified amounts of both assets.
-        tfTwoAsset uint = 1048576
-        // Perform a single-asset deposit and receive the specified amount of LP Tokens.
-        tfOneAssetLPToken uint = 2097152
-        // Perform a single-asset deposit with a specified effective price.
-        tfLimitLPToken uint = 4194304
         // Perform a special double-asset deposit to an AMM with an empty pool.
         tfTwoAssetIfEmpty uint = 8388608
 )
@@ -8532,18 +8522,130 @@ func (a *AMMVote) Validate() (bool, error) <span class="cov8" title="1">{
 		
 		<pre class="file" id="file141" style="display: none">package transaction
 
+import (
+        "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+        "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+// Withdraw assets from an Automated Market Maker (AMM) instance by returning the AMM's liquidity provider tokens (LP Tokens).
+//
+// # Example
+//
+// ```json
+//
+//        {
+//            "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+//            "Amount" : {
+//                "currency" : "TST",
+//                "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+//                "value" : "5"
+//            },
+//            "Amount2" : "50000000",
+//            "Asset" : {
+//                "currency" : "TST",
+//                "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+//            },
+//            "Asset2" : {
+//                "currency" : "XRP"
+//            },
+//            "Fee" : "10",
+//            "Flags" : 1048576,
+//            "Sequence" : 10,
+//            "TransactionType" : "AMMWithdraw"
+//        }
+//
+// / ```
 type AMMWithdraw struct {
         BaseTx
+        // The definition for one of the assets in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+        Asset ledger.Asset
+        // The definition for the other asset in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+        Asset2 ledger.Asset
+        // The amount of one asset to withdraw from the AMM. This must match the type of one of the assets (tokens or XRP) in the AMM's pool.
+        Amount types.CurrencyAmount `json:",omitempty"`
+        // The amount of another asset to withdraw from the AMM. If present, this must match the type of the other asset in the AMM's pool and cannot be the same type as Amount.
+        Amount2 types.CurrencyAmount `json:",omitempty"`
+        // The minimum effective price, in LP Token returned, to pay per unit of the asset to withdraw.
+        EPrice types.CurrencyAmount `json:",omitempty"`
+        // How many of the AMM's LP Tokens to redeem.
+        LPTokenIn types.CurrencyAmount `json:",omitempty"`
 }
 
-func (*AMMWithdraw) TxType() TxType <span class="cov0" title="0">{
+// ****************************
+// AMMWithdraw Flags
+// ****************************
+
+const (
+        // Perform a double-asset withdrawal returning all your LP Tokens.
+        tfWithdrawAll uint = 131072
+        // Perform a single-asset withdrawal returning all of your LP Tokens.
+        tfOneAssetWithdrawAll uint = 262144
+)
+
+// Perform a double-asset withdrawal and receive the specified amount of LP Tokens.
+func (a *AMMWithdraw) SetLPTokentFlag() <span class="cov8" title="1">{
+        a.Flags |= tfLPToken
+}</span>
+
+// Perform a double-asset withdrawal returning all your LP Tokens.
+func (a *AMMWithdraw) SetWithdrawAllFlag() <span class="cov8" title="1">{
+        a.Flags |= tfWithdrawAll
+}</span>
+
+// Perform a single-asset withdrawal returning all of your LP Tokens.
+func (a *AMMWithdraw) SetOneAssetWithdrawAllFlag() <span class="cov8" title="1">{
+        a.Flags |= tfOneAssetWithdrawAll
+}</span>
+
+// Perform a single-asset withdrawal with a specified amount of the asset to withdrawal.
+func (a *AMMWithdraw) SetSingleAssetFlag() <span class="cov8" title="1">{
+        a.Flags |= tfSingleAsset
+}</span>
+
+// Perform a double-asset withdrawal with specified amounts of both assets.
+func (a *AMMWithdraw) SetTwoAssetFlag() <span class="cov8" title="1">{
+        a.Flags |= tfTwoAsset
+}</span>
+
+// Perform a single-asset withdrawal and receive the specified amount of LP Tokens.
+func (a *AMMWithdraw) SetOneAssetLPTokenFlag() <span class="cov8" title="1">{
+        a.Flags |= tfOneAssetLPToken
+}</span>
+
+// Perform a single-asset withdrawal with a specified effective price.
+func (a *AMMWithdraw) SetLimitLPTokenFlag() <span class="cov8" title="1">{
+        a.Flags |= tfLimitLPToken
+}</span>
+
+func (*AMMWithdraw) TxType() TxType <span class="cov8" title="1">{
         return AMMWithdrawTx
 }</span>
 
-// TODO: Implement flatten
-func (s *AMMWithdraw) Flatten() FlatTransaction <span class="cov0" title="0">{
-        return nil
-}</span>
+func (a *AMMWithdraw) Flatten() FlatTransaction <span class="cov8" title="1">{
+        // Add BaseTx fields
+        flattened := a.BaseTx.Flatten()
+
+        // Add AMMWithdraw-specific fields
+        flattened["TransactionType"] = "AMMWithdraw"
+
+        flattened["Asset"] = a.Asset.Flatten()
+        flattened["Asset2"] = a.Asset2.Flatten()
+
+        if a.Amount != nil </span><span class="cov8" title="1">{
+                flattened["Amount"] = a.Amount.Flatten()
+        }</span>
+        <span class="cov8" title="1">if a.Amount2 != nil </span><span class="cov8" title="1">{
+                flattened["Amount2"] = a.Amount2.Flatten()
+        }</span>
+        <span class="cov8" title="1">if a.EPrice != nil </span><span class="cov8" title="1">{
+                flattened["EPrice"] = a.EPrice.Flatten()
+        }</span>
+        <span class="cov8" title="1">if a.LPTokenIn != nil </span><span class="cov8" title="1">{
+                flattened["LPTokenIn"] = a.LPTokenIn.Flatten()
+        }</span>
+
+        <span class="cov8" title="1">return flattened</span>
+}
 </pre>
 		
 		<pre class="file" id="file142" style="display: none">package transaction
@@ -10188,7 +10290,7 @@ func UnmarshalTx(data json.RawMessage) (Tx, error) <span class="cov8" title="1">
                 tx = &amp;AMMDeposit{}</span>
         case AMMVoteTx:<span class="cov0" title="0">
                 tx = &amp;AMMVote{}</span>
-        case AMMWithdrawTx:<span class="cov8" title="1">
+        case AMMWithdrawTx:<span class="cov0" title="0">
                 tx = &amp;AMMWithdraw{}</span>
         case AccountSetTx:<span class="cov8" title="1">
                 tx = &amp;AccountSet{}</span>

--- a/xrpl/currency/native.go
+++ b/xrpl/currency/native.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	DROPS_PER_XRP       float64 = 1000000
-	MAX_FRACTION_LENGTH uint    = 6
+	DROPS_PER_XRP          float64 = 1000000
+	MAX_FRACTION_LENGTH    uint    = 6
+	NATIVE_CURRENCY_SYMBOL string  = "XRP"
 )
 
 // Convert an amount in XRP to an amount in drops.

--- a/xrpl/transaction/amm_bid.go
+++ b/xrpl/transaction/amm_bid.go
@@ -115,11 +115,11 @@ func (a *AMMBid) Validate() (bool, error) {
 		return false, errors.New("at least one of the assets must be non-XRP")
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.BidMin, fieldName: "BidMin", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.BidMin, "BidMin", false); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.BidMax, fieldName: "BidMax", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.BidMax, "BidMax", false); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/amm_common.go
+++ b/xrpl/transaction/amm_common.go
@@ -1,0 +1,10 @@
+package transaction
+
+// Common flags for AMM transactions (Deposit and Withdraw).
+const (
+	tfLPToken         uint = 65536
+	tfSingleAsset     uint = 524288
+	tfTwoAsset        uint = 1048576
+	tfOneAssetLPToken uint = 2097152
+	tfLimitLPToken    uint = 4194304
+)

--- a/xrpl/transaction/amm_common.go
+++ b/xrpl/transaction/amm_common.go
@@ -2,9 +2,14 @@ package transaction
 
 // Common flags for AMM transactions (Deposit and Withdraw).
 const (
-	tfLPToken         uint = 65536
-	tfSingleAsset     uint = 524288
-	tfTwoAsset        uint = 1048576
+	// Perform a double-asset withdrawal/deposit and receive the specified amount of LP Tokens.
+	tfLPToken uint = 65536
+	// Perform a single-asset withdrawal/deposit with a specified amount of the asset to deposit.
+	tfSingleAsset uint = 524288
+	// Perform a double-asset withdrawal/deposit with specified amounts of both assets.
+	tfTwoAsset uint = 1048576
+	// Perform a single-asset withdrawal/deposit and receive the specified amount of LP Tokens.
 	tfOneAssetLPToken uint = 2097152
-	tfLimitLPToken    uint = 4194304
+	// Perform a single-asset withdrawal/deposit with a specified effective price.
+	tfLimitLPToken uint = 4194304
 )

--- a/xrpl/transaction/amm_create.go
+++ b/xrpl/transaction/amm_create.go
@@ -49,11 +49,11 @@ func (a *AMMCreate) Validate() (bool, error) {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount, fieldName: "Amount", isFieldRequired: true}); !ok {
+	if ok, err := IsAmount(a.Amount, "Amount", true); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount2, fieldName: "Amount2", isFieldRequired: true}); !ok {
+	if ok, err := IsAmount(a.Amount2, "Amount2", true); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/amm_deposit.go
+++ b/xrpl/transaction/amm_deposit.go
@@ -155,15 +155,15 @@ func (a *AMMDeposit) Validate() (bool, error) {
 		return false, errors.New("ammDeposit:  must set at least LPTokenOut or Amount")
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount, fieldName: "Amount", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.Amount, "Amount", false); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount2, fieldName: "Amount", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.Amount2, "Amount", false); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.EPrice, fieldName: "EPrice", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.EPrice, "EPrice", false); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/amm_deposit.go
+++ b/xrpl/transaction/amm_deposit.go
@@ -61,16 +61,6 @@ type AMMDeposit struct {
 
 // You must specify exactly one of these flags, plus any global flags.
 const (
-	// Perform a double-asset deposit and receive the specified amount of LP Tokens.
-	tfLPToken uint = 65536
-	// Perform a single-asset deposit with a specified amount of the asset to deposit.
-	tfSingleAsset uint = 524288
-	// Perform a double-asset deposit with specified amounts of both assets.
-	tfTwoAsset uint = 1048576
-	// Perform a single-asset deposit and receive the specified amount of LP Tokens.
-	tfOneAssetLPToken uint = 2097152
-	// Perform a single-asset deposit with a specified effective price.
-	tfLimitLPToken uint = 4194304
 	// Perform a special double-asset deposit to an AMM with an empty pool.
 	tfTwoAssetIfEmpty uint = 8388608
 )

--- a/xrpl/transaction/amm_withdraw.go
+++ b/xrpl/transaction/amm_withdraw.go
@@ -97,10 +97,12 @@ func (a *AMMWithdraw) SetLimitLPTokenFlag() {
 	a.Flags |= tfLimitLPToken
 }
 
+// TxType returns the type of the transaction (AMMWithdraw).
 func (*AMMWithdraw) TxType() TxType {
 	return AMMWithdrawTx
 }
 
+// Flatten returns the flattened map of the AMMWithdraw transaction.
 func (a *AMMWithdraw) Flatten() FlatTransaction {
 	// Add BaseTx fields
 	flattened := a.BaseTx.Flatten()
@@ -127,6 +129,7 @@ func (a *AMMWithdraw) Flatten() FlatTransaction {
 	return flattened
 }
 
+// Validates the AMMWithdraw struct and make sure all the fields are correct.
 func (a *AMMWithdraw) Validate() (bool, error) {
 	_, err := a.BaseTx.Validate()
 	if err != nil {

--- a/xrpl/transaction/amm_withdraw.go
+++ b/xrpl/transaction/amm_withdraw.go
@@ -99,7 +99,28 @@ func (*AMMWithdraw) TxType() TxType {
 	return AMMWithdrawTx
 }
 
-// TODO: Implement flatten
-func (s *AMMWithdraw) Flatten() FlatTransaction {
-	return nil
+func (a *AMMWithdraw) Flatten() FlatTransaction {
+	// Add BaseTx fields
+	flattened := a.BaseTx.Flatten()
+
+	// Add AMMWithdraw-specific fields
+	flattened["TransactionType"] = "AMMWithdraw"
+
+	flattened["Asset"] = a.Asset.Flatten()
+	flattened["Asset2"] = a.Asset2.Flatten()
+
+	if a.Amount != nil {
+		flattened["Amount"] = a.Amount.Flatten()
+	}
+	if a.Amount2 != nil {
+		flattened["Amount2"] = a.Amount2.Flatten()
+	}
+	if a.EPrice != nil {
+		flattened["EPrice"] = a.EPrice.Flatten()
+	}
+	if a.LPTokenIn != nil {
+		flattened["LPTokenIn"] = a.LPTokenIn.Flatten()
+	}
+
+	return flattened
 }

--- a/xrpl/transaction/amm_withdraw.go
+++ b/xrpl/transaction/amm_withdraw.go
@@ -1,7 +1,98 @@
 package transaction
 
+import (
+	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+// Withdraw assets from an Automated Market Maker (AMM) instance by returning the AMM's liquidity provider tokens (LP Tokens).
+//
+// # Example
+//
+// ```json
+//
+//	{
+//	    "Account" : "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+//	    "Amount" : {
+//	        "currency" : "TST",
+//	        "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+//	        "value" : "5"
+//	    },
+//	    "Amount2" : "50000000",
+//	    "Asset" : {
+//	        "currency" : "TST",
+//	        "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+//	    },
+//	    "Asset2" : {
+//	        "currency" : "XRP"
+//	    },
+//	    "Fee" : "10",
+//	    "Flags" : 1048576,
+//	    "Sequence" : 10,
+//	    "TransactionType" : "AMMWithdraw"
+//	}
+//
+// / ```
 type AMMWithdraw struct {
 	BaseTx
+	// The definition for one of the assets in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+	Asset ledger.Asset
+	// The definition for the other asset in the AMM's pool. In JSON, this is an object with currency and issuer fields (omit issuer for XRP).
+	Asset2 ledger.Asset
+	// The amount of one asset to withdraw from the AMM. This must match the type of one of the assets (tokens or XRP) in the AMM's pool.
+	Amount types.CurrencyAmount `json:",omitempty"`
+	// The amount of another asset to withdraw from the AMM. If present, this must match the type of the other asset in the AMM's pool and cannot be the same type as Amount.
+	Amount2 types.CurrencyAmount `json:",omitempty"`
+	// The minimum effective price, in LP Token returned, to pay per unit of the asset to withdraw.
+	EPrice types.CurrencyAmount `json:",omitempty"`
+	// How many of the AMM's LP Tokens to redeem.
+	LPTokenIn types.CurrencyAmount `json:",omitempty"`
+}
+
+// ****************************
+// AMMWithdraw Flags
+// ****************************
+
+const (
+	// Perform a double-asset withdrawal returning all your LP Tokens.
+	tfWithdrawAll uint = 131072
+	// Perform a single-asset withdrawal returning all of your LP Tokens.
+	tfOneAssetWithdrawAll uint = 262144
+)
+
+// Perform a double-asset withdrawal and receive the specified amount of LP Tokens.
+func (a *AMMWithdraw) SetLPTokentFlag() {
+	a.Flags |= tfLPToken
+}
+
+// Perform a double-asset withdrawal returning all your LP Tokens.
+func (a *AMMWithdraw) SetWithdrawAllFlag() {
+	a.Flags |= tfWithdrawAll
+}
+
+// Perform a single-asset withdrawal returning all of your LP Tokens.
+func (a *AMMWithdraw) SetOneAssetWithdrawAllFlag() {
+	a.Flags |= tfOneAssetWithdrawAll
+}
+
+// Perform a single-asset withdrawal with a specified amount of the asset to withdrawal.
+func (a *AMMWithdraw) SetSingleAssetFlag() {
+	a.Flags |= tfSingleAsset
+}
+
+// Perform a double-asset withdrawal with specified amounts of both assets.
+func (a *AMMWithdraw) SetTwoAssetFlag() {
+	a.Flags |= tfTwoAsset
+}
+
+// Perform a single-asset withdrawal and receive the specified amount of LP Tokens.
+func (a *AMMWithdraw) SetOneAssetLPTokenFlag() {
+	a.Flags |= tfOneAssetLPToken
+}
+
+// Perform a single-asset withdrawal with a specified effective price.
+func (a *AMMWithdraw) SetLimitLPTokenFlag() {
+	a.Flags |= tfLimitLPToken
 }
 
 func (*AMMWithdraw) TxType() TxType {

--- a/xrpl/transaction/amm_withdraw.go
+++ b/xrpl/transaction/amm_withdraw.go
@@ -150,15 +150,15 @@ func (a *AMMWithdraw) Validate() (bool, error) {
 		return false, errors.New("ammWithdraw: must set Amount with EPrice")
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount, fieldName: "Amount", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.Amount, "Amount", false); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.Amount2, fieldName: "Amount2", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.Amount2, "Amount2", false); !ok {
 		return false, err
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: a.EPrice, fieldName: "EPrice", isFieldRequired: false}); !ok {
+	if ok, err := IsAmount(a.EPrice, "EPrice", false); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/amm_withdraw_test.go
+++ b/xrpl/transaction/amm_withdraw_test.go
@@ -207,3 +207,320 @@ func TestAMMWithdraw_Flatten(t *testing.T) {
 		})
 	}
 }
+func TestAMMWithdraw_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *AMMWithdraw
+		expected bool
+	}{
+		{
+			name: "Valid AMMWithdraw",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "50000000",
+					Currency: "ABC",
+					Issuer:   "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "TST",
+					Issuer:   "rJhPKEN1m6FDGy9FZ85Ek2n3tAyUBR4KBv",
+				},
+				LPTokenIn: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rQH2Rhja1YRC3spuVukZBu9WzRiD1R9Dcr",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid AMMWithdraw BaseTx, TransactionType missing",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:  "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					Fee:      types.XRPCurrencyAmount(10),
+					Flags:    1048576,
+					Sequence: 10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "50000000",
+					Currency: "ABC",
+					Issuer:   "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "TST",
+					Issuer:   "rJhPKEN1m6FDGy9FZ85Ek2n3tAyUBR4KBv",
+				},
+				LPTokenIn: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rQH2Rhja1YRC3spuVukZBu9WzRiD1R9Dcr",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid Asset",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid, Amount2 without Amount",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "UST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "50000000",
+					Currency: "ABC",
+					Issuer:   "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid, EPrice set without Amount",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "UST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "50000000",
+					Currency: "ABC",
+					Issuer:   "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid Asset2",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "USDC",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid Amount",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid Amount2",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "10",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:  "",
+					Issuer: "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid EPrice",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "10",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "12",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:  "12",
+					Issuer: "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid LPTokenIn",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "10",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "12",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "12",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				LPTokenIn: types.IssuedCurrencyAmount{
+					Value:  "12",
+					Issuer: "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := tt.input.Validate()
+			if valid != tt.expected {
+				t.Errorf("Expected validation result to be %v, got %v", tt.expected, valid)
+			}
+			if (err != nil) != !tt.expected {
+				t.Errorf("Expected error presence to be %v, got %v", !tt.expected, err != nil)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/amm_withdraw_test.go
+++ b/xrpl/transaction/amm_withdraw_test.go
@@ -1,44 +1,80 @@
 package transaction
 
 import (
-	"encoding/json"
-	"reflect"
 	"testing"
 
-	"github.com/Peersyst/xrpl-go/xrpl/testutil"
-	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAMMWithdrawTransaction(t *testing.T) {
-	s := AMMWithdraw{
-		BaseTx: BaseTx{
-			Account:         "abcdef",
-			TransactionType: AMMWithdrawTx,
-			Fee:             types.XRPCurrencyAmount(1),
-			Sequence:        1234,
-			SigningPubKey:   "ghijk",
-			TxnSignature:    "A1B2C3D4E5F6",
+func TestAMMWithdraw_TxType(t *testing.T) {
+	tx := &AMMWithdraw{}
+	assert.Equal(t, AMMWithdrawTx, tx.TxType())
+}
+
+func TestAMMWithdraw_Flags(t *testing.T) {
+	tests := []struct {
+		name     string
+		setter   func(*AMMWithdraw)
+		expected uint
+	}{
+		{
+			name: "SetLPTokentFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetLPTokentFlag()
+			},
+			expected: tfLPToken,
+		},
+		{
+			name: "SetWithdrawAllFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetWithdrawAllFlag()
+			},
+			expected: tfWithdrawAll,
+		},
+		{
+			name: "SetOneAssetWithdrawAllFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetOneAssetWithdrawAllFlag()
+			},
+			expected: tfOneAssetWithdrawAll,
+		},
+		{
+			name: "SetSingleAssetFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetSingleAssetFlag()
+			},
+			expected: tfSingleAsset,
+		},
+		{
+			name: "SetTwoAssetFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetTwoAssetFlag()
+			},
+			expected: tfTwoAsset,
+		},
+		{
+			name: "SetOneAssetLPTokenFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetOneAssetLPTokenFlag()
+			},
+			expected: tfOneAssetLPToken,
+		},
+		{
+			name: "SetLimitLPTokenFlag",
+			setter: func(a *AMMWithdraw) {
+				a.SetLimitLPTokenFlag()
+			},
+			expected: tfLimitLPToken,
 		},
 	}
 
-	j := `{
-	"Account": "abcdef",
-	"TransactionType": "AMMWithdraw",
-	"Fee": "1",
-	"Sequence": 1234,
-	"SigningPubKey": "ghijk",
-	"TxnSignature": "A1B2C3D4E5F6"
-}`
-
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
-	}
-
-	tx, err := UnmarshalTx(json.RawMessage(j))
-	if err != nil {
-		t.Errorf("UnmarshalTx error: %s", err.Error())
-	}
-	if !reflect.DeepEqual(tx, &s) {
-		t.Error("UnmarshalTx result differs from expected")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AMMWithdraw{}
+			tt.setter(a)
+			if a.Flags != tt.expected {
+				t.Errorf("Expected AMMWithdraw Flags to be %d, got %d", tt.expected, a.Flags)
+			}
+		})
 	}
 }

--- a/xrpl/transaction/amm_withdraw_test.go
+++ b/xrpl/transaction/amm_withdraw_test.go
@@ -3,6 +3,9 @@ package transaction
 import (
 	"testing"
 
+	ledger "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,6 +77,132 @@ func TestAMMWithdraw_Flags(t *testing.T) {
 			tt.setter(a)
 			if a.Flags != tt.expected {
 				t.Errorf("Expected AMMWithdraw Flags to be %d, got %d", tt.expected, a.Flags)
+			}
+		})
+	}
+}
+
+func TestAMMWithdraw_Flatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *AMMWithdraw
+		expected string
+	}{
+		{
+			name: "Full AMMWithdraw",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+				Amount: types.IssuedCurrencyAmount{
+					Value:    "5",
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Amount2: types.IssuedCurrencyAmount{
+					Value:    "50000000",
+					Currency: "ABC",
+					Issuer:   "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur",
+				},
+				EPrice: types.IssuedCurrencyAmount{
+					Value:    "1",
+					Currency: "TST",
+					Issuer:   "rJhPKEN1m6FDGy9FZ85Ek2n3tAyUBR4KBv",
+				},
+				LPTokenIn: types.IssuedCurrencyAmount{
+					Value:    "100",
+					Currency: "TST",
+					Issuer:   "rQH2Rhja1YRC3spuVukZBu9WzRiD1R9Dcr",
+				},
+			},
+			expected: `{
+				"TransactionType": "AMMWithdraw",
+				"Account": "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+				"Fee": "10",
+				"Flags": 1048576,
+				"Sequence": 10,
+				"Asset": {
+					"currency": "TST",
+					"issuer":   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+				},
+				"Asset2": {
+					"currency": "XRP"
+				},
+				"Amount": {
+					"value":    "5",
+					"currency": "TST",
+					"issuer":   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+				},
+				"Amount2": {
+					"value": "50000000",
+					"currency": "ABC",
+					"issuer": "rKswUGcm3wXPSaMfEHdUAQvE8otkZCd1ur"
+				},
+				"EPrice": {
+					"value": "1",
+					"currency": "TST",
+					"issuer": "rJhPKEN1m6FDGy9FZ85Ek2n3tAyUBR4KBv"
+				},
+				"LPTokenIn": {
+					"value": "100",
+					"currency": "TST",
+					"issuer": "rQH2Rhja1YRC3spuVukZBu9WzRiD1R9Dcr"
+				}
+			}`,
+		},
+		{
+			name: "Minimal AMMWithdraw",
+			input: &AMMWithdraw{
+				BaseTx: BaseTx{
+					Account:         "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+					TransactionType: "AMMWithdraw",
+					Fee:             types.XRPCurrencyAmount(10),
+					Flags:           1048576,
+					Sequence:        10,
+				},
+				Asset: ledger.Asset{
+					Currency: "TST",
+					Issuer:   "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd",
+				},
+				Asset2: ledger.Asset{
+					Currency: "XRP",
+				},
+			},
+			expected: `{
+				"TransactionType": "AMMWithdraw",
+				"Account": "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+				"Fee": "10",
+				"Flags": 1048576,
+				"Sequence": 10,
+				"Asset": {
+					"currency": "TST",
+					"issuer": "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+				},
+				"Asset2": {
+					"currency": "XRP"
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.Flatten()
+
+			err := testutil.CompareFlattenAndExpected(result, []byte(tt.expected))
+			if err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/xrpl/transaction/payment.go
+++ b/xrpl/transaction/payment.go
@@ -211,7 +211,7 @@ func (tx *Payment) Validate() (bool, error) {
 	}
 
 	// Check if the field Amount is valid
-	if ok, err := IsAmount(IsAmountArgs{field: tx.Amount, fieldName: "Amount", isFieldRequired: true}); !ok {
+	if ok, err := IsAmount(tx.Amount, "Amount", true); !ok {
 		return false, err
 	}
 
@@ -241,17 +241,17 @@ func (tx *Payment) Validate() (bool, error) {
 	}
 
 	// Check if the field SendMax is valid
-	if ok, err := IsAmount(IsAmountArgs{field: tx.SendMax, fieldName: "SendMax"}); !ok {
+	if ok, err := IsAmount(tx.SendMax, "SendMax", false); !ok {
 		return false, err
 	}
 
 	// Check if the field DeliverMax is valid
-	if ok, err := IsAmount(IsAmountArgs{field: tx.DeliverMax, fieldName: "DeliverMax"}); !ok {
+	if ok, err := IsAmount(tx.DeliverMax, "DeliverMax", false); !ok {
 		return false, err
 	}
 
 	// Check if the field DeliverMin is valid
-	if ok, err := IsAmount(IsAmountArgs{field: tx.DeliverMin, fieldName: "DeliverMin"}); !ok {
+	if ok, err := IsAmount(tx.DeliverMin, "DeliverMin", false); !ok {
 		return false, err
 	}
 
@@ -276,7 +276,7 @@ func checkPartialPayment(tx *Payment) (bool, error) {
 		return false, errors.New("payment transaction: tfPartialPayment flag required with DeliverMin")
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: tx.DeliverMin, fieldName: "DeliverMin", isFieldRequired: true}); !ok {
+	if ok, err := IsAmount(tx.DeliverMin, "DeliverMin", true); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/trust_set.go
+++ b/xrpl/transaction/trust_set.go
@@ -139,7 +139,7 @@ func (tx *TrustSet) Validate() (bool, error) {
 		return false, errors.New("trustSet: missing field LimitAmount")
 	}
 
-	if ok, err := IsAmount(IsAmountArgs{field: tx.LimitAmount, fieldName: "LimitAmount", isFieldRequired: true}); !ok {
+	if ok, err := IsAmount(tx.LimitAmount, "LimitAmount", true); !ok {
 		return false, err
 	}
 

--- a/xrpl/transaction/types/currency_amount.go
+++ b/xrpl/transaction/types/currency_amount.go
@@ -64,6 +64,11 @@ func (i IssuedCurrencyAmount) Flatten() interface{} {
 	return json
 }
 
+// IsZero returns true if the IssuedCurrencyAmount is the zero value (empty object).
+func (i IssuedCurrencyAmount) IsZero() bool {
+	return i == IssuedCurrencyAmount{}
+}
+
 type XRPCurrencyAmount uint64
 
 func (a XRPCurrencyAmount) Uint64() uint64 {

--- a/xrpl/transaction/types/currency_amount_test.go
+++ b/xrpl/transaction/types/currency_amount_test.go
@@ -1,0 +1,55 @@
+package types
+
+import "testing"
+
+func TestIssuedCurrencyAmount_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		ica  IssuedCurrencyAmount
+		want bool
+	}{
+		{
+			name: "Zero value",
+			ica:  IssuedCurrencyAmount{},
+			want: true,
+		},
+		{
+			name: "Non-zero value",
+			ica: IssuedCurrencyAmount{
+				Issuer:   "rEXAMPLE",
+				Currency: "USD",
+				Value:    "100",
+			},
+			want: false,
+		},
+		{
+			name: "Non-zero value, invalid only with issuer",
+			ica: IssuedCurrencyAmount{
+				Issuer: "rEXAMPLE",
+			},
+			want: false,
+		},
+		{
+			name: "Non-zero value, invalid only with value",
+			ica: IssuedCurrencyAmount{
+				Value: "100",
+			},
+			want: false,
+		},
+		{
+			name: "Non-zero value, invalid only with currency",
+			ica: IssuedCurrencyAmount{
+				Currency: "USD",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ica.IsZero(); got != tt.want {
+				t.Errorf("IssuedCurrencyAmount.IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -9,6 +9,7 @@ import (
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
 	maputils "github.com/Peersyst/xrpl-go/pkg/map_utils"
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
 	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
@@ -116,7 +117,7 @@ func IsIssuedCurrency(input types.CurrencyAmount) (bool, error) {
 	if strings.TrimSpace(issuedAmount.Currency) == "" {
 		return false, errors.New("currency field is required for an issued currency")
 	}
-	if strings.ToUpper(issuedAmount.Currency) == "XRP" {
+	if strings.ToUpper(issuedAmount.Currency) == currency.NATIVE_CURRENCY_SYMBOL {
 		return false, errors.New("cannot have an issued currency with a similar standard code as XRP")
 	}
 
@@ -159,7 +160,7 @@ func IsPath(path []PathStep) (bool, error) {
 		*/
 		if (hasAccount && !hasCurrency && !hasIssuer) || (hasCurrency && !hasAccount && !hasIssuer) || (hasIssuer && !hasAccount && !hasCurrency) {
 			return true, nil
-		} else if hasIssuer && hasCurrency && pathStep.Currency != "XRP" {
+		} else if hasIssuer && hasCurrency && pathStep.Currency != currency.NATIVE_CURRENCY_SYMBOL {
 			return true, nil
 		} else {
 			return false, errors.New("invalid path step, check the valid fields combination at https://xrpl.org/docs/concepts/tokens/fungible-tokens/paths#path-specifications")
@@ -201,11 +202,11 @@ func IsAsset(asset ledger.Asset) (bool, error) {
 		return false, errors.New("currency field is required for an asset")
 	}
 
-	if strings.ToUpper(asset.Currency) == "XRP" && strings.TrimSpace(asset.Issuer.String()) == "" {
+	if strings.ToUpper(asset.Currency) == currency.NATIVE_CURRENCY_SYMBOL && strings.TrimSpace(asset.Issuer.String()) == "" {
 		return true, nil
 	}
 
-	if strings.ToUpper(asset.Currency) == "XRP" && asset.Issuer != "" {
+	if strings.ToUpper(asset.Currency) == currency.NATIVE_CURRENCY_SYMBOL && asset.Issuer != "" {
 		return false, errors.New("issuer field should be omitted for XRP currency")
 	}
 

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -76,29 +76,23 @@ func IsSigner(signerData SignerData) (bool, error) {
 
 }
 
-type IsAmountArgs struct {
-	field           types.CurrencyAmount
-	fieldName       string
-	isFieldRequired bool
-}
-
 // IsAmount checks if the given object is a valid Amount object.
 // It is a string for an XRP amount or a map for an IssuedCurrency amount.
-func IsAmount(props IsAmountArgs) (bool, error) {
-	if props.isFieldRequired && props.field == nil {
-		return false, fmt.Errorf("missing field %s", props.fieldName)
+func IsAmount(field types.CurrencyAmount, fieldName string, isFieldRequired bool) (bool, error) {
+	if isFieldRequired && field == nil {
+		return false, fmt.Errorf("missing field %s", fieldName)
 	}
 
-	if !props.isFieldRequired && props.field == nil {
+	if !isFieldRequired && field == nil {
 		// no need to check further properties on a nil field, will create a panic with tests otherwise
 		return true, nil
 	}
 
-	if props.field.Kind() == types.XRP {
+	if field.Kind() == types.XRP {
 		return true, nil
 	}
 
-	if ok, err := IsIssuedCurrency(props.field); !ok {
+	if ok, err := IsIssuedCurrency(field); !ok {
 		return false, err
 	}
 


### PR DESCRIPTION
# Title

This PR needs to be reviewed after #42 .

This PR aims to add the `AMMWithdraw` type with:
- Validate() + tests
- Flatten() + tests
- Add a `IsZero` function to IssuedCurrency objects to check if the object is empty or not. The PR adds tests for this func also.

It also refactors some flags which are share between `AMMWithdraw` and `AMMDeposit`. Those shared flags are placed in a `amm_common.go` file.

AMMWithdraw has 100% coverage tests.

![image](https://github.com/user-attachments/assets/d946886e-18de-4951-9d48-c7e48f17519e)


## Changes

- Change 1
- Change 2

## Notes (optional)

Describe any additional notes here.
