### PR TITLE
[TA-3575]: add testing coverage  for crypto package

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -125,17 +125,17 @@
 				
 				<option value="file34">github.com/Peersyst/xrpl-go/keypairs/keypairs.go (89.2%)</option>
 				
-				<option value="file35">github.com/Peersyst/xrpl-go/pkg/big-decimal/big_decimal.go (96.6%)</option>
+				<option value="file35">github.com/Peersyst/xrpl-go/main.go (0.0%)</option>
 				
-				<option value="file36">github.com/Peersyst/xrpl-go/pkg/crypto/der.go (85.7%)</option>
+				<option value="file36">github.com/Peersyst/xrpl-go/pkg/big-decimal/big_decimal.go (96.6%)</option>
 				
-				<option value="file37">github.com/Peersyst/xrpl-go/pkg/crypto/ed25519.go (78.6%)</option>
+				<option value="file37">github.com/Peersyst/xrpl-go/pkg/crypto/der.go (100.0%)</option>
 				
-				<option value="file38">github.com/Peersyst/xrpl-go/pkg/crypto/secp256k1.go (92.0%)</option>
+				<option value="file38">github.com/Peersyst/xrpl-go/pkg/crypto/ed25519.go (96.3%)</option>
 				
-				<option value="file39">github.com/Peersyst/xrpl-go/pkg/crypto/sha512.go (100.0%)</option>
+				<option value="file39">github.com/Peersyst/xrpl-go/pkg/crypto/secp256k1.go (97.7%)</option>
 				
-				<option value="file40">github.com/Peersyst/xrpl-go/pkg/crypto/types.go (0.0%)</option>
+				<option value="file40">github.com/Peersyst/xrpl-go/pkg/crypto/sha512.go (100.0%)</option>
 				
 				<option value="file41">github.com/Peersyst/xrpl-go/pkg/map_utils/map_utils.go (100.0%)</option>
 				
@@ -3858,7 +3858,19 @@ func Validate(msg, pubKey, sig string) (bool, error) <span class="cov8" title="1
 }
 </pre>
 		
-		<pre class="file" id="file35" style="display: none">package bigdecimal
+		<pre class="file" id="file35" style="display: none">package main
+
+import (
+        "encoding/hex"
+        "fmt"
+)
+
+func main() <span class="cov0" title="0">{
+        fmt.Println(hex.EncodeToString([]byte{0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x03, 0x01}))
+}</span>
+</pre>
+		
+		<pre class="file" id="file36" style="display: none">package bigdecimal
 
 import (
         "errors"
@@ -4012,7 +4024,7 @@ func bigDecimalRegEx(value string) bool <span class="cov8" title="1">{
 }</span>
 </pre>
 		
-		<pre class="file" id="file36" style="display: none">package crypto
+		<pre class="file" id="file37" style="display: none">package crypto
 
 import (
         "encoding/hex"
@@ -4020,6 +4032,20 @@ import (
         "fmt"
         "math/big"
         "strings"
+)
+
+var (
+        // ErrInvalidHexString is returned when the hex string is invalid.
+        ErrInvalidHexString = errors.New("invalid hex string")
+
+        // ErrInvalidDERNotEnoughData is returned when the DER data is not enough.
+        ErrInvalidDERNotEnoughData = errors.New("invalid DER: not enough data")
+        // ErrInvalidDERIntegerTag is returned when the DER integer tag is invalid.
+        ErrInvalidDERIntegerTag = errors.New("invalid DER: expected integer tag")
+        // ErrInvalidDERSignature is returned when the DER signature is invalid.
+        ErrInvalidDERSignature = errors.New("invalid signature: incorrect length")
+        // ErrLeftoverBytes is returned when there are leftover bytes after parsing the DER signature.
+        ErrLeftoverBytes = errors.New("invalid signature: left bytes after parsing")
 )
 
 // DERHexFromSig converts r and s hex strings to a DER-encoded signature hex string.
@@ -4044,11 +4070,11 @@ func DERHexFromSig(rHex, sHex string) (string, error) <span class="cov8" title="
         // Convert hex strings to big.Int
         <span class="cov8" title="1">r, ok := new(big.Int).SetString(rHex, 16)
         if !ok </span><span class="cov8" title="1">{
-                return "", errors.New("invalid r hex string: " + rHex)
+                return "", ErrInvalidHexString
         }</span>
         <span class="cov8" title="1">s, ok := new(big.Int).SetString(sHex, 16)
         if !ok </span><span class="cov8" title="1">{
-                return "", errors.New("invalid s hex string: " + sHex)
+                return "", ErrInvalidHexString
         }</span>
 
         // Convert r and s to sliced hex strings
@@ -4080,15 +4106,15 @@ func DERHexFromSig(rHex, sHex string) (string, error) <span class="cov8" title="
 // It returns a *big.Int representing the parsed integer, a byte slice containing the remaining data after parsing,
 // and an error if any occurred during parsing.
 func parseInt(data []byte) (*big.Int, []byte, error) <span class="cov8" title="1">{
-        if len(data) &lt; 2 </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid DER: not enough data")
+        if len(data) &lt; 2 </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERNotEnoughData
         }</span>
-        <span class="cov8" title="1">if data[0] != 0x02 </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid DER: expected integer tag")
+        <span class="cov8" title="1">if data[0] != 0x02 </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERIntegerTag
         }</span>
         <span class="cov8" title="1">length := int(data[1])
-        if len(data) &lt; 2+length </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid DER: not enough data")
+        if len(data) &lt; 2+length </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERNotEnoughData
         }</span>
         <span class="cov8" title="1">number := new(big.Int).SetBytes(data[2 : 2+length])
         return number, data[2+length:], nil</span>
@@ -4099,66 +4125,79 @@ func parseInt(data []byte) (*big.Int, []byte, error) <span class="cov8" title="1
 func DERHexToSig(hexSignature string) ([]byte, []byte, error) <span class="cov8" title="1">{
         data, err := hex.DecodeString(hexSignature)
         if err != nil </span><span class="cov8" title="1">{
-                return nil, nil, fmt.Errorf("invalid hex string: %v", err)
+                return nil, nil, ErrInvalidHexString
         }</span>
 
         <span class="cov8" title="1">if len(data) &lt; 2 || data[0] != 0x30 </span><span class="cov8" title="1">{
-                return nil, nil, errors.New("invalid signature tag")
+                return nil, nil, ErrInvalidDERSignature
         }</span>
-        <span class="cov8" title="1">if int(data[1]) != len(data)-2 </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid signature: incorrect length")
+        <span class="cov8" title="1">if int(data[1]) != len(data)-2 </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERSignature
         }</span>
 
         <span class="cov8" title="1">r, sBytes, err := parseInt(data[2:])
-        if err != nil </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid signature: incorrect length")
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERSignature
         }</span>
 
         <span class="cov8" title="1">s, leftover, err := parseInt(sBytes)
-        if err != nil </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid signature: incorrect length")
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, nil, ErrInvalidDERSignature
         }</span>
 
-        <span class="cov8" title="1">if len(leftover) &gt; 0 </span><span class="cov0" title="0">{
-                return nil, nil, errors.New("invalid signature: left bytes after parsing")
+        <span class="cov8" title="1">if len(leftover) &gt; 0 </span><span class="cov8" title="1">{
+                return nil, nil, ErrLeftoverBytes
         }</span>
 
         <span class="cov8" title="1">return r.Bytes(), s.Bytes(), nil</span>
 }
 </pre>
 		
-		<pre class="file" id="file37" style="display: none">package crypto
+		<pre class="file" id="file38" style="display: none">package crypto
 
 import (
         "bytes"
         "crypto/ed25519"
         "encoding/hex"
+        "errors"
         "strings"
 )
 
 const (
-        ed25519Prefix = 0xED
+        ed25519Prefix byte = 0xED
 )
 
-type ED25519CryptoAlgorithm Algorithm
+var (
+        ErrValidatorNotSupported = errors.New("validator keypairs can not use Ed25519")
+)
 
+// ED25519CryptoAlgorithm is the implementation of the ED25519 cryptographic algorithm.
+type ED25519CryptoAlgorithm struct {
+        prefix           byte
+        familySeedPrefix byte
+}
+
+// ED25519 returns the ED25519 cryptographic algorithm.
 func ED25519() ED25519CryptoAlgorithm <span class="cov8" title="1">{
         return ED25519CryptoAlgorithm{
                 prefix: ed25519Prefix,
         }
 }</span>
 
-func (c ED25519CryptoAlgorithm) Prefix() byte <span class="cov0" title="0">{
+// Prefix returns the prefix for the ED25519 cryptographic algorithm.
+func (c ED25519CryptoAlgorithm) Prefix() byte <span class="cov8" title="1">{
         return c.prefix
 }</span>
 
-func (c ED25519CryptoAlgorithm) FamilySeedPrefix() byte <span class="cov0" title="0">{
+// FamilySeedPrefix returns the family seed prefix for the ED25519 cryptographic algorithm.
+func (c ED25519CryptoAlgorithm) FamilySeedPrefix() byte <span class="cov8" title="1">{
         return c.familySeedPrefix
 }</span>
 
+// DeriveKeypair derives a keypair from a seed.
 func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool) (string, string, error) <span class="cov8" title="1">{
         if validator </span><span class="cov8" title="1">{
-                return "", "", &amp;ed25519ValidatorError{}
+                return "", "", ErrValidatorNotSupported
         }</span>
         <span class="cov8" title="1">rawPriv := Sha512Half(decodedSeed)
         pubKey, privKey, err := ed25519.GenerateKey(bytes.NewBuffer(rawPriv))
@@ -4174,7 +4213,7 @@ func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool
 
 func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) <span class="cov8" title="1">{
         b, err := hex.DecodeString(privKey)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return "", err
         }</span>
         <span class="cov8" title="1">rawPriv := ed25519.NewKeyFromSeed(b[1:])
@@ -4182,28 +4221,23 @@ func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) <span 
         return strings.ToUpper(hex.EncodeToString(signedMsg)), nil</span>
 }
 
+// Validate validates a signature for a message with a public key.
 func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool <span class="cov8" title="1">{
         bp, err := hex.DecodeString(pubkey)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return false
         }</span>
 
         <span class="cov8" title="1">bs, err := hex.DecodeString(sig)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return false
         }</span>
 
         <span class="cov8" title="1">return ed25519.Verify(ed25519.PublicKey(bp[1:]), []byte(msg), bs)</span>
 }
-
-type ed25519ValidatorError struct{}
-
-func (e *ed25519ValidatorError) Error() string <span class="cov8" title="1">{
-        return "validator keypairs can not use Ed25519"
-}</span>
 </pre>
 		
-		<pre class="file" id="file38" style="display: none">package crypto
+		<pre class="file" id="file39" style="display: none">package crypto
 
 import (
         "crypto/sha512"
@@ -4219,13 +4253,29 @@ import (
 
 const (
         // SECP256K1 prefix - value is 0
-        secp256K1Prefix = 0x00
+        secp256K1Prefix byte = 0x00
         // SECP256K1 family seed prefix - value is 33
-        secp256K1FamilySeedPrefix = 0x21
+        secp256K1FamilySeedPrefix byte = 0x21
 )
 
-type SECP256K1CryptoAlgorithm Algorithm
+var (
+        _ Algorithm = SECP256K1CryptoAlgorithm{}
 
+        // ErrValidatorKeypairDerivation is returned when a validator keypair is attempted to be derived
+        ErrValidatorKeypairDerivation = errors.New("validator keypair derivation not supported")
+        // ErrInvalidPrivateKey is returned when a private key is invalid
+        ErrInvalidPrivateKey = errors.New("invalid private key")
+        // ErrInvalidMessage is returned when a message is required but not provided
+        ErrInvalidMessage = errors.New("message is required")
+)
+
+// SECP256K1CryptoAlgorithm is the implementation of the SECP256K1 algorithm.
+type SECP256K1CryptoAlgorithm struct {
+        prefix           byte
+        familySeedPrefix byte
+}
+
+// SECP256K1 returns a new SECP256K1CryptoAlgorithm instance.
 func SECP256K1() SECP256K1CryptoAlgorithm <span class="cov8" title="1">{
         return SECP256K1CryptoAlgorithm{
                 prefix:           secp256K1Prefix,
@@ -4233,14 +4283,17 @@ func SECP256K1() SECP256K1CryptoAlgorithm <span class="cov8" title="1">{
         }
 }</span>
 
-func (c SECP256K1CryptoAlgorithm) Prefix() byte <span class="cov0" title="0">{
+// Prefix returns the prefix for the SECP256K1 algorithm.
+func (c SECP256K1CryptoAlgorithm) Prefix() byte <span class="cov8" title="1">{
         return c.prefix
 }</span>
 
-func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() byte <span class="cov0" title="0">{
+// FamilySeedPrefix returns the family seed prefix for the SECP256K1 algorithm.
+func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() byte <span class="cov8" title="1">{
         return c.familySeedPrefix
 }</span>
 
+// deriveScalar derives a scalar from a seed.
 func (c SECP256K1CryptoAlgorithm) deriveScalar(bytes []byte, discrim *big.Int) *big.Int <span class="cov8" title="1">{
 
         order := btcec.S256().N
@@ -4278,6 +4331,7 @@ func (c SECP256K1CryptoAlgorithm) deriveScalar(bytes []byte, discrim *big.Int) *
         <span class="cov0" title="0">panic("impossible unicorn ;)")</span>
 }
 
+// DeriveKeypair derives a keypair from a seed.
 func (c SECP256K1CryptoAlgorithm) DeriveKeypair(seed []byte, validator bool) (string, string, error) <span class="cov8" title="1">{
         curve := btcec.S256()
         order := curve.N
@@ -4285,7 +4339,7 @@ func (c SECP256K1CryptoAlgorithm) DeriveKeypair(seed []byte, validator bool) (st
         privateGen := c.deriveScalar(seed, nil)
 
         if validator </span><span class="cov8" title="1">{
-                return "", "", errors.New("validator keypair derivation not supported")
+                return "", "", ErrValidatorKeypairDerivation
         }</span>
 
         <span class="cov8" title="1">rootPrivateKey, _ := btcec.PrivKeyFromBytes(privateGen.Bytes())
@@ -4304,20 +4358,21 @@ func (c SECP256K1CryptoAlgorithm) DeriveKeypair(seed []byte, validator bool) (st
         return "00" + private, strings.ToUpper(hex.EncodeToString(pubKeyBytes)), nil</span>
 }
 
+// Sign signs a message with a private key.
 func (c SECP256K1CryptoAlgorithm) Sign(msg, privKey string) (string, error) <span class="cov8" title="1">{
         if len(privKey) != 64 &amp;&amp; len(privKey) != 66 </span><span class="cov8" title="1">{
-                return "", errors.New("invalid private key")
+                return "", ErrInvalidPrivateKey
         }</span>
-        <span class="cov8" title="1">if len(msg) == 0 </span><span class="cov0" title="0">{
-                return "", errors.New("message is required")
+        <span class="cov8" title="1">if len(msg) == 0 </span><span class="cov8" title="1">{
+                return "", ErrInvalidMessage
         }</span>
 
         <span class="cov8" title="1">if len(privKey) == 66 </span><span class="cov8" title="1">{
                 privKey = privKey[2:]
         }</span>
         <span class="cov8" title="1">key, err := hex.DecodeString(privKey)
-        if err != nil </span><span class="cov0" title="0">{
-                return "", err
+        if err != nil </span><span class="cov8" title="1">{
+                return "", ErrInvalidPrivateKey
         }</span>
 
         <span class="cov8" title="1">secpPrivKey := secp256k1.PrivKeyFromBytes(key)
@@ -4330,6 +4385,7 @@ func (c SECP256K1CryptoAlgorithm) Sign(msg, privKey string) (string, error) <spa
         <span class="cov8" title="1">return strings.ToUpper(parsedSig), nil</span>
 }
 
+// Validate validates a signature for a message with a public key.
 func (c SECP256K1CryptoAlgorithm) Validate(msg, pubkey, sig string) bool <span class="cov8" title="1">{
         // Decode the signature from DERHex to a hex string
         r, s, err := DERHexToSig(sig)
@@ -4361,12 +4417,13 @@ func (c SECP256K1CryptoAlgorithm) Validate(msg, pubkey, sig string) bool <span c
 
         // Verify the signature
         <span class="cov8" title="1">pubKey, err := secp256k1.ParsePubKey(pubkeyBytes)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return false
         }</span>
         <span class="cov8" title="1">return parsedSig.Verify(hash, pubKey)</span>
 }
 
+// DerivePublicKeyFromPublicGenerator derives a public key from a public generator.
 func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromPublicGenerator(pubKey []byte) ([]byte, error) <span class="cov8" title="1">{
         // Get the curve
         curve := btcec.S256()
@@ -4407,7 +4464,7 @@ func (c SECP256K1CryptoAlgorithm) DerivePublicKeyFromPublicGenerator(pubKey []by
 }
 </pre>
 		
-		<pre class="file" id="file39" style="display: none">package crypto
+		<pre class="file" id="file40" style="display: none">package crypto
 
 import "crypto/sha512"
 
@@ -4415,34 +4472,6 @@ import "crypto/sha512"
 func Sha512Half(msg []byte) []byte <span class="cov8" title="1">{
         h := sha512.Sum512(msg)
         return h[:32]
-}</span>
-</pre>
-		
-		<pre class="file" id="file40" style="display: none">package crypto
-
-type Algorithm struct {
-        prefix           uint8
-        familySeedPrefix uint8
-}
-
-func (c Algorithm) Prefix() uint8 <span class="cov0" title="0">{
-        return c.prefix
-}</span>
-
-func (c Algorithm) FamilySeedPrefix() uint8 <span class="cov0" title="0">{
-        return c.familySeedPrefix
-}</span>
-
-func (c Algorithm) DeriveKeypair(_ []byte, _ bool) (string, string, error) <span class="cov0" title="0">{
-        return "", "", nil
-}</span>
-
-func (c Algorithm) Sign(_ string, _ string) (string, error) <span class="cov0" title="0">{
-        return "", nil
-}</span>
-
-func (c Algorithm) Validate(_ string, _ string, _ string) bool <span class="cov0" title="0">{
-        return false
 }</span>
 </pre>
 		

--- a/pkg/crypto/der.go
+++ b/pkg/crypto/der.go
@@ -119,7 +119,6 @@ func DERHexToSig(hexSignature string) ([]byte, []byte, error) {
 		return nil, nil, ErrInvalidDERSignature
 	}
 
-
 	if len(leftover) > 0 {
 		return nil, nil, ErrLeftoverBytes
 	}

--- a/pkg/crypto/der.go
+++ b/pkg/crypto/der.go
@@ -8,6 +8,20 @@ import (
 	"strings"
 )
 
+var (
+	// ErrInvalidHexString is returned when the hex string is invalid.
+	ErrInvalidHexString = errors.New("invalid hex string")
+
+	// ErrInvalidDERNotEnoughData is returned when the DER data is not enough.
+	ErrInvalidDERNotEnoughData = errors.New("invalid DER: not enough data")
+	// ErrInvalidDERIntegerTag is returned when the DER integer tag is invalid.
+	ErrInvalidDERIntegerTag = errors.New("invalid DER: expected integer tag")
+	// ErrInvalidDERSignature is returned when the DER signature is invalid.
+	ErrInvalidDERSignature = errors.New("invalid signature: incorrect length")
+	// ErrLeftoverBytes is returned when there are leftover bytes after parsing the DER signature.
+	ErrLeftoverBytes = errors.New("invalid signature: left bytes after parsing")
+)
+
 // DERHexFromSig converts r and s hex strings to a DER-encoded signature hex string.
 // It returns the DER-encoded signature as a hex string and an error if any occurred during the process.
 func DERHexFromSig(rHex, sHex string) (string, error) {
@@ -30,11 +44,11 @@ func DERHexFromSig(rHex, sHex string) (string, error) {
 	// Convert hex strings to big.Int
 	r, ok := new(big.Int).SetString(rHex, 16)
 	if !ok {
-		return "", errors.New("invalid r hex string: " + rHex)
+		return "", ErrInvalidHexString
 	}
 	s, ok := new(big.Int).SetString(sHex, 16)
 	if !ok {
-		return "", errors.New("invalid s hex string: " + sHex)
+		return "", ErrInvalidHexString
 	}
 
 	// Convert r and s to sliced hex strings
@@ -67,14 +81,14 @@ func DERHexFromSig(rHex, sHex string) (string, error) {
 // and an error if any occurred during parsing.
 func parseInt(data []byte) (*big.Int, []byte, error) {
 	if len(data) < 2 {
-		return nil, nil, errors.New("invalid DER: not enough data")
+		return nil, nil, ErrInvalidDERNotEnoughData
 	}
 	if data[0] != 0x02 {
-		return nil, nil, errors.New("invalid DER: expected integer tag")
+		return nil, nil, ErrInvalidDERIntegerTag
 	}
 	length := int(data[1])
 	if len(data) < 2+length {
-		return nil, nil, errors.New("invalid DER: not enough data")
+		return nil, nil, ErrInvalidDERNotEnoughData
 	}
 	number := new(big.Int).SetBytes(data[2 : 2+length])
 	return number, data[2+length:], nil
@@ -85,28 +99,29 @@ func parseInt(data []byte) (*big.Int, []byte, error) {
 func DERHexToSig(hexSignature string) ([]byte, []byte, error) {
 	data, err := hex.DecodeString(hexSignature)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid hex string: %v", err)
+		return nil, nil, ErrInvalidHexString
 	}
 
 	if len(data) < 2 || data[0] != 0x30 {
-		return nil, nil, errors.New("invalid signature tag")
+		return nil, nil, ErrInvalidDERSignature
 	}
 	if int(data[1]) != len(data)-2 {
-		return nil, nil, errors.New("invalid signature: incorrect length")
+		return nil, nil, ErrInvalidDERSignature
 	}
 
 	r, sBytes, err := parseInt(data[2:])
 	if err != nil {
-		return nil, nil, errors.New("invalid signature: incorrect length")
+		return nil, nil, ErrInvalidDERSignature
 	}
 
 	s, leftover, err := parseInt(sBytes)
 	if err != nil {
-		return nil, nil, errors.New("invalid signature: incorrect length")
+		return nil, nil, ErrInvalidDERSignature
 	}
 
+
 	if len(leftover) > 0 {
-		return nil, nil, errors.New("invalid signature: left bytes after parsing")
+		return nil, nil, ErrLeftoverBytes
 	}
 
 	return r.Bytes(), s.Bytes(), nil

--- a/pkg/crypto/der_test.go
+++ b/pkg/crypto/der_test.go
@@ -72,7 +72,6 @@ func TestDERHexToSig(t *testing.T) {
 			expectedS:    "6fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
 			expectError:  nil,
 		},
-	
 	}
 
 	for _, tc := range testCases {
@@ -152,39 +151,39 @@ func TestDERHexFromSig(t *testing.T) {
 
 func TestParseInt(t *testing.T) {
 	testcases := []struct {
-		name        string
-		data        []byte
-		expectedInt *big.Int
+		name              string
+		data              []byte
+		expectedInt       *big.Int
 		expectedRemaining []byte
-		expectError error
+		expectError       error
 	}{
 		{
-			name:        "fail - not enough data",
-			data:        []byte{},
-			expectedInt: nil,
+			name:              "fail - not enough data",
+			data:              []byte{},
+			expectedInt:       nil,
 			expectedRemaining: nil,
-			expectError: ErrInvalidDERNotEnoughData,
+			expectError:       ErrInvalidDERNotEnoughData,
 		},
 		{
-			name:        "fail - invalid tag",
-			data:        []byte{0x01, 0x02, 0x03},
-			expectedInt: nil,
+			name:              "fail - invalid tag",
+			data:              []byte{0x01, 0x02, 0x03},
+			expectedInt:       nil,
 			expectedRemaining: nil,
-			expectError: ErrInvalidDERIntegerTag,
+			expectError:       ErrInvalidDERIntegerTag,
 		},
 		{
-			name:        "fail - invalid length",
-			data:        []byte{0x02, 0x02, 0x01},
-			expectedInt: nil,
+			name:              "fail - invalid length",
+			data:              []byte{0x02, 0x02, 0x01},
+			expectedInt:       nil,
 			expectedRemaining: nil,
-			expectError: ErrInvalidDERNotEnoughData,
+			expectError:       ErrInvalidDERNotEnoughData,
 		},
 		{
-			name:        "pass - valid data",
-			data:        []byte{0x02, 0x01, 0x01},
-			expectedInt: big.NewInt(1),
+			name:              "pass - valid data",
+			data:              []byte{0x02, 0x01, 0x01},
+			expectedInt:       big.NewInt(1),
 			expectedRemaining: []byte{},
-			expectError: nil,
+			expectError:       nil,
 		},
 	}
 

--- a/pkg/crypto/der_test.go
+++ b/pkg/crypto/der_test.go
@@ -2,8 +2,10 @@ package crypto
 
 import (
 	"encoding/hex"
-	"strings"
+	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkDERHexToSig(b *testing.B) {
@@ -19,49 +21,70 @@ func TestDERHexToSig(t *testing.T) {
 		hexSignature string
 		expectedR    string
 		expectedS    string
-		expectError  bool
+		expectError  error
 	}{
 		{
-			name:         "Valid DER signature",
-			hexSignature: "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
-			expectedR:    "E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C8297618",
-			expectedS:    "6FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
-			expectError:  false,
-		},
-		{
-			name:         "Invalid hex string",
+			name:         "fail - invalid hex string",
 			hexSignature: "invalid",
 			expectedR:    "",
 			expectedS:    "",
-			expectError:  true,
+			expectError:  ErrInvalidHexString,
 		},
 		{
-			name:         "Invalid signature tag",
+			name:         "fail - invalid signature tag",
 			hexSignature: "3145022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
 			expectedR:    "",
 			expectedS:    "",
-			expectError:  true,
+			expectError:  ErrInvalidDERSignature,
 		},
+		{
+			name:         "fail - invalid length",
+			hexSignature: "3044022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrInvalidDERSignature,
+		},
+		{
+			name:         "fail - invalid parseInt",
+			hexSignature: "3003020301",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrInvalidDERSignature,
+		},
+		{
+			name:         "fail - invalid parseInt - 2",
+			hexSignature: "3006020101020301",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrInvalidDERSignature,
+		},
+		{
+			name:         "fail - invalid leftover bytes",
+			hexSignature: "300702010102010101",
+			expectedR:    "",
+			expectedS:    "",
+			expectError:  ErrLeftoverBytes,
+		},
+		{
+			name:         "pass - valid DER signature",
+			hexSignature: "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
+			expectedR:    "e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c8297618",
+			expectedS:    "6fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
+			expectError:  nil,
+		},
+	
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r, s, err := DERHexToSig(tc.hexSignature)
 
-			if tc.expectError {
-				if err == nil {
-					t.Errorf("Expected an error, but got none")
-				}
+			if tc.expectError != nil {
+				require.Equal(t, tc.expectError, err)
 			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if hex.EncodeToString(r) != strings.ToLower(tc.expectedR) {
-					t.Errorf("Expected R %s, but got %s", tc.expectedR, hex.EncodeToString(r))
-				}
-				if hex.EncodeToString(s) != strings.ToLower(tc.expectedS) {
-					t.Errorf("Expected S %s, but got %s", tc.expectedS, hex.EncodeToString(s))
-				}
+				require.Equal(t, tc.expectedR, hex.EncodeToString(r))
+				require.Equal(t, tc.expectedS, hex.EncodeToString(s))
+				require.Nil(t, err)
 			}
 		})
 	}
@@ -81,35 +104,35 @@ func TestDERHexFromSig(t *testing.T) {
 		rHex        string
 		sHex        string
 		expectedDER string
-		expectError bool
+		expectError error
 	}{
 		{
-			name:        "Valid r and s values",
-			rHex:        "E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C8297618",
-			sHex:        "6FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
-			expectedDER: strings.ToLower("3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64"),
-			expectError: false,
+			name:        "pass - valid r and s values",
+			rHex:        "e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c8297618",
+			sHex:        "6fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
+			expectedDER: "3045022100e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c829761802206fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
+			expectError: nil,
 		},
 		{
-			name:        "Invalid r hex string",
+			name:        "fail - invalid r hex string",
 			rHex:        "invalid",
-			sHex:        "6FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
+			sHex:        "6fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
 			expectedDER: "",
-			expectError: true,
+			expectError: ErrInvalidHexString,
 		},
 		{
-			name:        "Invalid s hex string",
-			rHex:        "E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C8297618",
+			name:        "fail - invalid s hex string",
+			rHex:        "e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c8297618",
 			sHex:        "invalid",
 			expectedDER: "",
-			expectError: true,
+			expectError: ErrInvalidHexString,
 		},
 		{
-			name:        "r value with leading zero",
-			rHex:        "00E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C8297618",
-			sHex:        "6FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
-			expectedDER: strings.ToLower("3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64"),
-			expectError: false,
+			name:        "pass - r value with leading zero",
+			rHex:        "00e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c8297618",
+			sHex:        "6fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
+			expectedDER: "3045022100e1617f1a3c85b5bc8fa6224f893fe9068bea8f8d075ee144f6f9d255c829761802206fd9b361cde83a0c3d5654232f1d7cfb1a614e9a8f9b1a861564029065516e64",
+			expectError: nil,
 		},
 	}
 
@@ -117,17 +140,63 @@ func TestDERHexFromSig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := DERHexFromSig(tc.rHex, tc.sHex)
 
-			if tc.expectError {
-				if err == nil {
-					t.Errorf("Expected an error, but got none")
-				}
+			if tc.expectError != nil {
+				require.Equal(t, tc.expectError, err)
 			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if result != tc.expectedDER {
-					t.Errorf("Expected %s, but got %s", tc.expectedDER, result)
-				}
+				require.Equal(t, tc.expectedDER, result)
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestParseInt(t *testing.T) {
+	testcases := []struct {
+		name        string
+		data        []byte
+		expectedInt *big.Int
+		expectedRemaining []byte
+		expectError error
+	}{
+		{
+			name:        "fail - not enough data",
+			data:        []byte{},
+			expectedInt: nil,
+			expectedRemaining: nil,
+			expectError: ErrInvalidDERNotEnoughData,
+		},
+		{
+			name:        "fail - invalid tag",
+			data:        []byte{0x01, 0x02, 0x03},
+			expectedInt: nil,
+			expectedRemaining: nil,
+			expectError: ErrInvalidDERIntegerTag,
+		},
+		{
+			name:        "fail - invalid length",
+			data:        []byte{0x02, 0x02, 0x01},
+			expectedInt: nil,
+			expectedRemaining: nil,
+			expectError: ErrInvalidDERNotEnoughData,
+		},
+		{
+			name:        "pass - valid data",
+			data:        []byte{0x02, 0x01, 0x01},
+			expectedInt: big.NewInt(1),
+			expectedRemaining: []byte{},
+			expectError: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, remaining, err := parseInt(tc.data)
+			if tc.expectError != nil {
+				require.Equal(t, tc.expectError, err)
+			} else {
+				require.Equal(t, tc.expectedInt.Bytes(), n.Bytes())
+				require.Equal(t, tc.expectedRemaining, remaining)
+				require.Nil(t, err)
 			}
 		})
 	}

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -9,10 +9,14 @@ import (
 )
 
 const (
+	// ed25519 prefix - value is 237
 	ed25519Prefix byte = 0xED
 )
 
 var (
+	_ Algorithm = &ED25519CryptoAlgorithm{}
+
+	// ErrValidatorNotSupported is returned when a validator keypair is used with the ED25519 algorithm.
 	ErrValidatorNotSupported = errors.New("validator keypairs can not use Ed25519")
 )
 

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -4,32 +4,45 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"strings"
 )
 
 const (
-	ed25519Prefix = 0xED
+	ed25519Prefix byte = 0xED
 )
 
-type ED25519CryptoAlgorithm Algorithm
+var (
+	ErrValidatorNotSupported = errors.New("validator keypairs can not use Ed25519")
+)
 
+// ED25519CryptoAlgorithm is the implementation of the ED25519 cryptographic algorithm.
+type ED25519CryptoAlgorithm struct {
+	prefix           byte
+	familySeedPrefix byte
+}
+
+// ED25519 returns the ED25519 cryptographic algorithm.
 func ED25519() ED25519CryptoAlgorithm {
 	return ED25519CryptoAlgorithm{
 		prefix: ed25519Prefix,
 	}
 }
 
+// Prefix returns the prefix for the ED25519 cryptographic algorithm.
 func (c ED25519CryptoAlgorithm) Prefix() byte {
 	return c.prefix
 }
 
+// FamilySeedPrefix returns the family seed prefix for the ED25519 cryptographic algorithm.
 func (c ED25519CryptoAlgorithm) FamilySeedPrefix() byte {
 	return c.familySeedPrefix
 }
 
+// DeriveKeypair derives a keypair from a seed.
 func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool) (string, string, error) {
 	if validator {
-		return "", "", &ed25519ValidatorError{}
+		return "", "", ErrValidatorNotSupported
 	}
 	rawPriv := Sha512Half(decodedSeed)
 	pubKey, privKey, err := ed25519.GenerateKey(bytes.NewBuffer(rawPriv))
@@ -53,6 +66,7 @@ func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	return strings.ToUpper(hex.EncodeToString(signedMsg)), nil
 }
 
+// Validate validates a signature for a message with a public key.
 func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 	bp, err := hex.DecodeString(pubkey)
 	if err != nil {
@@ -65,10 +79,4 @@ func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 	}
 
 	return ed25519.Verify(ed25519.PublicKey(bp[1:]), []byte(msg), bs)
-}
-
-type ed25519ValidatorError struct{}
-
-func (e *ed25519ValidatorError) Error() string {
-	return "validator keypairs can not use Ed25519"
 }

--- a/pkg/crypto/ed25519_test.go
+++ b/pkg/crypto/ed25519_test.go
@@ -6,35 +6,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestED25519_Prefix(t *testing.T) {
+	require.Equal(t, ed25519Prefix, ED25519().Prefix())
+}
+
+func TestED25519_FamilySeedPrefix(t *testing.T) {
+	require.Zero(t, ED25519().FamilySeedPrefix())
+}
+
 func TestED25519DeriveKeypair(t *testing.T) {
 	tt := []struct {
-		description string
-		seedBytes   []byte
-		validator   bool
-		expPubKey   string
-		expPrivKey  string
-		expErr      error
+		name       string
+		seedBytes  []byte
+		validator  bool
+		expPubKey  string
+		expPrivKey string
+		expErr     error
 	}{
 		{
-			description: "Successfully derive keypair",
-			seedBytes:   []byte{102, 97, 107, 101, 82, 97, 110, 100, 111, 109, 83, 116, 114, 105, 110, 103},
-			validator:   false,
-			expPubKey:   "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
-			expPrivKey:  "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
-			expErr:      nil,
+			name:       "pass- successfully derive keypair",
+			seedBytes:  []byte{102, 97, 107, 101, 82, 97, 110, 100, 111, 109, 83, 116, 114, 105, 110, 103},
+			validator:  false,
+			expPubKey:  "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
+			expPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
+			expErr:     nil,
 		},
 		{
-			description: "Error if validator is set to true",
-			seedBytes:   []byte{102, 97, 107, 101, 82, 97, 110, 100, 111, 109, 83, 116, 114, 105, 110, 103},
-			validator:   true,
-			expPubKey:   "",
-			expPrivKey:  "",
-			expErr:      &ed25519ValidatorError{},
+			name:       "fail - error if validator is set to true",
+			seedBytes:  []byte{102, 97, 107, 101, 82, 97, 110, 100, 111, 109, 83, 116, 114, 105, 110, 103},
+			validator:  true,
+			expPubKey:  "",
+			expPrivKey: "",
+			expErr:     ErrValidatorNotSupported,
 		},
 	}
 
 	for _, tc := range tt {
-		t.Run(tc.description, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			priv, pub, err := ED25519().DeriveKeypair(tc.seedBytes, tc.validator)
 			if tc.expErr != nil {
 				require.Zero(t, pub)
@@ -50,28 +58,35 @@ func TestED25519DeriveKeypair(t *testing.T) {
 
 func TestED25519Sign(t *testing.T) {
 	tt := []struct {
-		description  string
+		name         string
 		inputMsg     string
 		inputPrivKey string
 		expected     string
 		expectedErr  error
 	}{
 		{
-			description:  "Sign a valid message",
+			name:         "fail - invalid private key hex",
+			inputMsg:     "hello world",
+			inputPrivKey: "invalid_key",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
+			name:         "pass - sign a valid message",
 			inputMsg:     "hello world",
 			inputPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
 			expected:     "E83CAFEAF100793F0C6570D60C7447FF3A87E0DC0CAE9AD90EF0102860EC3BD1D20F432494021F3E19DAFF257A420CA64A49C283AB5AD00B6B0CEA1756151C01",
 			expectedErr:  nil,
 		},
 		{
-			description:  "Sign a message with a different private key",
+			name:         "pass - sign a message with a different private key",
 			inputMsg:     "hello world",
 			inputPrivKey: "ED6BF4E585BA0C4055F6E63D0D6D06E7D8B9F00AA02337BCF864385275892A1EB5",
 			expected:     "84F05438BFFC29F49E8DC8865251DA1CEF9A5A9CAA7DC2629985986C35271CC1AC389846F955C548A322F433F387CE928329F091E8FA7E2A8E7DFDAB8E88310B",
 			expectedErr:  nil,
 		},
 		{
-			description:  "Sign a longer message with a different private key",
+			name:         "pass - sign a longer message with a different private key",
 			inputMsg:     "hello madsjdadjdas,adajofahffa !$@~",
 			inputPrivKey: "ED28E9ADC9383EB494476DCF7D95DD4B16F6A2C325365F9E17007294F4AE487CE0",
 			expected:     "77F07A34D408DD8C3C6BCED0E31C2909D8E13ECB15AF15345CA1ECE53118519754971BE1DD7A0A52E5D737D4DBFAD01018727EF1F0BAD06B31CD8D6F3D9E7E05",
@@ -80,7 +95,7 @@ func TestED25519Sign(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		t.Run(tc.description, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			actual, err := ED25519().Sign(tc.inputMsg, tc.inputPrivKey)
 
 			if tc.expectedErr != nil {
@@ -96,30 +111,44 @@ func TestED25519Sign(t *testing.T) {
 
 func TestED25519Validate(t *testing.T) {
 	tt := []struct {
-		description string
+		name        string
 		inputMsg    string
 		inputPubKey string
 		inputSig    string
 		expected    bool
 	}{
 		{
-			description: "A valid signature for message",
+			name:        "fail - invalid signature hex",
 			inputMsg:    "test message",
 			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
-			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
-			expected:    true,
+			inputSig:    "invalid_sig",
+			expected:    false,
 		},
 		{
-			description: "An invalid signature for message",
+			name:        "fail - invalid signature for message",
 			inputMsg:    "test message",
 			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FB6",
 			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
 			expected:    false,
 		},
+		{
+			name:        "fail - invalid public key hex",
+			inputMsg:    "test message",
+			inputPubKey: "invalid_key",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "pass - valid signature for message",
+			inputMsg:    "test message",
+			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    true,
+		},
 	}
 
 	for _, tc := range tt {
-		t.Run(tc.description, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			actual := ED25519().Validate(tc.inputMsg, tc.inputPubKey, tc.inputSig)
 			require.Equal(t, tc.expected, actual)
 		})

--- a/pkg/crypto/secp256k1_test.go
+++ b/pkg/crypto/secp256k1_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSecp256k1_Prefix(t *testing.T) {
+	require.Equal(t, secp256K1Prefix, SECP256K1().Prefix())
+}
+
+func TestSecp256k1_FamilySeedPrefix(t *testing.T) {
+	require.Equal(t, secp256K1FamilySeedPrefix, SECP256K1().FamilySeedPrefix())
+}
+
 func TestSecp256k1_deriveKeypair(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -17,7 +25,7 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 		expectedErr     error
 	}{
 		{
-			name:            "valid seed (1)",
+			name:            "pass - valid seed 1",
 			seedBytes:       []byte{229, 81, 182, 134, 131, 220, 192, 126, 133, 114, 150, 132, 140, 237, 222, 196},
 			validator:       false,
 			expectedPubKey:  "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E",
@@ -25,7 +33,7 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 			expectedErr:     nil,
 		},
 		{
-			name:            "valid seed (2)",
+			name:            "pass - valid seed 2",
 			seedBytes:       []byte{124, 228, 51, 247, 54, 54, 81, 51, 239, 86, 226, 187, 232, 20, 111, 163},
 			validator:       false,
 			expectedPubKey:  "031FBCFDD2EC6C2EDFBBA3866BDBAC28E5253C6A01FE9EFF8CAAE01871F009E837",
@@ -33,12 +41,12 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 			expectedErr:     nil,
 		},
 		{
-			name:            "validator set to true",
+			name:            "fail - validator set to true",
 			seedBytes:       []byte{124, 228, 51, 247, 54, 54, 81, 51, 239, 86, 226, 187, 232, 20, 111, 163},
 			validator:       true,
 			expectedPubKey:  "",
 			expectedPrivKey: "",
-			expectedErr:     errors.New("validator keypair derivation not supported"),
+			expectedErr:     ErrValidatorKeypairDerivation,
 		},
 	}
 
@@ -46,25 +54,17 @@ func TestSecp256k1_deriveKeypair(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			privKey, pubKey, err := SECP256K1().DeriveKeypair(tc.seedBytes, tc.validator)
 			if tc.expectedErr != nil {
-				if err == nil || err.Error() != tc.expectedErr.Error() {
-					t.Fatalf("expected error %v, got %v", tc.expectedErr, err)
-				}
+				require.Error(t, err, tc.expectedErr.Error())
 			} else {
-				if err != nil {
-					t.Fatalf("expected valid keypair, got error: %v", err)
-				}
-				if privKey != tc.expectedPrivKey {
-					t.Errorf("expected private key %s, got %s", tc.expectedPrivKey, privKey)
-				}
-				if pubKey != tc.expectedPubKey {
-					t.Errorf("expected public key %s, got %s", tc.expectedPubKey, pubKey)
-				}
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedPrivKey, privKey)
+				require.Equal(t, tc.expectedPubKey, pubKey)
 			}
 		})
 	}
 }
 
-func TestSecp256k1_sign(t *testing.T) {
+func TestSecp256k1_Sign(t *testing.T) {
 	testCases := []struct {
 		name              string
 		message           string
@@ -73,72 +73,86 @@ func TestSecp256k1_sign(t *testing.T) {
 		wantErr           bool
 	}{
 		{
-			name:              "valid message",
+			name:              "pass - valid message",
 			message:           "test message",
 			privKey:           "00D78B9735C3F26501C7337B8A5727FD53A6EFDBC6AA55984F098488561F985E23",
 			expectedSignature: "30440220583A91C95E54E6A651C47BEC22744E0B101E2C4060E7B08F6341657DAD9BC3EE02207D1489C7395DB0188D3A56A977ECBA54B36FA9371B40319655B1B4429E33EF2D",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature",
+			name:              "pass - valid signature",
 			message:           "Hello World",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 2",
+			name:              "pass - valid signature 2",
 			message:           "test",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "30450221008F0B50BEEA0C9787E85EEF9624E9385CCBE565B221BAEC2F2DA5F1D9D6D976F7022022C1B1829AE0E758FB690110F245F15433A0579C44910785FE75F93B9D0FB41F",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 3",
+			name:              "pass - valid signature 3",
 			message:           "message",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "3045022100F07CD8D749AAD8F972475A34591336162A959FCC7F8E692D56410CB70B9634F702201B96AF63E166371D8A2C4C3D4CDA69F6064212D1C28D01F598653BE05C323E8C",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 4",
+			name:              "pass - valid signature 4",
 			message:           "message2",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "3045022100A2847849BC186B227DB941B1D0A4C39FABBE04A10BF364FC4E394E8B53FD308D02202D47CA9DC35B7FE3E04B578A935CCBE1827B610911709AC13343344F311BD799",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 5",
+			name:              "pass - valid signature 5",
 			message:           "message3",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "304402202D5CDBCF251868046CB07FC2CB49200FED9FF216D4B38455A1D222ED29E6123B022057E9962B336D180F0B8DCD99B72C30BB09A5451D2059556E3C1E45C1F5D018B6",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 6",
+			name:              "pass - valid signature 6",
 			message:           "message4",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "3045022100A07B597B3D61C3E97B3CCC2DB65F40B26BAEEF7A3EAF8969C0F4E879DDAD1314022058296AC8B4A6E2D5F33891B5BB2211D2AEF1853DF42452649865AB2FE2C83922",
 			wantErr:           false,
 		},
 		{
-			name:              "Valid signature 7",
+			name:              "pass - valid signature 7",
 			message:           "message5",
 			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
 			expectedSignature: "3044022033950382A62160DBD731D3108C34B07AFD5CD816943931B64E3A25440E8C911902200ABEF5FB3E8B0C4CBD304421B8D3BD6F135D54831FE5426BE74D340ECDFE1F8F",
 			wantErr:           false,
 		},
 		{
-			name:              "Empty private key",
+			name:              "fail - empty private key",
 			message:           "Hello World",
 			privKey:           "",
 			expectedSignature: "",
 			wantErr:           true,
 		},
 		{
-			name:              "Invalid private key",
+			name:              "fail - invalid private key",
 			message:           "Hello World",
 			privKey:           "invalid_key",
+			expectedSignature: "",
+			wantErr:           true,
+		},
+		{
+			name:              "fail - invalid message length",
+			message:           "",
+			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071A",
+			expectedSignature: "",
+			wantErr:           true,
+		},
+		{
+			name:              "fail - invalid private key hex",
+			message:           "Hello World",
+			privKey:           "00B167A9F3B9E60A4F93695713682C102438620AA1785C3AE635F53E5B6261071X",
 			expectedSignature: "",
 			wantErr:           true,
 		},
@@ -147,24 +161,17 @@ func TestSecp256k1_sign(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			signature, err := SECP256K1().Sign(tc.message, tc.privKey)
-
-			if signature != tc.expectedSignature {
-				t.Errorf("sign() returned %v, want %v", signature, tc.expectedSignature)
-			}
-
-			if (err != nil) != tc.wantErr {
-				t.Errorf("sign() error = %v, wantErr %v", err, tc.wantErr)
-				return
-			}
-
-			if !tc.wantErr && len(signature) == 0 {
-				t.Errorf("sign() returned empty signature for valid input")
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedSignature, signature)
 			}
 		})
 	}
 }
 
-func TestSecp256k1_validate(t *testing.T) {
+func TestSecp256k1_Validate(t *testing.T) {
 	testCases := []struct {
 		name      string
 		message   string
@@ -173,38 +180,45 @@ func TestSecp256k1_validate(t *testing.T) {
 		wantValid bool
 	}{
 		{
-			name:      "Valid signature",
+			name:      "pass - valid signature",
 			message:   "Hello World",
 			signature: "3045022100E1617F1A3C85B5BC8FA6224F893FE9068BEA8F8D075EE144F6F9D255C829761802206FD9B361CDE83A0C3D5654232F1D7CFB1A614E9A8F9B1A861564029065516E64",
 			pubKey:    "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E",
 			wantValid: true,
 		},
 		{
-			name:      "Valid signature",
+			name:      "pass - valid signature",
 			message:   "test",
 			signature: "30450221008F0B50BEEA0C9787E85EEF9624E9385CCBE565B221BAEC2F2DA5F1D9D6D976F7022022C1B1829AE0E758FB690110F245F15433A0579C44910785FE75F93B9D0FB41F",
 			pubKey:    "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E",
 			wantValid: true,
 		},
 		{
-			name:      "Invalid signature",
+			name:      "fail - invalid signature",
 			message:   "Hello, World!",
 			signature: "3045022100B1629F44BB12A86AE5A3D79A4E2BE6A473DBBD3F4FB4E3898A2E9A9BE1A54EF502204C3B0C33C46F5ABDE7C2C1A3F2B79B8A9F3A69D8C7C248B2B5C16A39A9C3B5F6",
 			pubKey:    "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E",
 			wantValid: false,
 		},
 		{
-			name:      "Invalid public key",
+			name:      "fail - invalid public key",
 			message:   "Hello, World!",
 			signature: "3045022100B1629F44BB12A86AE5A3D79A4E2BE6A473DBBD3F4FB4E3898A2E9A9BE1A54EF502204C3B0C33C46F5ABDE7C2C1A3F2B79B8A9F3A69D8C7C248B2B5C16A39A9C3B5F5",
 			pubKey:    "invalid_key",
 			wantValid: false,
 		},
 		{
-			name:      "Empty signature",
+			name:      "fail - empty signature",
 			message:   "Hello, World!",
 			signature: "",
 			pubKey:    "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D56E",
+			wantValid: false,
+		},
+		{
+			name:      "fail - invalid public key hex",
+			message:   "Hello, World!",
+			signature: "3045022100B1629F44BB12A86AE5A3D79A4E2BE6A473DBBD3F4FB4E3898A2E9A9BE1A54EF502204C3B0C33C46F5ABDE7C2C1A3F2B79B8A9F3A69D8C7C248B2B5C16A39A9C3B5F5",
+			pubKey:    "02950F4710101A25073BF37086D73FBBD00C7A6B0F91097D8F0BC6D268C400D5",
 			wantValid: false,
 		},
 	}
@@ -212,15 +226,12 @@ func TestSecp256k1_validate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isValid := SECP256K1().Validate(tc.message, tc.pubKey, tc.signature)
-
-			if isValid != tc.wantValid {
-				t.Errorf("validate() = %v, want %v", isValid, tc.wantValid)
-			}
+			require.Equal(t, tc.wantValid, isValid)
 		})
 	}
 }
 
-func TestSecp256k1_derivePublicKeyFromPublicGenerator(t *testing.T) {
+func TestSecp256k1_DerivePublicKeyFromPublicGenerator(t *testing.T) {
 	testcases := []struct {
 		name        string
 		inputPubKey []byte

--- a/pkg/crypto/types.go
+++ b/pkg/crypto/types.go
@@ -1,26 +1,6 @@
 package crypto
 
-type Algorithm struct {
-	prefix           uint8
-	familySeedPrefix uint8
-}
-
-func (c Algorithm) Prefix() uint8 {
-	return c.prefix
-}
-
-func (c Algorithm) FamilySeedPrefix() uint8 {
-	return c.familySeedPrefix
-}
-
-func (c Algorithm) DeriveKeypair(_ []byte, _ bool) (string, string, error) {
-	return "", "", nil
-}
-
-func (c Algorithm) Sign(_ string, _ string) (string, error) {
-	return "", nil
-}
-
-func (c Algorithm) Validate(_ string, _ string, _ string) bool {
-	return false
+type Algorithm interface {
+	Prefix() byte
+	FamilySeedPrefix() byte
 }


### PR DESCRIPTION
# [TA-3575]: add testing coverage  for crypto package

This PR aims to upgrade the test coverage for the `crypto` package. It also refactors some errors and add testcases to some algorithm functions

## Changes

- Upgraded test coverage
