### PR TITLE
Payment channel transaction types

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -11180,8 +11180,6 @@ var (
         ErrInvalidChannel = errors.New("invalid Channel, must be a valid 64-character hexadecimal string")
         // ErrInvalidSignature is returned when the Signature is not a valid hexadecimal string.
         ErrInvalidSignature = errors.New("invalid Signature, must be a valid hexadecimal string")
-        // ErrInvalidPublicKey is returned when the PublicKey is not a valid hexadecimal string.
-        ErrInvalidPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
 )
 
 // Claim XRP from a payment channel, adjust the payment channel's expiration, or both. This transaction can be used differently depending on the transaction sender's role in the specified channel:
@@ -11315,6 +11313,8 @@ func (p *PaymentChannelClaim) Validate() (bool, error) <span class="cov8" title=
 		<pre class="file" id="file170" style="display: none">package transaction
 
 import (
+        addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+        "github.com/Peersyst/xrpl-go/pkg/typecheck"
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
@@ -11380,6 +11380,26 @@ func (p *PaymentChannelCreate) Flatten() FlatTransaction <span class="cov8" titl
         }</span>
 
         <span class="cov8" title="1">return flattened</span>
+}
+
+// Validate validates the PaymentChannelCreate fields.
+func (p *PaymentChannelCreate) Validate() (bool, error) <span class="cov8" title="1">{
+        ok, err := p.BaseTx.Validate()
+        if (err != nil) || !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        // check valid xrpl address for Destination
+        <span class="cov8" title="1">if !addresscodec.IsValidClassicAddress(p.Destination.String()) </span><span class="cov8" title="1">{
+                return false, ErrInvalidDestination
+        }</span>
+
+        // check PublicKey is valid hexademical string
+        <span class="cov8" title="1">if !typecheck.IsHex(p.PublicKey) </span><span class="cov8" title="1">{
+                return false, ErrInvalidPublicKey
+        }</span>
+
+        <span class="cov8" title="1">return true, nil</span>
 }
 </pre>
 		

--- a/coverage.html
+++ b/coverage.html
@@ -395,7 +395,7 @@
 				
 				<option value="file169">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_claim.go (12.5%)</option>
 				
-				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (0.0%)</option>
+				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (100.0%)</option>
 				
 				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_fund.go (100.0%)</option>
 				
@@ -11237,24 +11237,69 @@ import (
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
+// Create a payment channel and fund it with XRP. The address sending this transaction becomes the "source address" of the payment channel.
+//
+// Example:
+//
+// ```json
+//
+//        {
+//            "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+//            "TransactionType": "PaymentChannelCreate",
+//            "Amount": "10000",
+//            "Destination": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+//            "SettleDelay": 86400,
+//            "PublicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+//            "CancelAfter": 533171558,
+//            "DestinationTag": 23480,
+//            "SourceTag": 11747
+//        }
+//
+// / ```
 type PaymentChannelCreate struct {
         BaseTx
-        Amount         types.XRPCurrencyAmount
-        Destination    types.Address
-        SettleDelay    uint32
-        PublicKey      string
-        CancelAfter    uint32 `json:",omitempty"`
+        // Amount of XRP, in drops, to deduct from the sender's balance and set aside in this channel.
+        // While the channel is open, the XRP can only go to the Destination address. When the channel closes, any unclaimed XRP is returned to the source address's balance.
+        Amount types.XRPCurrencyAmount
+        // Address to receive XRP claims against this channel. This is also known as the "destination address" for the channel. Cannot be the same as the sender (Account).
+        Destination types.Address
+        // Amount of time the source address must wait before closing the channel if it has unclaimed XRP.
+        SettleDelay uint32
+        // The 33-byte public key of the key pair the source will use to sign claims against this channel, in hexadecimal.
+        // This can be any secp256k1 or Ed25519 public key. For more information on key pairs, see Key Derivation
+        PublicKey string
+        // (Optional) The time, in seconds since the Ripple Epoch, when this channel expires.
+        // Any transaction that would modify the channel after this time closes the channel without otherwise affecting it.
+        // This value is immutable; the channel can be closed earlier than this time but cannot remain open after this time.
+        CancelAfter uint32 `json:",omitempty"`
+        // (Optional) Arbitrary tag to further specify the destination for this payment channel, such as a hosted recipient at the destination address.
         DestinationTag uint32 `json:",omitempty"`
 }
 
-func (*PaymentChannelCreate) TxType() TxType <span class="cov0" title="0">{
+// TxType returns the type of the transaction (PaymentChannelCreate).
+func (*PaymentChannelCreate) TxType() TxType <span class="cov8" title="1">{
         return PaymentChannelCreateTx
 }</span>
 
-// TODO: Implement flatten
-func (s *PaymentChannelCreate) Flatten() FlatTransaction <span class="cov0" title="0">{
-        return nil
-}</span>
+// Flatten returns a map of the PaymentChannelCreate transaction fields.
+func (p *PaymentChannelCreate) Flatten() FlatTransaction <span class="cov8" title="1">{
+        flattened := p.BaseTx.Flatten()
+
+        flattened["Amount"] = p.Amount.String()
+        flattened["Destination"] = p.Destination.String()
+        flattened["SettleDelay"] = p.SettleDelay
+        flattened["PublicKey"] = p.PublicKey
+
+        if p.CancelAfter != 0 </span><span class="cov8" title="1">{
+                flattened["CancelAfter"] = p.CancelAfter
+        }</span>
+
+        <span class="cov8" title="1">if p.DestinationTag != 0 </span><span class="cov8" title="1">{
+                flattened["DestinationTag"] = p.DestinationTag
+        }</span>
+
+        <span class="cov8" title="1">return flattened</span>
+}
 </pre>
 		
 		<pre class="file" id="file171" style="display: none">package transaction

--- a/coverage.html
+++ b/coverage.html
@@ -397,7 +397,7 @@
 				
 				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (0.0%)</option>
 				
-				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_fund.go (0.0%)</option>
+				<option value="file171">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_fund.go (100.0%)</option>
 				
 				<option value="file172">github.com/Peersyst/xrpl-go/xrpl/transaction/set_regular_key.go (100.0%)</option>
 				
@@ -11260,24 +11260,79 @@ func (s *PaymentChannelCreate) Flatten() FlatTransaction <span class="cov0" titl
 		<pre class="file" id="file171" style="display: none">package transaction
 
 import (
+        "errors"
+        "time"
+
+        "github.com/Peersyst/xrpl-go/xrpl"
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
+var (
+        ErrInvalidExpiration = errors.New("expiration time must be either later than the current time plus the SettleDelay of the channel, or the existing Expiration of the channel")
+)
+
+// Add additional XRP to an open payment channel, and optionally update the expiration time of the channel. Only the source address of the channel can use this transaction.
+//
+// Example:
+//
+// ```json
+//
+//        {
+//                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+//                "TransactionType": "PaymentChannelFund",
+//                "Channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+//                "Amount": "200000",
+//                "Expiration": 543171558
+//        }
+//
+// ```
 type PaymentChannelFund struct {
         BaseTx
-        Channel    types.Hash256
-        Amount     types.XRPCurrencyAmount
+        // The unique ID of the channel to fund, as a 64-character hexadecimal string.
+        Channel types.Hash256
+        // Amount of XRP, in drops to add to the channel. Must be a positive amount of XRP.
+        Amount types.XRPCurrencyAmount
+        // (Optional) New Expiration time to set for the channel, in seconds since the Ripple Epoch.
+        // This must be later than either the current time plus the SettleDelay of the channel, or the existing Expiration of the channel.
+        // After the Expiration time, any transaction that would access the channel closes the channel without taking its normal action.
+        // Any unspent XRP is returned to the source address when the channel closes. (Expiration is separate from the channel's immutable CancelAfter time.) For more information, see the PayChannel ledger object type.
         Expiration uint32 `json:",omitempty"`
 }
 
-func (*PaymentChannelFund) TxType() TxType <span class="cov0" title="0">{
+// TxType returns the type of the transaction (PaymentChannelFund).
+func (*PaymentChannelFund) TxType() TxType <span class="cov8" title="1">{
         return PaymentChannelFundTx
 }</span>
 
-// TODO: Implement flatten
-func (s *PaymentChannelFund) Flatten() FlatTransaction <span class="cov0" title="0">{
-        return nil
-}</span>
+// Flatten returns a map of the PaymentChannelFund transaction fields.
+func (p *PaymentChannelFund) Flatten() FlatTransaction <span class="cov8" title="1">{
+        flattened := p.BaseTx.Flatten()
+
+        flattened["Channel"] = p.Channel.String()
+        flattened["Amount"] = p.Amount.String()
+
+        if p.Expiration != 0 </span><span class="cov8" title="1">{
+                flattened["Expiration"] = p.Expiration
+        }</span>
+
+        <span class="cov8" title="1">return flattened</span>
+}
+
+// Validate validates the PaymentChannelFund fields.
+func (p *PaymentChannelFund) Validate() (bool, error) <span class="cov8" title="1">{
+        ok, err := p.BaseTx.Validate()
+        if err != nil || !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        // check the expiration time is in the future. /!\ Incomplete as the channel SettleDelay is not taken into account but it's already a good check.
+        <span class="cov8" title="1">currentRippleTime := xrpl.UnixTimeToRippleTime(time.Now().Unix())
+        if (p.Expiration != 0) &amp;&amp; (p.Expiration &lt; uint32(currentRippleTime)) </span><span class="cov8" title="1">{
+                return false, ErrInvalidExpiration
+        }</span>
+
+        <span class="cov8" title="1">return true, nil</span>
+}
 </pre>
 		
 		<pre class="file" id="file172" style="display: none">package transaction

--- a/coverage.html
+++ b/coverage.html
@@ -393,7 +393,7 @@
 				
 				<option value="file168">github.com/Peersyst/xrpl-go/xrpl/transaction/payment.go (79.7%)</option>
 				
-				<option value="file169">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_claim.go (12.5%)</option>
+				<option value="file169">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_claim.go (100.0%)</option>
 				
 				<option value="file170">github.com/Peersyst/xrpl-go/xrpl/transaction/payment_channel_create.go (100.0%)</option>
 				
@@ -11142,8 +11142,15 @@ func checkPartialPayment(tx *Payment) (bool, error) <span class="cov8" title="1"
 		<pre class="file" id="file169" style="display: none">package transaction
 
 import (
+        "errors"
+
+        "github.com/Peersyst/xrpl-go/pkg/typecheck"
         "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
+
+// *********************
+// Flags
+// *********************
 
 const (
         // Clear the channel's Expiration time. (Expiration is different from the
@@ -11164,44 +11171,96 @@ const (
         tfClose uint32 = 131072 // 0x00020000
 )
 
-// Claim XRP from a payment channel, adjust the payment channel's expiration,
-// or both.
+// *********************
+// Errors
+// *********************
+
+var (
+        // ErrInvalidChannel is returned when the Channel is not a valid 64-character hexadecimal string.
+        ErrInvalidChannel = errors.New("invalid Channel, must be a valid 64-character hexadecimal string")
+        // ErrInvalidSignature is returned when the Signature is not a valid hexadecimal string.
+        ErrInvalidSignature = errors.New("invalid Signature, must be a valid hexadecimal string")
+        // ErrInvalidPublicKey is returned when the PublicKey is not a valid hexadecimal string.
+        ErrInvalidPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
+)
+
+// Claim XRP from a payment channel, adjust the payment channel's expiration, or both. This transaction can be used differently depending on the transaction sender's role in the specified channel:
+//
+// The source address of a channel can:
+//
+// - Send XRP from the channel to the destination with or without a signed Claim.
+// - Set the channel to expire as soon as the channel's SettleDelay has passed.
+// - Clear a pending Expiration time.
+// - Close a channel immediately, with or without processing a claim first. The source address cannot close the channel immediately if the channel has XRP remaining.
+//
+// The destination address of a channel can:
+//
+// - Receive XRP from the channel using a signed Claim.
+// - Close the channel immediately after processing a Claim, refunding any unclaimed XRP to the channel's source.
+//
+// Any address sending this transaction can:
+//
+// - Cause a channel to be closed if its Expiration or CancelAfter time is older than the previous ledger's close time. Any validly-formed PaymentChannelClaim transaction has this effect regardless of the contents of the transaction.
+//
+// Example:
+//
+// ```json
+//
+//        {
+//                "Channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+//                "Balance": "1000000",
+//                "Amount": "1000000",
+//                "Signature": "30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B",
+//                "PublicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+//          }
+//
+// ```
 type PaymentChannelClaim struct {
         BaseTx
-        Channel   types.Hash256
-        Balance   types.XRPCurrencyAmount `json:",omitempty"`
-        Amount    types.XRPCurrencyAmount `json:",omitempty"`
-        Signature string                  `json:",omitempty"`
-        PublicKey string                  `json:",omitempty"`
+        // The unique ID of the channel, as a 64-character hexadecimal string.
+        Channel types.Hash256
+        // (Optional) Total amount of XRP, in drops, delivered by this channel after processing this claim. Required to deliver XRP.
+        // Must be more than the total amount delivered by the channel so far, but not greater than the Amount of the signed claim. Must be provided except when closing the channel.
+        Balance types.XRPCurrencyAmount `json:",omitempty"`
+        // (Optional) The amount of XRP, in drops, authorized by the Signature. This must match the amount in the signed message.
+        // This is the cumulative amount of XRP that can be dispensed by the channel, including XRP previously redeemed.
+        Amount types.XRPCurrencyAmount `json:",omitempty"`
+        // (Optional) The signature of this claim, as hexadecimal. The signed message contains the channel ID and the amount of the claim.
+        // Required unless the sender of the transaction is the source address of the channel.
+        Signature string `json:",omitempty"`
+        // (Optional) The public key used for the signature, as hexadecimal. This must match the PublicKey stored in the ledger for the channel.
+        // Required unless the sender of the transaction is the source address of the channel and the Signature field is omitted.
+        // (The transaction includes the public key so that rippled can check the validity of the signature before trying to apply the transaction to the ledger.)
+        PublicKey string `json:",omitempty"`
 }
 
 // TxType returns the type of the transaction (PaymentChannelClaim).
-func (*PaymentChannelClaim) TxType() TxType <span class="cov0" title="0">{
+func (*PaymentChannelClaim) TxType() TxType <span class="cov8" title="1">{
         return PaymentChannelClaimTx
 }</span>
 
 // Flatten returns a flattened map of the PaymentChannelClaim transaction.
-func (s *PaymentChannelClaim) Flatten() FlatTransaction <span class="cov0" title="0">{
+func (s *PaymentChannelClaim) Flatten() FlatTransaction <span class="cov8" title="1">{
         flattened := s.BaseTx.Flatten()
 
         flattened["TransactionType"] = "PaymentChannelClaim"
 
-        if s.Channel != "" </span><span class="cov0" title="0">{
+        if s.Channel != "" </span><span class="cov8" title="1">{
                 flattened["Channel"] = s.Channel.String()
         }</span>
-        <span class="cov0" title="0">if s.Balance != 0 </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if s.Balance != 0 </span><span class="cov8" title="1">{
                 flattened["Balance"] = s.Balance.Flatten()
         }</span>
-        <span class="cov0" title="0">if s.Amount != 0 </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if s.Amount != 0 </span><span class="cov8" title="1">{
                 flattened["Amount"] = s.Amount.Flatten()
         }</span>
-        <span class="cov0" title="0">if s.Signature != "" </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if s.Signature != "" </span><span class="cov8" title="1">{
                 flattened["Signature"] = s.Signature
         }</span>
-        <span class="cov0" title="0">if s.PublicKey != "" </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if s.PublicKey != "" </span><span class="cov8" title="1">{
                 flattened["PublicKey"] = s.PublicKey
         }</span>
-        <span class="cov0" title="0">return flattened</span>
+        <span class="cov8" title="1">return flattened</span>
 }
 
 // SetRenewFlag sets the Renew flag.
@@ -11229,6 +11288,28 @@ func (s *PaymentChannelClaim) SetRenewFlag() <span class="cov8" title="1">{
 func (s *PaymentChannelClaim) SetCloseFlag() <span class="cov8" title="1">{
         s.Flags |= tfClose
 }</span>
+
+// Validate validates the PaymentChannelFund fields.
+func (p *PaymentChannelClaim) Validate() (bool, error) <span class="cov8" title="1">{
+        ok, err := p.BaseTx.Validate()
+        if err != nil || !ok </span><span class="cov8" title="1">{
+                return false, err
+        }</span>
+
+        <span class="cov8" title="1">if p.Channel == "" </span><span class="cov8" title="1">{
+                return false, ErrInvalidChannel
+        }</span>
+
+        <span class="cov8" title="1">if p.Signature != "" &amp;&amp; !typecheck.IsHex(p.Signature) </span><span class="cov8" title="1">{
+                return false, ErrInvalidSignature
+        }</span>
+
+        <span class="cov8" title="1">if p.PublicKey != "" &amp;&amp; !typecheck.IsHex(p.PublicKey) </span><span class="cov8" title="1">{
+                return false, ErrInvalidPublicKey
+        }</span>
+
+        <span class="cov8" title="1">return true, nil</span>
+}
 </pre>
 		
 		<pre class="file" id="file170" style="display: none">package transaction

--- a/xrpl/transaction/errors.go
+++ b/xrpl/transaction/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrInvalidDestination = errors.New("invalid xrpl address for Destination")
 	// ErrInvalidOwner is returned when the Owner field does not meet XRPL address standards.
 	ErrInvalidOwner = errors.New("invalid xrpl address for Owner")
+	// ErrInvalidPublicKey is returned when the PublicKey is not a valid hexadecimal string.
+	ErrInvalidPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
 	// ErrInvalidTransactionType is returned when the TransactionType field is invalid or missing.
 	ErrInvalidTransactionType = errors.New("invalid or missing TransactionType")
 )

--- a/xrpl/transaction/errors.go
+++ b/xrpl/transaction/errors.go
@@ -11,8 +11,8 @@ var (
 	ErrInvalidDestination = errors.New("invalid xrpl address for Destination")
 	// ErrInvalidOwner is returned when the Owner field does not meet XRPL address standards.
 	ErrInvalidOwner = errors.New("invalid xrpl address for Owner")
-	// ErrInvalidPublicKey is returned when the PublicKey is not a valid hexadecimal string.
-	ErrInvalidPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
+	// ErrInvalidHexPublicKey is returned when the PublicKey is not a valid hexadecimal string.
+	ErrInvalidHexPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
 	// ErrInvalidTransactionType is returned when the TransactionType field is invalid or missing.
 	ErrInvalidTransactionType = errors.New("invalid or missing TransactionType")
 )

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -23,15 +23,54 @@ const (
 	tfClose uint32 = 131072 // 0x00020000
 )
 
-// Claim XRP from a payment channel, adjust the payment channel's expiration,
-// or both.
+// Claim XRP from a payment channel, adjust the payment channel's expiration, or both. This transaction can be used differently depending on the transaction sender's role in the specified channel:
+//
+// The source address of a channel can:
+//
+// - Send XRP from the channel to the destination with or without a signed Claim.
+// - Set the channel to expire as soon as the channel's SettleDelay has passed.
+// - Clear a pending Expiration time.
+// - Close a channel immediately, with or without processing a claim first. The source address cannot close the channel immediately if the channel has XRP remaining.
+//
+// The destination address of a channel can:
+//
+// - Receive XRP from the channel using a signed Claim.
+// - Close the channel immediately after processing a Claim, refunding any unclaimed XRP to the channel's source.
+//
+// Any address sending this transaction can:
+//
+// - Cause a channel to be closed if its Expiration or CancelAfter time is older than the previous ledger's close time. Any validly-formed PaymentChannelClaim transaction has this effect regardless of the contents of the transaction.
+//
+// Example:
+//
+// ```json
+//
+//	{
+//		"Channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+//		"Balance": "1000000",
+//		"Amount": "1000000",
+//		"Signature": "30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B",
+//		"PublicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+//	  }
+//
+// ```
 type PaymentChannelClaim struct {
 	BaseTx
-	Channel   types.Hash256
-	Balance   types.XRPCurrencyAmount `json:",omitempty"`
-	Amount    types.XRPCurrencyAmount `json:",omitempty"`
-	Signature string                  `json:",omitempty"`
-	PublicKey string                  `json:",omitempty"`
+	// The unique ID of the channel, as a 64-character hexadecimal string.
+	Channel types.Hash256
+	// (Optional) Total amount of XRP, in drops, delivered by this channel after processing this claim. Required to deliver XRP.
+	// Must be more than the total amount delivered by the channel so far, but not greater than the Amount of the signed claim. Must be provided except when closing the channel.
+	Balance types.XRPCurrencyAmount `json:",omitempty"`
+	// (Optional) The amount of XRP, in drops, authorized by the Signature. This must match the amount in the signed message.
+	// This is the cumulative amount of XRP that can be dispensed by the channel, including XRP previously redeemed.
+	Amount types.XRPCurrencyAmount `json:",omitempty"`
+	// (Optional) The signature of this claim, as hexadecimal. The signed message contains the channel ID and the amount of the claim.
+	// Required unless the sender of the transaction is the source address of the channel.
+	Signature string `json:",omitempty"`
+	// (Optional) The public key used for the signature, as hexadecimal. This must match the PublicKey stored in the ledger for the channel.
+	// Required unless the sender of the transaction is the source address of the channel and the Signature field is omitted.
+	// (The transaction includes the public key so that rippled can check the validity of the signature before trying to apply the transaction to the ledger.)
+	PublicKey string `json:",omitempty"`
 }
 
 // TxType returns the type of the transaction (PaymentChannelClaim).

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -97,25 +97,25 @@ func (*PaymentChannelClaim) TxType() TxType {
 }
 
 // Flatten returns a flattened map of the PaymentChannelClaim transaction.
-func (s *PaymentChannelClaim) Flatten() FlatTransaction {
-	flattened := s.BaseTx.Flatten()
+func (p *PaymentChannelClaim) Flatten() FlatTransaction {
+	flattened := p.BaseTx.Flatten()
 
 	flattened["TransactionType"] = "PaymentChannelClaim"
 
-	if s.Channel != "" {
-		flattened["Channel"] = s.Channel.String()
+	if p.Channel != "" {
+		flattened["Channel"] = p.Channel.String()
 	}
-	if s.Balance != 0 {
-		flattened["Balance"] = s.Balance.Flatten()
+	if p.Balance != 0 {
+		flattened["Balance"] = p.Balance.Flatten()
 	}
-	if s.Amount != 0 {
-		flattened["Amount"] = s.Amount.Flatten()
+	if p.Amount != 0 {
+		flattened["Amount"] = p.Amount.Flatten()
 	}
-	if s.Signature != "" {
-		flattened["Signature"] = s.Signature
+	if p.Signature != "" {
+		flattened["Signature"] = p.Signature
 	}
-	if s.PublicKey != "" {
-		flattened["PublicKey"] = s.PublicKey
+	if p.PublicKey != "" {
+		flattened["PublicKey"] = p.PublicKey
 	}
 	return flattened
 }
@@ -125,8 +125,8 @@ func (s *PaymentChannelClaim) Flatten() FlatTransaction {
 // Renew: Clear the channel's Expiration time. (Expiration is different from the
 // channel's immutable CancelAfter time.) Only the source address of the
 // payment channel can use this flag.
-func (s *PaymentChannelClaim) SetRenewFlag() {
-	s.Flags |= tfRenew
+func (p *PaymentChannelClaim) SetRenewFlag() {
+	p.Flags |= tfRenew
 }
 
 // SetCloseFlag sets the Close flag.
@@ -142,8 +142,8 @@ func (s *PaymentChannelClaim) SetRenewFlag() {
 // time.) If the destination address uses this flag when the channel still
 // holds XRP, any XRP that remains after processing the claim is returned to
 // the source address.
-func (s *PaymentChannelClaim) SetCloseFlag() {
-	s.Flags |= tfClose
+func (p *PaymentChannelClaim) SetCloseFlag() {
+	p.Flags |= tfClose
 }
 
 // Validate validates the PaymentChannelFund fields.

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -7,10 +7,6 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
-// *********************
-// Flags
-// *********************
-
 const (
 	// Clear the channel's Expiration time. (Expiration is different from the
 	// channel's immutable CancelAfter time.) Only the source address of the
@@ -29,10 +25,6 @@ const (
 	// the source address.
 	tfClose uint32 = 131072 // 0x00020000
 )
-
-// *********************
-// Errors
-// *********************
 
 var (
 	// ErrInvalidChannel is returned when the Channel is not a valid 64-character hexadecimal string.
@@ -162,7 +154,7 @@ func (p *PaymentChannelClaim) Validate() (bool, error) {
 	}
 
 	if p.PublicKey != "" && !typecheck.IsHex(p.PublicKey) {
-		return false, ErrInvalidPublicKey
+		return false, ErrInvalidHexPublicKey
 	}
 
 	return true, nil

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -39,8 +39,6 @@ var (
 	ErrInvalidChannel = errors.New("invalid Channel, must be a valid 64-character hexadecimal string")
 	// ErrInvalidSignature is returned when the Signature is not a valid hexadecimal string.
 	ErrInvalidSignature = errors.New("invalid Signature, must be a valid hexadecimal string")
-	// ErrInvalidPublicKey is returned when the PublicKey is not a valid hexadecimal string.
-	ErrInvalidPublicKey = errors.New("invalid PublicKey, must be a valid hexadecimal string")
 )
 
 // Claim XRP from a payment channel, adjust the payment channel's expiration, or both. This transaction can be used differently depending on the transaction sender's role in the specified channel:

--- a/xrpl/transaction/payment_channel_claim_test.go
+++ b/xrpl/transaction/payment_channel_claim_test.go
@@ -2,7 +2,16 @@ package transaction
 
 import (
 	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestPaymentChannelClaim_TxType(t *testing.T) {
+	tx := &PaymentChannelClaim{}
+	assert.Equal(t, PaymentChannelClaimTx, tx.TxType())
+}
 
 func TestPaymentChannelClaimFlags(t *testing.T) {
 	tests := []struct {
@@ -11,21 +20,21 @@ func TestPaymentChannelClaimFlags(t *testing.T) {
 		expected uint32
 	}{
 		{
-			name: "SetRenewFlag",
+			name: "pass - SetRenewFlag",
 			setter: func(p *PaymentChannelClaim) {
 				p.SetRenewFlag()
 			},
 			expected: tfRenew,
 		},
 		{
-			name: "SetCloseFlag",
+			name: "pass - SetCloseFlag",
 			setter: func(p *PaymentChannelClaim) {
 				p.SetCloseFlag()
 			},
 			expected: tfClose,
 		},
 		{
-			name: "SetRenewFlag and SetCloseFlag",
+			name: "pass - SetRenewFlag and SetCloseFlag",
 			setter: func(p *PaymentChannelClaim) {
 				p.SetRenewFlag()
 				p.SetCloseFlag()
@@ -40,6 +49,96 @@ func TestPaymentChannelClaimFlags(t *testing.T) {
 			tt.setter(p)
 			if p.Flags != tt.expected {
 				t.Errorf("Expected Flags to be %d, got %d", tt.expected, p.Flags)
+			}
+		})
+	}
+}
+
+func TestPaymentChannelClaim_Flatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		claim    PaymentChannelClaim
+		expected string
+	}{
+		{
+			name: "pass - PaymentChannelClaim with Channel",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Channel: types.Hash256("ABC123"),
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Channel": "ABC123"
+			}`,
+		},
+		{
+			name: "PaymentChannelClaim with Balance and Amount",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Balance: types.XRPCurrencyAmount(1000),
+				Amount:  types.XRPCurrencyAmount(2000),
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Balance": "1000",
+				"Amount": "2000"
+			}`,
+		},
+		{
+			name: "PaymentChannelClaim with Signature and PublicKey",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Signature: "ABCDEF",
+				PublicKey: "123456",
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Signature": "ABCDEF",
+				"PublicKey": "123456"
+			}`,
+		},
+		{
+			name: "PaymentChannelClaim with all fields",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Channel:   types.Hash256("ABC123"),
+				Balance:   types.XRPCurrencyAmount(1000),
+				Amount:    types.XRPCurrencyAmount(2000),
+				Signature: "ABCDEF",
+				PublicKey: "123456",
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelClaim",
+				"Channel": "ABC123",
+				"Balance": "1000",
+				"Amount": "2000",
+				"Signature": "ABCDEF",
+				"PublicKey": "123456"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testutil.CompareFlattenAndExpected(tt.claim.Flatten(), []byte(tt.expected))
+			if err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/xrpl/transaction/payment_channel_claim_test.go
+++ b/xrpl/transaction/payment_channel_claim_test.go
@@ -76,7 +76,7 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 			}`,
 		},
 		{
-			name: "PaymentChannelClaim with Balance and Amount",
+			name: "pass - PaymentChannelClaim with Balance and Amount",
 			claim: PaymentChannelClaim{
 				BaseTx: BaseTx{
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -93,7 +93,7 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 			}`,
 		},
 		{
-			name: "PaymentChannelClaim with Signature and PublicKey",
+			name: "pass - PaymentChannelClaim with Signature and PublicKey",
 			claim: PaymentChannelClaim{
 				BaseTx: BaseTx{
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -110,7 +110,7 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 			}`,
 		},
 		{
-			name: "PaymentChannelClaim with all fields",
+			name: "pass - PaymentChannelClaim with all fields",
 			claim: PaymentChannelClaim{
 				BaseTx: BaseTx{
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",

--- a/xrpl/transaction/payment_channel_claim_test.go
+++ b/xrpl/transaction/payment_channel_claim_test.go
@@ -47,9 +47,7 @@ func TestPaymentChannelClaimFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &PaymentChannelClaim{}
 			tt.setter(p)
-			if p.Flags != tt.expected {
-				t.Errorf("Expected Flags to be %d, got %d", tt.expected, p.Flags)
-			}
+			assert.Equal(t, tt.expected, p.Flags)
 		})
 	}
 }
@@ -137,9 +135,7 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := testutil.CompareFlattenAndExpected(tt.claim.Flatten(), []byte(tt.expected))
-			if err != nil {
-				t.Error(err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -232,19 +228,15 @@ func TestPaymentChannelClaim_Validate(t *testing.T) {
 			},
 			wantValid:   false,
 			wantErr:     true,
-			expectedErr: ErrInvalidPublicKey,
+			expectedErr: ErrInvalidHexPublicKey,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			valid, err := tt.claim.Validate()
-			if valid != tt.wantValid {
-				t.Errorf("Validate() valid = %v, want %v", valid, tt.wantValid)
-			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			assert.Equal(t, tt.wantValid, valid)
+			assert.Equal(t, tt.wantErr, err != nil)
 			if err != nil && err != tt.expectedErr {
 				t.Errorf("Validate() error = %v, expectedErr %v", err, tt.expectedErr)
 			}

--- a/xrpl/transaction/payment_channel_create.go
+++ b/xrpl/transaction/payment_channel_create.go
@@ -84,7 +84,7 @@ func (p *PaymentChannelCreate) Validate() (bool, error) {
 
 	// check PublicKey is valid hexademical string
 	if !typecheck.IsHex(p.PublicKey) {
-		return false, ErrInvalidPublicKey
+		return false, ErrInvalidHexPublicKey
 	}
 
 	return true, nil

--- a/xrpl/transaction/payment_channel_create.go
+++ b/xrpl/transaction/payment_channel_create.go
@@ -4,21 +4,66 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
+// Create a payment channel and fund it with XRP. The address sending this transaction becomes the "source address" of the payment channel.
+//
+// Example:
+//
+// ```json
+//
+//	{
+//	    "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+//	    "TransactionType": "PaymentChannelCreate",
+//	    "Amount": "10000",
+//	    "Destination": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+//	    "SettleDelay": 86400,
+//	    "PublicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+//	    "CancelAfter": 533171558,
+//	    "DestinationTag": 23480,
+//	    "SourceTag": 11747
+//	}
+//
+// / ```
 type PaymentChannelCreate struct {
 	BaseTx
-	Amount         types.XRPCurrencyAmount
-	Destination    types.Address
-	SettleDelay    uint32
-	PublicKey      string
-	CancelAfter    uint32 `json:",omitempty"`
+	// Amount of XRP, in drops, to deduct from the sender's balance and set aside in this channel.
+	// While the channel is open, the XRP can only go to the Destination address. When the channel closes, any unclaimed XRP is returned to the source address's balance.
+	Amount types.XRPCurrencyAmount
+	// Address to receive XRP claims against this channel. This is also known as the "destination address" for the channel. Cannot be the same as the sender (Account).
+	Destination types.Address
+	// Amount of time the source address must wait before closing the channel if it has unclaimed XRP.
+	SettleDelay uint32
+	// The 33-byte public key of the key pair the source will use to sign claims against this channel, in hexadecimal.
+	// This can be any secp256k1 or Ed25519 public key. For more information on key pairs, see Key Derivation
+	PublicKey string
+	// (Optional) The time, in seconds since the Ripple Epoch, when this channel expires.
+	// Any transaction that would modify the channel after this time closes the channel without otherwise affecting it.
+	// This value is immutable; the channel can be closed earlier than this time but cannot remain open after this time.
+	CancelAfter uint32 `json:",omitempty"`
+	// (Optional) Arbitrary tag to further specify the destination for this payment channel, such as a hosted recipient at the destination address.
 	DestinationTag uint32 `json:",omitempty"`
 }
 
+// TxType returns the type of the transaction (PaymentChannelCreate).
 func (*PaymentChannelCreate) TxType() TxType {
 	return PaymentChannelCreateTx
 }
 
-// TODO: Implement flatten
-func (s *PaymentChannelCreate) Flatten() FlatTransaction {
-	return nil
+// Flatten returns a map of the PaymentChannelCreate transaction fields.
+func (p *PaymentChannelCreate) Flatten() FlatTransaction {
+	flattened := p.BaseTx.Flatten()
+
+	flattened["Amount"] = p.Amount.String()
+	flattened["Destination"] = p.Destination.String()
+	flattened["SettleDelay"] = p.SettleDelay
+	flattened["PublicKey"] = p.PublicKey
+
+	if p.CancelAfter != 0 {
+		flattened["CancelAfter"] = p.CancelAfter
+	}
+
+	if p.DestinationTag != 0 {
+		flattened["DestinationTag"] = p.DestinationTag
+	}
+
+	return flattened
 }

--- a/xrpl/transaction/payment_channel_create.go
+++ b/xrpl/transaction/payment_channel_create.go
@@ -1,6 +1,8 @@
 package transaction
 
 import (
+	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
@@ -66,4 +68,24 @@ func (p *PaymentChannelCreate) Flatten() FlatTransaction {
 	}
 
 	return flattened
+}
+
+// Validate validates the PaymentChannelCreate fields.
+func (p *PaymentChannelCreate) Validate() (bool, error) {
+	ok, err := p.BaseTx.Validate()
+	if (err != nil) || !ok {
+		return false, err
+	}
+
+	// check valid xrpl address for Destination
+	if !addresscodec.IsValidClassicAddress(p.Destination.String()) {
+		return false, ErrInvalidDestination
+	}
+
+	// check PublicKey is valid hexademical string
+	if !typecheck.IsHex(p.PublicKey) {
+		return false, ErrInvalidPublicKey
+	}
+
+	return true, nil
 }

--- a/xrpl/transaction/payment_channel_create_test.go
+++ b/xrpl/transaction/payment_channel_create_test.go
@@ -165,19 +165,15 @@ func TestPaymentChannelCreate_Validate(t *testing.T) {
 			},
 			wantValid:   false,
 			wantErr:     true,
-			expectedErr: ErrInvalidPublicKey,
+			expectedErr: ErrInvalidHexPublicKey,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			valid, err := tt.tx.Validate()
-			if valid != tt.wantValid {
-				t.Errorf("Validate() valid = %v, want %v", valid, tt.wantValid)
-			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			assert.Equal(t, tt.wantValid, valid)	
+			assert.Equal(t, tt.wantErr, err != nil)
 			if err != nil && err != tt.expectedErr {
 				t.Errorf("Validate() error = %v, expectedErr %v", err, tt.expectedErr)
 			}

--- a/xrpl/transaction/payment_channel_create_test.go
+++ b/xrpl/transaction/payment_channel_create_test.go
@@ -76,3 +76,111 @@ func TestPaymentChannelCreate_Flatten(t *testing.T) {
 		})
 	}
 }
+
+func TestPaymentChannelCreate_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		tx          *PaymentChannelCreate
+		wantValid   bool
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name: "pass - All fields valid",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:         types.XRPCurrencyAmount(10000),
+				Destination:    types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay:    86400,
+				PublicKey:      "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+				CancelAfter:    533171558,
+				DestinationTag: 23480,
+			},
+			wantValid: true,
+			wantErr:   false,
+		},
+		{
+			name: "fail - Invalid BaseTx, missing TransactionType",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account: "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+				},
+				Amount:         types.XRPCurrencyAmount(10000),
+				Destination:    types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay:    86400,
+				PublicKey:      "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+				CancelAfter:    533171558,
+				DestinationTag: 23480,
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidTransactionType,
+		},
+		{
+			name: "fail - Invalid destination address",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: "invalidAddress",
+				SettleDelay: 86400,
+				PublicKey:   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidDestination,
+		},
+		{
+			name: "fail - Empty destination address",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: "",
+				SettleDelay: 86400,
+				PublicKey:   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidDestination,
+		},
+		{
+			name: "fail - Invalid public key",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay: 86400,
+				PublicKey:   "invalidPublicKey",
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidPublicKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := tt.tx.Validate()
+			if valid != tt.wantValid {
+				t.Errorf("Validate() valid = %v, want %v", valid, tt.wantValid)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && err != tt.expectedErr {
+				t.Errorf("Validate() error = %v, expectedErr %v", err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/payment_channel_create_test.go
+++ b/xrpl/transaction/payment_channel_create_test.go
@@ -1,1 +1,78 @@
 package transaction
+
+import (
+	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaymentChannelCreate_TxType(t *testing.T) {
+	tx := &PaymentChannelCreate{}
+	assert.Equal(t, PaymentChannelCreateTx, tx.TxType())
+}
+
+func TestPaymentChannelCreate_Flatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		tx       *PaymentChannelCreate
+		expected string
+	}{
+		{
+			name: "pass - All fields set",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:         types.XRPCurrencyAmount(10000),
+				Destination:    types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay:    86400,
+				PublicKey:      "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+				CancelAfter:    533171558,
+				DestinationTag: 23480,
+			},
+			expected: `{
+				"Account":       "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+				"TransactionType": "PaymentChannelCreate",
+				"Amount":        "10000",
+				"Destination":   "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"SettleDelay":   86400,
+				"PublicKey":     "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+				"CancelAfter":   533171558,
+				"DestinationTag": 23480
+			}`,
+		},
+		{
+			name: "pass - Optional fields omitted",
+			tx: &PaymentChannelCreate{
+				BaseTx: BaseTx{
+					Account:         "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+					TransactionType: PaymentChannelCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				SettleDelay: 86400,
+				PublicKey:   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
+			},
+			expected: `{
+				"Account":     "r2UeJh4HhYc5VtYc8U2YpZfQzY5Lw8kZV",
+				"TransactionType": "PaymentChannelCreate",
+				"Amount":      "10000",
+				"Destination": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"SettleDelay": 86400,
+				"PublicKey":   "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testutil.CompareFlattenAndExpected(tt.tx.Flatten(), []byte(tt.expected))
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/xrpl/transaction/payment_channel_fund.go
+++ b/xrpl/transaction/payment_channel_fund.go
@@ -4,18 +4,48 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
+// Add additional XRP to an open payment channel, and optionally update the expiration time of the channel. Only the source address of the channel can use this transaction.
+//
+// Example:
+//
+// ```json
+//
+// {
+// "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+// "TransactionType": "PaymentChannelFund",
+// "Channel": "C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198",
+// "Amount": "200000",
+// "Expiration": 543171558
+// }
+// ```
 type PaymentChannelFund struct {
 	BaseTx
-	Channel    types.Hash256
-	Amount     types.XRPCurrencyAmount
+	// The unique ID of the channel to fund, as a 64-character hexadecimal string.
+	Channel types.Hash256
+	// Amount of XRP, in drops to add to the channel. Must be a positive amount of XRP.
+	Amount types.XRPCurrencyAmount
+	// (Optional) New Expiration time to set for the channel, in seconds since the Ripple Epoch.
+	// This must be later than either the current time plus the SettleDelay of the channel, or the existing Expiration of the channel.
+	// After the Expiration time, any transaction that would access the channel closes the channel without taking its normal action.
+	//Any unspent XRP is returned to the source address when the channel closes. (Expiration is separate from the channel's immutable CancelAfter time.) For more information, see the PayChannel ledger object type.
 	Expiration uint32 `json:",omitempty"`
 }
 
+// TxType returns the type of the transaction (PaymentChannelFund).
 func (*PaymentChannelFund) TxType() TxType {
 	return PaymentChannelFundTx
 }
 
-// TODO: Implement flatten
+// Flatten returns a map of the PaymentChannelFund transaction fields.
 func (s *PaymentChannelFund) Flatten() FlatTransaction {
-	return nil
+	flattened := s.BaseTx.Flatten()
+
+	flattened["Channel"] = s.Channel.String()
+	flattened["Amount"] = s.Amount.String()
+
+	if s.Expiration != 0 {
+		flattened["Expiration"] = s.Expiration
+	}
+
+	return flattened
 }

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -2,7 +2,9 @@ package transaction
 
 import (
 	"testing"
+	"time"
 
+	"github.com/Peersyst/xrpl-go/xrpl"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +64,85 @@ func TestPaymentChannelFund_Flatten(t *testing.T) {
 			err := testutil.CompareFlattenAndExpected(tt.tx.Flatten(), []byte(tt.expected))
 			if err != nil {
 				t.Error(err)
+			}
+		})
+	}
+}
+func TestPaymentChannelFund_Validate(t *testing.T) {
+	tests := []struct {
+		name             string
+		tx               *PaymentChannelFund
+		expirationSetter func(tx *PaymentChannelFund)
+		wantValid        bool
+		wantErr          bool
+		expectedErr      error
+	}{
+		{
+			name: "pass - Valid Transaction",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel: "ABC123",
+				Amount:  types.XRPCurrencyAmount(200000),
+			},
+			expirationSetter: func(tx *PaymentChannelFund) {
+				tx.Expiration = uint32(time.Now().Unix()) + 5000
+			},
+			wantValid:   true,
+			wantErr:     false,
+			expectedErr: nil,
+		},
+		{
+			name: "fail - Valid Transaction",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel: "ABC123",
+				Amount:  types.XRPCurrencyAmount(200000),
+			},
+			expirationSetter: func(tx *PaymentChannelFund) {
+				tx.Expiration = uint32(xrpl.UnixTimeToRippleTime(time.Now().Unix()) + 5000)
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidAccount,
+		},
+		{
+			name: "fail - Invalid Expiration",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel:    "DEF456",
+				Amount:     types.XRPCurrencyAmount(300000),
+				Expiration: 1, // Invalid expiration time
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidExpiration,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := tt.tx.Validate()
+			if tt.expirationSetter != nil {
+				tt.expirationSetter(tt.tx)
+			}
+
+			if valid != tt.wantValid {
+				t.Errorf("Validate() valid = %v, want %v", valid, tt.wantValid)
+			}
+			if (err != nil) && err != tt.expectedErr {
+				t.Errorf("Validate() got error message = %v, want error message %v", err, tt.expectedErr)
+				return
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -39,7 +39,7 @@ func TestPaymentChannelFund_Flatten(t *testing.T) {
 			}`,
 		},
 		{
-			name: "With Expiration",
+			name: "pass - With Expiration",
 			tx: &PaymentChannelFund{
 				BaseTx: BaseTx{
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -68,6 +68,7 @@ func TestPaymentChannelFund_Flatten(t *testing.T) {
 		})
 	}
 }
+
 func TestPaymentChannelFund_Validate(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -135,16 +135,12 @@ func TestPaymentChannelFund_Validate(t *testing.T) {
 				tt.expirationSetter(tt.tx)
 			}
 
-			if valid != tt.wantValid {
-				t.Errorf("Validate() valid = %v, want %v", valid, tt.wantValid)
-			}
+			assert.Equal(t, tt.wantValid, valid)
 			if (err != nil) && err != tt.expectedErr {
 				t.Errorf("Validate() got error message = %v, want error message %v", err, tt.expectedErr)
 				return
 			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
 }

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -95,7 +95,7 @@ func TestPaymentChannelFund_Validate(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "fail - Valid Transaction",
+			name: "fail - Invalid BaseTx, missing Account",
 			tx: &PaymentChannelFund{
 				BaseTx: BaseTx{
 					TransactionType: PaymentChannelFundTx,

--- a/xrpl/transaction/payment_channel_fund_test.go
+++ b/xrpl/transaction/payment_channel_fund_test.go
@@ -1,1 +1,68 @@
 package transaction
+
+import (
+	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaymentChannelFund_TxType(t *testing.T) {
+	tx := &PaymentChannelFund{}
+	assert.Equal(t, PaymentChannelFundTx, tx.TxType())
+}
+
+func TestPaymentChannelFund_Flatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		tx       *PaymentChannelFund
+		expected string
+	}{
+		{
+			name: "pass - Without Expiration",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel: "ABC123",
+				Amount:  types.XRPCurrencyAmount(200000),
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelFund",
+				"Channel": "ABC123",
+				"Amount":  "200000"
+			}`,
+		},
+		{
+			name: "With Expiration",
+			tx: &PaymentChannelFund{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelFundTx,
+				},
+				Channel:    "DEF456",
+				Amount:     types.XRPCurrencyAmount(300000),
+				Expiration: 543171558,
+			},
+			expected: `{
+				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				"TransactionType": "PaymentChannelFund",
+				"Channel": "DEF456",
+				"Amount": "300000",
+				"Expiration": 543171558
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testutil.CompareFlattenAndExpected(tt.tx.Flatten(), []byte(tt.expected))
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Title

This PR aims to add support for all three Payment Channel transaction types (claim, create and fund).
It adds the relevant tests with 100% coverage.

![image](https://github.com/user-attachments/assets/1a89c476-6fbe-4c92-8fc6-ca232ac7475d)
