### PR TITLE
fix network id key in BaseTx's Flatten() method

### DIFF
--- a/xrpl/transaction/tx.go
+++ b/xrpl/transaction/tx.go
@@ -137,7 +137,7 @@ func (tx *BaseTx) Flatten() FlatTransaction {
 		flattened["Memos"] = flattenedMemos
 	}
 	if tx.NetworkID != 0 {
-		flattened["NetworkId"] = tx.NetworkID
+		flattened["NetworkID"] = tx.NetworkID
 	}
 	if len(tx.Signers) > 0 {
 		flattenedSigners := make([]interface{}, len(tx.Signers))

--- a/xrpl/transaction/tx_test.go
+++ b/xrpl/transaction/tx_test.go
@@ -207,7 +207,7 @@ func TestBaseTx_Flatten(t *testing.T) {
 						}
 					}
 				],
-				"NetworkId": 1,
+				"NetworkID": 1,
 				"Signers": [
 					{
 						"Signer": {


### PR DESCRIPTION
# Title
fix network id key in BaseTx's Flatten() method

## Description
This PR fixes the network id key used in BaseTx's Flatten() method. The previous key would not be validated, caught in the the Autofill method, nor serialized. Workaround is to set the network id in the client.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Change "NetworkId" to "NetworkID"

