### PR TITLE
[TA-3644]: add ws client queries

### DIFF
--- a/xrpl/queries/nft/nftoken_buy_offers.go
+++ b/xrpl/queries/nft/nftoken_buy_offers.go
@@ -1,4 +1,4 @@
-package path
+package nft
 
 import (
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"

--- a/xrpl/queries/nft/nftoken_buy_offers_test.go
+++ b/xrpl/queries/nft/nftoken_buy_offers_test.go
@@ -1,4 +1,4 @@
-package path
+package nft
 
 import (
 	"testing"

--- a/xrpl/queries/nft/nftoken_sell_offers.go
+++ b/xrpl/queries/nft/nftoken_sell_offers.go
@@ -1,4 +1,4 @@
-package path
+package nft
 
 import (
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"

--- a/xrpl/queries/nft/nftoken_sell_offers_test.go
+++ b/xrpl/queries/nft/nftoken_sell_offers_test.go
@@ -1,4 +1,4 @@
-package path
+package nft
 
 import (
 	"testing"

--- a/xrpl/queries/nft/types/nftoken_offer.go
+++ b/xrpl/queries/nft/types/nftoken_offer.go
@@ -5,10 +5,10 @@ import (
 )
 
 type NFTokenOffer struct {
-	Amount            types.CurrencyAmount `json:"amount"`
-	Flags             uint                 `json:"flags"`
-	NFTokenOfferIndex string               `json:"nft_offer_index"`
-	Owner             types.Address        `json:"owner"`
-	Destination       types.Address        `json:"destination,omitempty"`
-	Expiration        int                  `json:"expiration,omitempty"`
+	Amount            any           `json:"amount"`
+	Flags             uint          `json:"flags"`
+	NFTokenOfferIndex string        `json:"nft_offer_index"`
+	Owner             types.Address `json:"owner"`
+	Destination       types.Address `json:"destination,omitempty"`
+	Expiration        int           `json:"expiration,omitempty"`
 }

--- a/xrpl/queries/path/path_find.go
+++ b/xrpl/queries/path/path_find.go
@@ -32,6 +32,11 @@ func (*FindCreateRequest) Method() string {
 	return "path_find"
 }
 
+// TODO: Implement V2
+func (*FindCreateRequest) Validate() error {
+	return nil
+}
+
 // ############################################################################
 // Close Request
 // ############################################################################
@@ -78,9 +83,10 @@ func (*FindStatusRequest) Validate() error {
 type FindResponse struct {
 	Alternatives       []pathtypes.Alternative `json:"alternatives"`
 	DestinationAccount types.Address           `json:"destination_account"`
-	DestinationAmount  types.CurrencyAmount    `json:"destination_amount"`
-	SourceAccount      types.Address           `json:"source_account"`
-	FullReply          bool                    `json:"full_reply"`
-	Closed             bool                    `json:"closed,omitempty"`
-	Status             bool                    `json:"status,omitempty"`
+	// DestinationAmount  types.CurrencyAmount    `json:"destination_amount"`
+	DestinationAmount any           `json:"destination_amount"`
+	SourceAccount     types.Address `json:"source_account"`
+	FullReply         bool          `json:"full_reply"`
+	Closed            bool          `json:"closed,omitempty"`
+	Status            bool          `json:"status,omitempty"`
 }

--- a/xrpl/queries/path/types/book_offer.go
+++ b/xrpl/queries/path/types/book_offer.go
@@ -2,15 +2,16 @@ package types
 
 import (
 	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
-	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
 type BookOffer struct {
 	ledger.Offer
-	OwnerFunds      string               `json:"owner_funds,omitempty"`
-	TakerGetsFunded types.CurrencyAmount `json:"taker_gets_funded,omitempty"`
-	TakerPaysFunded types.CurrencyAmount `json:"taker_pays_funded,omitempty"`
-	Quality         string               `json:"quality,omitempty"`
+	OwnerFunds string `json:"owner_funds,omitempty"`
+	// TakerGetsFunded types.CurrencyAmount `json:"taker_gets_funded,omitempty"`
+	TakerGetsFunded any `json:"taker_gets_funded,omitempty"`
+	// TakerPaysFunded types.CurrencyAmount `json:"taker_pays_funded,omitempty"`
+	TakerPaysFunded any    `json:"taker_pays_funded,omitempty"`
+	Quality         string `json:"quality,omitempty"`
 }
 
 type BookOfferCurrency struct {

--- a/xrpl/queries/path/types/path.go
+++ b/xrpl/queries/path/types/path.go
@@ -2,16 +2,18 @@ package types
 
 import (
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
-	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
 type Alternative struct {
-	PathsComputed     [][]transaction.PathStep `json:"paths_computed"`
-	SourceAmount      types.CurrencyAmount     `json:"source_amount"`
-	DestinationAmount types.CurrencyAmount     `json:"destination_amount,omitempty"`
+	PathsComputed [][]transaction.PathStep `json:"paths_computed"`
+	// SourceAmount      types.CurrencyAmount     `json:"source_amount"`
+	SourceAmount any `json:"source_amount"`
+	// DestinationAmount types.CurrencyAmount     `json:"destination_amount,omitempty"`
+	DestinationAmount any `json:"destination_amount,omitempty"`
 }
 
 type RippleAlternative struct {
 	PathsComputed [][]transaction.PathStep `json:"paths_computed"`
-	SourceAmount  types.CurrencyAmount     `json:"source_amount"`
+	// SourceAmount  types.CurrencyAmount     `json:"source_amount"`
+	SourceAmount any `json:"source_amount"`
 }

--- a/xrpl/websocket/queries.go
+++ b/xrpl/websocket/queries.go
@@ -81,6 +81,9 @@ func (c *Client) GetAccountLines(req *account.LinesRequest) (*account.LinesRespo
 	return &acr, nil
 }
 
+// GetAccountNFTs retrieves a list of NFTs owned by an account on the XRP Ledger.
+// It takes an AccountNFTsRequest as input and returns an AccountNFTsResponse,
+// along with any error encountered.
 func (c *Client) GetAccountNFTs(req *account.NFTsRequest) (*account.NFTsResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -94,6 +97,9 @@ func (c *Client) GetAccountNFTs(req *account.NFTsRequest) (*account.NFTsResponse
 	return &acr, nil
 }
 
+// GetAccountCurrencies retrieves a list of currencies that an account can send or receive.
+// It takes an AccountCurrenciesRequest as input and returns an AccountCurrenciesResponse,
+// along with any error encountered.
 func (c *Client) GetAccountCurrencies(req *account.CurrenciesRequest) (*account.CurrenciesResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -107,6 +113,10 @@ func (c *Client) GetAccountCurrencies(req *account.CurrenciesRequest) (*account.
 	return &acr, nil
 }
 
+// GetAccountOffers retrieves a list of offers made by an account that are currently active
+// in the XRP Ledger's decentralized exchange.
+// It takes an AccountOffersRequest as input and returns an AccountOffersResponse,
+// along with any error encountered.
 func (c *Client) GetAccountOffers(req *account.OffersRequest) (*account.OffersResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -120,6 +130,9 @@ func (c *Client) GetAccountOffers(req *account.OffersRequest) (*account.OffersRe
 	return &acr, nil
 }
 
+// GetAccountTransactions retrieves a list of transactions that involved a specific account.
+// It takes an AccountTransactionsRequest as input and returns an AccountTransactionsResponse,
+// along with any error encountered.
 func (c *Client) GetAccountTransactions(req *account.TransactionsRequest) (*account.TransactionsResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -135,6 +148,9 @@ func (c *Client) GetAccountTransactions(req *account.TransactionsRequest) (*acco
 
 // Channel queries
 
+// GetChannelVerify verifies the signature of a payment channel claim.
+// It takes a ChannelVerifyRequest as input and returns a ChannelVerifyResponse,
+// along with any error encountered.
 func (c *Client) GetChannelVerify(req *channel.VerifyRequest) (*channel.VerifyResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -150,7 +166,8 @@ func (c *Client) GetChannelVerify(req *channel.VerifyRequest) (*channel.VerifyRe
 
 // Ledger queries
 
-// Returns the index of the most recently validated ledger.
+// GetLedgerIndex returns the index of the most recently validated ledger.
+// It returns the ledger index as a LedgerIndex type and any error encountered.
 func (c *Client) GetLedgerIndex() (common.LedgerIndex, error) {
 	res, err := c.Request(&ledger.Request{
 		LedgerIndex: common.LedgerTitle("validated"),
@@ -167,6 +184,8 @@ func (c *Client) GetLedgerIndex() (common.LedgerIndex, error) {
 	return lr.LedgerIndex, err
 }
 
+// GetClosedLedger retrieves information about the last closed ledger.
+// It returns a ClosedResponse containing the ledger information and any error encountered.
 func (c *Client) GetClosedLedger() (*ledger.ClosedResponse, error) {
 	res, err := c.Request(&ledger.ClosedRequest{})
 	if err != nil {
@@ -180,6 +199,8 @@ func (c *Client) GetClosedLedger() (*ledger.ClosedResponse, error) {
 	return &lr, nil
 }
 
+// GetCurrentLedger retrieves information about the current working ledger.
+// It returns a CurrentResponse containing the ledger information and any error encountered.
 func (c *Client) GetCurrentLedger() (*ledger.CurrentResponse, error) {
 	res, err := c.Request(&ledger.CurrentRequest{})
 	if err != nil {
@@ -193,6 +214,9 @@ func (c *Client) GetCurrentLedger() (*ledger.CurrentResponse, error) {
 	return &lr, nil
 }
 
+// GetLedgerData retrieves contents of a ledger.
+// It takes a DataRequest as input and returns a DataResponse containing the ledger data,
+// along with any error encountered.
 func (c *Client) GetLedgerData(req *ledger.DataRequest) (*ledger.DataResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -206,6 +230,9 @@ func (c *Client) GetLedgerData(req *ledger.DataRequest) (*ledger.DataResponse, e
 	return &lr, nil
 }
 
+// GetLedger retrieves information about a specific ledger version.
+// It takes a Request as input and returns a Response containing the ledger information,
+// along with any error encountered.
 func (c *Client) GetLedger(req *ledger.Request) (*ledger.Response, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -221,6 +248,9 @@ func (c *Client) GetLedger(req *ledger.Request) (*ledger.Response, error) {
 
 // NFT queries
 
+// GetNFTBuyOffers retrieves all buy offers for a specific NFT.
+// It takes an NFTokenBuyOffersRequest as input and returns an NFTokenBuyOffersResponse,
+// along with any error encountered.
 func (c *Client) GetNFTBuyOffers(req *nft.NFTokenBuyOffersRequest) (*nft.NFTokenBuyOffersResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -234,6 +264,9 @@ func (c *Client) GetNFTBuyOffers(req *nft.NFTokenBuyOffersRequest) (*nft.NFToken
 	return &lr, nil
 }
 
+// GetNFTSellOffers retrieves all sell offers for a specific NFT.
+// It takes an NFTokenSellOffersRequest as input and returns an NFTokenSellOffersResponse,
+// along with any error encountered.
 func (c *Client) GetNFTSellOffers(req *nft.NFTokenSellOffersRequest) (*nft.NFTokenSellOffersResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -249,6 +282,9 @@ func (c *Client) GetNFTSellOffers(req *nft.NFTokenSellOffersRequest) (*nft.NFTok
 
 // Path queries
 
+// GetBookOffers retrieves a list of offers between two currencies.
+// It takes a BookOffersRequest as input and returns a BookOffersResponse,
+// along with any error encountered.
 func (c *Client) GetBookOffers(req *path.BookOffersRequest) (*path.BookOffersResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -262,6 +298,9 @@ func (c *Client) GetBookOffers(req *path.BookOffersRequest) (*path.BookOffersRes
 	return &lr, nil
 }
 
+// GetDepositAuthorized checks whether one account is authorized to send payments directly to another.
+// It takes a DepositAuthorizedRequest as input and returns a DepositAuthorizedResponse,
+// along with any error encountered.
 func (c *Client) GetDepositAuthorized(req *path.DepositAuthorizedRequest) (*path.DepositAuthorizedResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -275,6 +314,9 @@ func (c *Client) GetDepositAuthorized(req *path.DepositAuthorizedRequest) (*path
 	return &lr, nil
 }
 
+// FindPathCreate creates a path finding request that will be monitored until it expires or is closed.
+// It takes a FindCreateRequest as input and returns a FindResponse,
+// along with any error encountered.
 func (c *Client) FindPathCreate(req *path.FindCreateRequest) (*path.FindResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -288,6 +330,9 @@ func (c *Client) FindPathCreate(req *path.FindCreateRequest) (*path.FindResponse
 	return &lr, nil
 }
 
+// FindPathClose closes an existing path finding request.
+// It takes a FindCloseRequest as input and returns a FindResponse,
+// along with any error encountered.
 func (c *Client) FindPathClose(req *path.FindCloseRequest) (*path.FindResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -301,6 +346,9 @@ func (c *Client) FindPathClose(req *path.FindCloseRequest) (*path.FindResponse, 
 	return &lr, nil
 }
 
+// FindPathStatus checks the status of an existing path finding request.
+// It takes a FindStatusRequest as input and returns a FindResponse,
+// along with any error encountered.
 func (c *Client) FindPathStatus(req *path.FindStatusRequest) (*path.FindResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -314,6 +362,9 @@ func (c *Client) FindPathStatus(req *path.FindStatusRequest) (*path.FindResponse
 	return &lr, nil
 }
 
+// GetRipplePathFind finds paths for a payment between two accounts.
+// It takes a RipplePathFindRequest as input and returns a RipplePathFindResponse,
+// along with any error encountered.
 func (c *Client) GetRipplePathFind(req *path.RipplePathFindRequest) (*path.RipplePathFindResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -345,6 +396,9 @@ func (c *Client) GetServerInfo(req *server.InfoRequest) (*server.InfoResponse, e
 	return &sir, err
 }
 
+// GetAllFeatures retrieves information about all features supported by the server.
+// It takes a FeatureAllRequest as input and returns a FeatureAllResponse,
+// along with any error encountered.
 func (c *Client) GetAllFeatures(req *server.FeatureAllRequest) (*server.FeatureAllResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -358,6 +412,9 @@ func (c *Client) GetAllFeatures(req *server.FeatureAllRequest) (*server.FeatureA
 	return &lr, nil
 }
 
+// GetFeature retrieves information about a specific feature supported by the server.
+// It takes a FeatureOneRequest as input and returns a FeatureResponse,
+// along with any error encountered.
 func (c *Client) GetFeature(req *server.FeatureOneRequest) (*server.FeatureResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -371,6 +428,9 @@ func (c *Client) GetFeature(req *server.FeatureOneRequest) (*server.FeatureRespo
 	return &lr, nil
 }
 
+// GetFee retrieves the current transaction fee settings from the server.
+// It takes a FeeRequest as input and returns a FeeResponse,
+// along with any error encountered.
 func (c *Client) GetFee(req *server.FeeRequest) (*server.FeeResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -384,6 +444,9 @@ func (c *Client) GetFee(req *server.FeeRequest) (*server.FeeResponse, error) {
 	return &lr, nil
 }
 
+// GetManifest retrieves public information about a known validator.
+// It takes a ManifestRequest as input and returns a ManifestResponse,
+// along with any error encountered.
 func (c *Client) GetManifest(req *server.ManifestRequest) (*server.ManifestResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -397,6 +460,9 @@ func (c *Client) GetManifest(req *server.ManifestRequest) (*server.ManifestRespo
 	return &lr, nil
 }
 
+// GetServerState retrieves information about the current state of the server.
+// It takes a StateRequest as input and returns a StateResponse,
+// along with any error encountered.
 func (c *Client) GetServerState(req *server.StateRequest) (*server.StateResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -412,6 +478,9 @@ func (c *Client) GetServerState(req *server.StateRequest) (*server.StateResponse
 
 // Utility queries
 
+// Ping tests the connection to the server.
+// It takes a PingRequest as input and returns a PingResponse,
+// along with any error encountered.
 func (c *Client) Ping(req *utility.PingRequest) (*utility.PingResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {
@@ -425,6 +494,9 @@ func (c *Client) Ping(req *utility.PingRequest) (*utility.PingResponse, error) {
 	return &lr, nil
 }
 
+// GetRandom provides a random number from the server.
+// It takes a RandomRequest as input and returns a RandomResponse,
+// along with any error encountered.
 func (c *Client) GetRandom(req *utility.RandomRequest) (*utility.RandomResponse, error) {
 	res, err := c.Request(req)
 	if err != nil {

--- a/xrpl/websocket/queries.go
+++ b/xrpl/websocket/queries.go
@@ -3,11 +3,17 @@ package websocket
 import (
 	"github.com/Peersyst/xrpl-go/xrpl/currency"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/channel"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/nft"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/path"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/server"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/utility"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
+
+// Account queries
 
 // GetAccountInfo retrieves information about an account on the XRP Ledger.
 // It takes an AccountInfoRequest as input and returns an AccountInfoResponse,
@@ -75,6 +81,75 @@ func (c *Client) GetAccountLines(req *account.LinesRequest) (*account.LinesRespo
 	return &acr, nil
 }
 
+func (c *Client) GetAccountNFTs(req *account.NFTsRequest) (*account.NFTsResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var acr account.NFTsResponse
+	err = res.GetResult(&acr)
+	if err != nil {
+		return nil, err
+	}
+	return &acr, nil
+}
+
+func (c *Client) GetAccountCurrencies(req *account.CurrenciesRequest) (*account.CurrenciesResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var acr account.CurrenciesResponse
+	err = res.GetResult(&acr)
+	if err != nil {
+		return nil, err
+	}
+	return &acr, nil
+}
+
+func (c *Client) GetAccountOffers(req *account.OffersRequest) (*account.OffersResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var acr account.OffersResponse
+	err = res.GetResult(&acr)
+	if err != nil {
+		return nil, err
+	}
+	return &acr, nil
+}
+
+func (c *Client) GetAccountTransactions(req *account.TransactionsRequest) (*account.TransactionsResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var acr account.TransactionsResponse
+	err = res.GetResult(&acr)
+	if err != nil {
+		return nil, err
+	}
+	return &acr, nil
+}
+
+// Channel queries
+
+func (c *Client) GetChannelVerify(req *channel.VerifyRequest) (*channel.VerifyResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var acr channel.VerifyResponse
+	err = res.GetResult(&acr)
+	if err != nil {
+		return nil, err
+	}
+	return &acr, nil
+}
+
+// Ledger queries
+
 // Returns the index of the most recently validated ledger.
 func (c *Client) GetLedgerIndex() (common.LedgerIndex, error) {
 	res, err := c.Request(&ledger.Request{
@@ -92,6 +167,168 @@ func (c *Client) GetLedgerIndex() (common.LedgerIndex, error) {
 	return lr.LedgerIndex, err
 }
 
+func (c *Client) GetClosedLedger() (*ledger.ClosedResponse, error) {
+	res, err := c.Request(&ledger.ClosedRequest{})
+	if err != nil {
+		return nil, err
+	}
+	var lr ledger.ClosedResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetCurrentLedger() (*ledger.CurrentResponse, error) {
+	res, err := c.Request(&ledger.CurrentRequest{})
+	if err != nil {
+		return nil, err
+	}
+	var lr ledger.CurrentResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetLedgerData(req *ledger.DataRequest) (*ledger.DataResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr ledger.DataResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetLedger(req *ledger.Request) (*ledger.Response, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr ledger.Response
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// NFT queries
+
+func (c *Client) GetNFTBuyOffers(req *nft.NFTokenBuyOffersRequest) (*nft.NFTokenBuyOffersResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr nft.NFTokenBuyOffersResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetNFTSellOffers(req *nft.NFTokenSellOffersRequest) (*nft.NFTokenSellOffersResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr nft.NFTokenSellOffersResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// Path queries
+
+func (c *Client) GetBookOffers(req *path.BookOffersRequest) (*path.BookOffersResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.BookOffersResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetDepositAuthorized(req *path.DepositAuthorizedRequest) (*path.DepositAuthorizedResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.DepositAuthorizedResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) FindPathCreate(req *path.FindCreateRequest) (*path.FindResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.FindResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) FindPathClose(req *path.FindCloseRequest) (*path.FindResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.FindResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) FindPathStatus(req *path.FindStatusRequest) (*path.FindResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.FindResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetRipplePathFind(req *path.RipplePathFindRequest) (*path.RipplePathFindResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr path.RipplePathFindResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// Server queries
+
 // GetServerInfo retrieves information about the server.
 // It takes a ServerInfoRequest as input and returns a ServerInfoResponse,
 // along with any error encountered.
@@ -106,4 +343,97 @@ func (c *Client) GetServerInfo(req *server.InfoRequest) (*server.InfoResponse, e
 		return nil, err
 	}
 	return &sir, err
+}
+
+func (c *Client) GetAllFeatures(req *server.FeatureAllRequest) (*server.FeatureAllResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr server.FeatureAllResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetFeature(req *server.FeatureOneRequest) (*server.FeatureResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr server.FeatureResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetFee(req *server.FeeRequest) (*server.FeeResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr server.FeeResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetManifest(req *server.ManifestRequest) (*server.ManifestResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr server.ManifestResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetServerState(req *server.StateRequest) (*server.StateResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr server.StateResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// Utility queries
+
+func (c *Client) Ping(req *utility.PingRequest) (*utility.PingResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr utility.PingResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+func (c *Client) GetRandom(req *utility.RandomRequest) (*utility.RandomResponse, error) {
+	res, err := c.Request(req)
+	if err != nil {
+		return nil, err
+	}
+	var lr utility.RandomResponse
+	err = res.GetResult(&lr)
+	if err != nil {
+		return nil, err
+	}
+	return &lr, nil
 }

--- a/xrpl/websocket/queries_test.go
+++ b/xrpl/websocket/queries_test.go
@@ -8,14 +8,24 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
 	accounttypes "github.com/Peersyst/xrpl-go/xrpl/queries/account/types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/channel"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	ledgerqueries "github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
+	ledgertypes "github.com/Peersyst/xrpl-go/xrpl/queries/ledger/types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/nft"
+	nfttypes "github.com/Peersyst/xrpl-go/xrpl/queries/nft/types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/path"
+	pathtypes "github.com/Peersyst/xrpl-go/xrpl/queries/path/types"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/server"
 	servertypes "github.com/Peersyst/xrpl-go/xrpl/queries/server/types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/utility"
+	transaction "github.com/Peersyst/xrpl-go/xrpl/transaction"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/Peersyst/xrpl-go/xrpl/websocket/testutil"
 	"github.com/gorilla/websocket"
 )
 
-func TestWebsocketClient_GetServerInfo(t *testing.T) {
+func TestClient_GetServerInfo(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -108,7 +118,7 @@ func TestWebsocketClient_GetServerInfo(t *testing.T) {
 	}
 }
 
-func TestGetAccountInfo(t *testing.T) {
+func TestClient_GetAccountInfo(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -204,7 +214,7 @@ func TestGetAccountInfo(t *testing.T) {
 	}
 }
 
-func TestGetAccountObjects(t *testing.T) {
+func TestClient_GetAccountObjects(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -305,7 +315,7 @@ func TestGetAccountObjects(t *testing.T) {
 	}
 }
 
-func TestGetXrpBalance(t *testing.T) {
+func TestClient_GetXrpBalance(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -380,7 +390,7 @@ func TestGetXrpBalance(t *testing.T) {
 	}
 }
 
-func TestGetAccountLines(t *testing.T) {
+func TestClient_GetAccountLines(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -472,7 +482,7 @@ func TestGetAccountLines(t *testing.T) {
 	}
 }
 
-func TestGetLedgerIndex(t *testing.T) {
+func TestClient_GetLedgerIndex(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverMessages []map[string]any
@@ -524,6 +534,2253 @@ func TestGetLedgerIndex(t *testing.T) {
 			}
 
 			result, err := cl.GetLedgerIndex()
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetAccountNFTs(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *account.NFTsResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+					"account_nfts": []map[string]any{
+						{
+							"Flags":        3,
+							"Issuer":       "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+							"NFTokenID":    "00081388DC5AA8D5F45498ED961B89E0C69E5846E2F22B68845F76A79",
+							"NFTokenTaxon": 0,
+							"URI":          "697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469",
+							"nft_serial":   15,
+						},
+					},
+					"ledger_index": 14380380,
+					"validated":    true,
+				},
+			}},
+			expected: &account.NFTsResponse{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+				AccountNFTs: []accounttypes.NFT{
+					{
+						Flags:        3,
+						Issuer:       "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+						NFTokenID:    "00081388DC5AA8D5F45498ED961B89E0C69E5846E2F22B68845F76A79",
+						NFTokenTaxon: 0,
+						URI:          "697066733A2F2F62616679626569676479727A74357366703775646D37687537367568377932366E6634646675796C71616266336F636C67747179353566627A6469",
+						NFTSerial:    15,
+					},
+				},
+				LedgerIndex: 14380380,
+				Validated:   true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Account not found"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetAccountNFTs(&account.NFTsRequest{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+			})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetAccountCurrencies(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *account.CurrenciesResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"ledger_index":       14380380,
+					"receive_currencies": []string{"USD", "EUR"},
+					"send_currencies":    []string{"USD", "JPY"},
+					"validated":          true,
+				},
+			}},
+			expected: &account.CurrenciesResponse{
+				LedgerIndex:       14380380,
+				ReceiveCurrencies: []string{"USD", "EUR"},
+				SendCurrencies:    []string{"USD", "JPY"},
+				Validated:         true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Account not found"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetAccountCurrencies(&account.CurrenciesRequest{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+			})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetAccountOffers(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *account.OffersResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+					"offers": []map[string]any{
+						{
+							"flags":      float64(0),
+							"seq":        float64(1337),
+							"taker_gets": "100000000",
+							"taker_pays": map[string]any{
+								"currency": "USD",
+								"issuer":   "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+								"value":    "100",
+							},
+						},
+					},
+					"ledger_current_index": float64(14380380),
+				},
+			}},
+			expected: &account.OffersResponse{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+				Offers: []accounttypes.OfferResult{
+					{
+						Flags:     0,
+						Sequence:  1337,
+						TakerGets: "100000000",
+						TakerPays: map[string]any{
+							"currency": "USD",
+							"issuer":   "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+							"value":    "100",
+						},
+					},
+				},
+				LedgerCurrentIndex: 14380380,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Account not found"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetAccountOffers(&account.OffersRequest{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+			})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetAccountTransactions(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *account.TransactionsResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+					"transactions": []map[string]any{
+						{
+							"tx": map[string]any{
+								"Account":         "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+								"Fee":             "10",
+								"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+								"TransactionType": "Payment",
+								"TxnSignature":    "304402...",
+							},
+							"validated": true,
+						},
+					},
+					"ledger_index_min": uint32(14380380),
+					"ledger_index_max": uint32(14380381),
+				},
+			}},
+			expected: &account.TransactionsResponse{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+				Transactions: []account.Transaction{
+					{
+						Tx: transaction.FlatTransaction{
+							"Account":         "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+							"Fee":             "10",
+							"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+							"TransactionType": "Payment",
+							"TxnSignature":    "304402...",
+						},
+						Validated: true,
+					},
+				},
+				LedgerIndexMin: 14380380,
+				LedgerIndexMax: 14380381,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Account not found"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetAccountTransactions(&account.TransactionsRequest{
+				Account: "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+			})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetChannelVerify(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *channel.VerifyResponse
+		expectedErr    error
+	}{
+		{
+			name: "Valid channel verify",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"signature_verified": true,
+					},
+				},
+			},
+			expected: &channel.VerifyResponse{
+				SignatureVerified: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetChannelVerify(&channel.VerifyRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetClosedLedger(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *ledgerqueries.ClosedResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"ledger_hash":  "ABC123",
+					"ledger_index": uint32(14380380),
+				},
+			}},
+			expected: &ledgerqueries.ClosedResponse{
+				LedgerHash:  "ABC123",
+				LedgerIndex: 14380380,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetClosedLedger()
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetCurrentLedger(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *ledgerqueries.CurrentResponse
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"ledger_current_index": uint32(14380380),
+				},
+			}},
+			expected: &ledgerqueries.CurrentResponse{
+				LedgerCurrentIndex: 14380380,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetCurrentLedger()
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetLedgerData(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *ledgerqueries.DataResponse
+		expectedErr    error
+	}{
+		{
+			name: "Valid ledger data",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"ledger_hash":  "abc123",
+						"ledger_index": "123",
+						"state": []map[string]any{
+							{
+								"data":  "1100612200000000000000000000000000000000",
+								"index": "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+							},
+						},
+					},
+				},
+			},
+			expected: &ledgerqueries.DataResponse{
+				LedgerHash:  "abc123",
+				LedgerIndex: "123",
+				State: []ledgertypes.State{
+					{
+						Data:  "1100612200000000000000000000000000000000",
+						Index: "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetLedgerData(&ledgerqueries.DataRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetLedger(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *ledgerqueries.Response
+		expectedErr    error
+	}{
+		{
+			name: "Successful response",
+			serverMessages: []map[string]any{{
+				"id": 1,
+				"result": map[string]any{
+					"ledger": map[string]any{
+						"ledger_index":          "14380380",
+						"total_coins":           "99999999999999997",
+						"parent_hash":           "ABC123",
+						"transaction_hash":      "DEF456",
+						"account_hash":          "GHI789",
+						"parent_close_time":     uint32(123456),
+						"close_time":            uint32(123457),
+						"close_time_human":      "2023-Aug-01 12:34:56.789",
+						"close_time_resolution": uint32(10),
+						"closed":                true,
+					},
+				},
+			}},
+			expected: &ledgerqueries.Response{
+				Ledger: ledgertypes.BaseLedger{
+					LedgerIndex:         "14380380",
+					TotalCoins:          types.XRPCurrencyAmount(99999999999999997),
+					ParentHash:          "ABC123",
+					TransactionHash:     "DEF456",
+					AccountHash:         "GHI789",
+					ParentCloseTime:     123456,
+					CloseTime:           123457,
+					CloseTimeHuman:      "2023-Aug-01 12:34:56.789",
+					CloseTimeResolution: 10,
+					Closed:              true,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetLedger(&ledgerqueries.Request{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetNFTBuyOffers(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *nft.NFTokenBuyOffersResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"nft_id": "123",
+						"offers": []map[string]any{
+							{
+								"owner":           "r456",
+								"amount":          "100",
+								"flags":           uint32(1),
+								"nft_offer_index": "123",
+							},
+						},
+					},
+				},
+			},
+			expected: &nft.NFTokenBuyOffersResponse{
+				NFTokenID: "123",
+				Offers: []nfttypes.NFTokenOffer{
+					{
+						Amount:            "100",
+						Flags:             1,
+						NFTokenOfferIndex: "123",
+						Owner:             "r456",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":    2,
+					"error": "incorrect id",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetNFTBuyOffers(&nft.NFTokenBuyOffersRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetNFTSellOffers(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *nft.NFTokenSellOffersResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"nft_id": "123",
+						"offers": []map[string]any{
+							{
+								"owner":           "r456",
+								"amount":          "100",
+								"flags":           uint32(1),
+								"nft_offer_index": "123",
+							},
+						},
+					},
+				},
+			},
+			expected: &nft.NFTokenSellOffersResponse{
+				NFTokenID: "123",
+				Offers: []nfttypes.NFTokenOffer{
+					{
+						Amount:            "100",
+						Flags:             1,
+						NFTokenOfferIndex: "123",
+						Owner:             "r456",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":    2,
+					"error": "incorrect id",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetNFTSellOffers(&nft.NFTokenSellOffersRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetBookOffers(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.BookOffersResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"ledger_current_index": uint32(123),
+						"ledger_index":         uint32(123),
+						"ledger_hash":          "123",
+						"offers": []map[string]any{
+							{
+								"owner_funds":       "100",
+								"taker_gets_funded": "100",
+								"taker_pays_funded": "100",
+								"quality":           "100",
+							},
+						},
+						"validated": true,
+					},
+				},
+			},
+			expected: &path.BookOffersResponse{
+				LedgerCurrentIndex: 123,
+				LedgerIndex:        123,
+				LedgerHash:         "123",
+				Offers: []pathtypes.BookOffer{
+					{
+						OwnerFunds:      "100",
+						TakerGetsFunded: "100",
+						TakerPaysFunded: "100",
+						Quality:         "100",
+					},
+				},
+				Validated: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":    2,
+					"error": "incorrect id",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetBookOffers(&path.BookOffersRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetDepositAuthorized(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.DepositAuthorizedResponse
+		expectedErr    error
+	}{
+		{
+			name: "Valid deposit authorized response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"deposit_authorized":   true,
+						"destination_account":  "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+						"ledger_current_index": uint32(70825689),
+						"source_account":       "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+						"validated":            true,
+					},
+				},
+			},
+			expected: &path.DepositAuthorizedResponse{
+				DepositAuthorized:  true,
+				DestinationAccount: "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+				LedgerCurrentIndex: 70825689,
+				SourceAccount:      "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+				Validated:          true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Error response",
+			serverMessages: []map[string]any{{"error": "Server error"}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetDepositAuthorized(&path.DepositAuthorizedRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_FindPathCreate(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.FindResponse
+		expectedErr    error
+	}{
+		{
+			name: "Valid path find",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"alternatives": []map[string]any{
+							{
+								"paths_computed": [][]map[string]any{
+									{
+										{
+											"currency": "USD",
+											"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+											"account":  "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+										},
+									},
+								},
+								"source_amount": "100000",
+							},
+						},
+						"destination_account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						"destination_amount":  "100",
+						"source_account":      "rLHmBn4fT93D1NuWEGNxnYvhvGxzPVVJ5C",
+					},
+				},
+			},
+			expected: &path.FindResponse{
+				Alternatives: []pathtypes.Alternative{
+					{
+						PathsComputed: [][]transaction.PathStep{
+							{
+								{
+									Currency: "USD",
+									Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									Account:  "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+								},
+							},
+						},
+						SourceAmount: "100000",
+					},
+				},
+				DestinationAccount: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+				DestinationAmount:  "100",
+				SourceAccount:      "rLHmBn4fT93D1NuWEGNxnYvhvGxzPVVJ5C",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:           "Invalid ID",
+			serverMessages: []map[string]any{{"id": 2, "result": map[string]any{}}},
+			expected:       nil,
+			expectedErr:    errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.FindPathCreate(&path.FindCreateRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_FindPathClose(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.FindResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful path close",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"alternatives":        []map[string]any{},
+						"destination_account": "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+						"destination_amount":  "100",
+						"source_account":      "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+						"full_reply":          true,
+						"closed":              true,
+						"status":              true,
+					},
+				},
+			},
+			expected: &path.FindResponse{
+				Alternatives:       []pathtypes.Alternative{},
+				DestinationAccount: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+				DestinationAmount:  "100",
+				SourceAccount:      "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				FullReply:          true,
+				Closed:             true,
+				Status:             true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":    2,
+					"error": "incorrect id",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.FindPathClose(&path.FindCloseRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_FindPathStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.FindResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful path status request",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"alternatives": []map[string]any{
+							{
+								"paths_computed": [][]map[string]any{
+									{
+										{"currency": "USD", "issuer": "rXXXXXXXXXXXXXXXXXXXXX"},
+									},
+								},
+								"source_amount": "100",
+							},
+						},
+						"destination_account": "rXXXXXXXXXXXXXXXXXXXXX",
+						"destination_amount":  "100",
+						"source_account":      "rYYYYYYYYYYYYYYYYYYYYY",
+						"full_reply":          true,
+						"status":              true,
+					},
+				},
+			},
+			expected: &path.FindResponse{
+				Alternatives: []pathtypes.Alternative{
+					{
+						PathsComputed: [][]transaction.PathStep{
+							{
+								{Currency: "USD", Issuer: "rXXXXXXXXXXXXXXXXXXXXX"},
+							},
+						},
+						SourceAmount: "100",
+					},
+				},
+				DestinationAccount: "rXXXXXXXXXXXXXXXXXXXXX",
+				DestinationAmount:  "100",
+				SourceAccount:      "rYYYYYYYYYYYYYYYYYYYYY",
+				FullReply:          true,
+				Status:             true,
+			},
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":    1,
+					"error": "incorrect id",
+				},
+			},
+			expectedErr: errors.New("incorrect id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.FindPathStatus(&path.FindStatusRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetRipplePathFind(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *path.RipplePathFindResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"alternatives": []map[string]any{
+							{
+								"paths_computed": [][]map[string]any{
+									{
+										{
+											"account":  "rMAZ5ZnK73nyNUL4foAvaxdreczCkG3vA6",
+											"currency": "USD",
+											"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+										},
+									},
+								},
+								"source_amount": "100",
+							},
+						},
+						"destination_account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						"source_account":      "rMAZ5ZnK73nyNUL4foAvaxdreczCkG3vA6",
+					},
+				},
+			},
+			expected: &path.RipplePathFindResponse{
+				Alternatives: []pathtypes.RippleAlternative{
+					{
+						PathsComputed: [][]transaction.PathStep{
+							{
+								{
+									Account:  "rMAZ5ZnK73nyNUL4foAvaxdreczCkG3vA6",
+									Currency: "USD",
+									Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+								},
+							},
+						},
+						SourceAmount: "100",
+					},
+				},
+				DestinationAccount: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+				SourceAccount:      "rMAZ5ZnK73nyNUL4foAvaxdreczCkG3vA6",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetRipplePathFind(&path.RipplePathFindRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetAllFeatures(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *server.FeatureAllResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"features": map[string]any{
+							"MultiSign": map[string]any{
+								"enabled":   true,
+								"name":      "Multi-Signing",
+								"supported": true,
+								"vetoed":    false,
+							},
+						},
+					},
+					"status": "success",
+					"type":   "response",
+				},
+			},
+			expected: &server.FeatureAllResponse{
+				Features: map[string]servertypes.FeatureStatus{
+					"MultiSign": {
+						Enabled:   true,
+						Name:      "Multi-Signing",
+						Supported: true,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"status": "error",
+					"error":  "invalidParams",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetAllFeatures(&server.FeatureAllRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetFeature(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *server.FeatureResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"testFeature": map[string]any{
+							"enabled":   true,
+							"name":      "Test Feature",
+							"supported": true,
+						},
+					},
+					"status": "success",
+					"type":   "response",
+				},
+			},
+			expected: &server.FeatureResponse{
+				"testFeature": {
+					Enabled:   true,
+					Name:      "Test Feature",
+					Supported: true,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"error":  "invalidParams",
+					"status": "error",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetFeature(&server.FeatureOneRequest{Feature: "testFeature"})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetFee(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *server.FeeResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"current_ledger_size": "14",
+						"current_queue_size":  "20",
+						"drops": map[string]any{
+							"base_fee":        "10",
+							"median_fee":      "10000",
+							"minimum_fee":     "10",
+							"open_ledger_fee": "10",
+						},
+						"expected_ledger_size": "30",
+						"ledger_current_index": uint32(1),
+						"levels": map[string]any{
+							"median_level":      "128000",
+							"minimum_level":     "256",
+							"open_ledger_level": "256",
+							"reference_level":   "256",
+						},
+						"max_queue_size": "20",
+						"status":         "success",
+					},
+				},
+			},
+			expected: &server.FeeResponse{
+				CurrentLedgerSize:  "14",
+				CurrentQueueSize:   "20",
+				ExpectedLedgerSize: "30",
+				LedgerCurrentIndex: 1,
+				MaxQueueSize:       "20",
+				Drops: servertypes.FeeDrops{
+					BaseFee:       types.XRPCurrencyAmount(10),
+					MedianFee:     types.XRPCurrencyAmount(10000),
+					MinimumFee:    types.XRPCurrencyAmount(10),
+					OpenLedgerFee: types.XRPCurrencyAmount(10),
+				},
+				Levels: servertypes.FeeLevels{
+					MedianLevel:     types.XRPCurrencyAmount(128000),
+					MinimumLevel:    types.XRPCurrencyAmount(256),
+					OpenLedgerLevel: types.XRPCurrencyAmount(256),
+					ReferenceLevel:  types.XRPCurrencyAmount(256),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"error":  "invalidParams",
+					"status": "error",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetFee(&server.FeeRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetManifest(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *server.ManifestResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"status": "success",
+					"type":   "response",
+					"result": map[string]any{
+						"details": map[string]any{
+							"domain":        "example.com",
+							"ephemeral_key": "nHUFE9prPXPrHcG3SkwP1UzAQbSphqyQkQK9ATXLZsfkezhhda3p",
+							"master_key":    "nHUFE9prPXPrHcG3SkwP1UzAQbSphqyQkQK9ATXLZsfkezhhda3p",
+							"seq":           1,
+						},
+						"manifest":  "manifest",
+						"requested": "manifest",
+					},
+				},
+			},
+			expected: &server.ManifestResponse{
+				Details: server.ManifestDetails{
+					Domain:       "example.com",
+					EphemeralKey: "nHUFE9prPXPrHcG3SkwP1UzAQbSphqyQkQK9ATXLZsfkezhhda3p",
+					MasterKey:    "nHUFE9prPXPrHcG3SkwP1UzAQbSphqyQkQK9ATXLZsfkezhhda3p",
+					Seq:          1,
+				},
+				Manifest:  "manifest",
+				Requested: "manifest",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"status": "error",
+					"type":   "response",
+					"error":  "invalidParams",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetManifest(&server.ManifestRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetServerState(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *server.StateResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful response",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"state": map[string]any{
+							"build_version":    "1.9.4",
+							"complete_ledgers": "32570-6595042",
+							"io_latency_ms":    1,
+							"last_close": map[string]any{
+								"converge_time": 2,
+								"proposers":     4,
+							},
+							"load_factor":  1,
+							"peers":        21,
+							"pubkey_node":  "n9KwwpYCU3ctereLW9S48fKjK4rcsvYbHmjgiRXkgWReQR9nDjCw",
+							"server_state": "proposing",
+							"validated_ledger": map[string]any{
+								"close_time": 638329271,
+								"hash":       "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
+								"seq":        6595042,
+							},
+							"validation_quorum": 4,
+						},
+					},
+				},
+			},
+			expected: &server.StateResponse{
+				State: servertypes.State{
+					BuildVersion:     "1.9.4",
+					CompleteLedgers:  "32570-6595042",
+					IOLatencyMS:      1,
+					LastClose:        servertypes.CloseState{ConvergeTime: 2, Proposers: 4},
+					LoadFactor:       1,
+					Peers:            21,
+					PubkeyNode:       "n9KwwpYCU3ctereLW9S48fKjK4rcsvYbHmjgiRXkgWReQR9nDjCw",
+					ServerState:      "proposing",
+					ValidationQuorum: 4,
+					ValidatedLedger: servertypes.LedgerState{
+						CloseTime: 638329271,
+						Hash:      "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
+						Seq:       6595042,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"error":  "invalidParams",
+					"status": "error",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetServerState(&server.StateRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_Ping(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *utility.PingResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful ping",
+			serverMessages: []map[string]any{
+				{
+					"id": 1,
+					"result": map[string]any{
+						"role":      "full",
+						"unlimited": true,
+					},
+				},
+			},
+			expected:    &utility.PingResponse{Role: "full", Unlimited: true},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"error":  "invalidParams",
+					"status": "error",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.Ping(&utility.PingRequest{})
+
+			if tt.expectedErr != nil {
+				if err == nil || err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error %v, but got %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("Expected %+v, but got %+v", tt.expected, result)
+			}
+
+			cl.Disconnect()
+		})
+	}
+}
+
+func TestClient_GetRandom(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverMessages []map[string]any
+		expected       *utility.RandomResponse
+		expectedErr    error
+	}{
+		{
+			name: "successful random",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"result": map[string]any{"random": "123ABC"},
+				},
+			},
+			expected:    &utility.RandomResponse{Random: "123ABC"},
+			expectedErr: nil,
+		},
+		{
+			name: "error response",
+			serverMessages: []map[string]any{
+				{
+					"id":     1,
+					"error":  "invalidParams",
+					"status": "error",
+					"type":   "response",
+				},
+			},
+			expected:    nil,
+			expectedErr: errors.New("invalidParams"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					err := c.WriteJSON(m)
+					if err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := &Client{
+				cfg: ClientConfig{
+					host: url,
+				},
+			}
+
+			if err := cl.Connect(); err != nil {
+				t.Errorf("Error connecting to server: %v", err)
+			}
+
+			result, err := cl.GetRandom(&utility.RandomRequest{})
 
 			if tt.expectedErr != nil {
 				if err == nil || err.Error() != tt.expectedErr.Error() {


### PR DESCRIPTION
# [TA-3644]: add ws client queries

This PR aims to expose a query API for the websocket client, enhancing the developer experience.

## Changes

- Added query methods to ws client
- Refactored types due to queries response unmarshalling
