### PR TITLE
Fix: X-Address handling for AccountID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0]
+## [v0.1.1]
+
+### Added
+
+#### address-codec
+
+- New `ErrInvalidAddressFormat` error.
+
+### Fixed
+
+#### binary-codec
+
+- Fixed `AccountID` X-Address decoding/encoding support.
+
+#### xrpl
+
+- Replace `IsValidClassicAddress` with `IsValidAddress` on transactions `Validate` methods:
+  - `AccountDelete`
+  - `AMMBid`
+  - `DepositPreauth`
+  - `EscrowCancel`
+  - `EscrowFinish`
+  - `EscrowCancel`
+  - `NFTokenBurn`
+  - `NFTokenCreateOffer`
+  - `NFTokenMint`
+  - `NFTokenOffer`
+  - `Payment`
+  - `PaymentChannelCreate`
+  - `SetRegularKey`
+  - `SignerListSet`
+  - `BaseTx`
+  - `XChainBridge`
+  - `XChainAccountCreateCommit`
+  - `XChainAddAccountCreateAttestation`
+  - `XChainAddClaimAttestation`
+  - `XChainClaim`
+  - `XChainCreateClaimID`
+- Master address derivation on wallet `FromSeed` function.
+
+## [v0.1.0]
 
 ### Added
 

--- a/address-codec/errors.go
+++ b/address-codec/errors.go
@@ -21,7 +21,7 @@ var (
 	ErrInvalidAccountID = errors.New("invalid accountId")
 
 	// Invalid xrpl address, general error
-	ErrInvalidXrplAddress = errors.New("invalid xrpl address")
+	ErrInvalidAddressFormat = errors.New("invalid address format")
 
 	// ErrChecksum indicates that the checksum of a check-encoded string does not verify against
 	// the checksum.

--- a/address-codec/errors.go
+++ b/address-codec/errors.go
@@ -20,6 +20,9 @@ var (
 	// Invalid accountId
 	ErrInvalidAccountID = errors.New("invalid accountId")
 
+	// Invalid xrpl address, general error
+	ErrInvalidXrplAddress = errors.New("invalid xrpl address")
+
 	// ErrChecksum indicates that the checksum of a check-encoded string does not verify against
 	// the checksum.
 	ErrChecksum = errors.New("checksum error")

--- a/binary-codec/types/account_id.go
+++ b/binary-codec/types/account_id.go
@@ -41,7 +41,7 @@ func (a *AccountID) FromJSON(value any) ([]byte, error) {
 		return accountID, nil
 
 	default:
-		return nil, addresscodec.ErrInvalidXrplAddress
+		return nil, addresscodec.ErrInvalidAddressFormat
 	}
 }
 

--- a/binary-codec/types/account_id_test.go
+++ b/binary-codec/types/account_id_test.go
@@ -64,7 +64,7 @@ func TestAccountID_FromJson(t *testing.T) {
 			name:        "Invalid XRPL address",
 			input:       "abcde",
 			expected:    nil,
-			expectedErr: addresscodec.ErrInvalidXrplAddress,
+			expectedErr: addresscodec.ErrInvalidAddressFormat,
 		},
 		{
 			name:        "Invalid input type",

--- a/binary-codec/types/account_id_test.go
+++ b/binary-codec/types/account_id_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccountID_FromJson(t *testing.T) {
 	tt := []struct {
 		name        string
-		input       string
+		input       any
 		expected    []byte
 		expectedErr error
 	}{
@@ -33,6 +33,44 @@ func TestAccountID_FromJson(t *testing.T) {
 			input:       "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p2",
 			expected:    nil,
 			expectedErr: addresscodec.ErrInvalidClassicAddress,
+		},
+		{
+			name:  "Valid AccountID with XAddress",
+			input: "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5Pesju", // rLJ9FwQ3opJZBMsTjhqhHrbhRNALqAQJ5U
+			expected: []byte{
+				211, 168, 209, 109, 176,
+				55, 12, 60, 93, 57, 103,
+				89, 62, 51, 191, 128,
+				222, 149, 106, 66},
+			expectedErr: nil,
+		},
+		{
+			name:  "Valid AccountID with XAddress and tag",
+			input: "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7kXKTG5X57UCKzEwYx", // rLJ9FwQ3opJZBMsTjhqhHrbhRNALqAQJ5U:12345
+			expected: []byte{
+				211, 168, 209, 109, 176,
+				55, 12, 60, 93, 57, 103,
+				89, 62, 51, 191, 128,
+				222, 149, 106, 66},
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid AccountID with invalid XAddress",
+			input:       "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5PesjuA",
+			expected:    nil,
+			expectedErr: addresscodec.ErrInvalidXAddress,
+		},
+		{
+			name:        "Invalid XRPL address",
+			input:       "abcde",
+			expected:    nil,
+			expectedErr: addresscodec.ErrInvalidXrplAddress,
+		},
+		{
+			name:        "Invalid input type",
+			input:       1, // should be a string
+			expected:    nil,
+			expectedErr: errors.New("expected a string but got int"),
 		},
 	}
 

--- a/examples/multisigning/rpc/main.go
+++ b/examples/multisigning/rpc/main.go
@@ -84,6 +84,12 @@ func main() {
 					SignerWeight: 1,
 				},
 			},
+			{
+				SignerEntry: ledger.SignerEntry{
+					Account:      "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5Pesju",
+					SignerWeight: 1,
+				},
+			},
 		},
 	}
 

--- a/examples/multisigning/ws/main.go
+++ b/examples/multisigning/ws/main.go
@@ -95,22 +95,32 @@ func main() {
 					SignerWeight: 1,
 				},
 			},
+			{
+				SignerEntry: ledger.SignerEntry{
+					Account:      "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5Pesju",
+					SignerWeight: 1,
+				},
+			},
 		},
 	}
 
+	fmt.Println("⏳ Flattening transaction...")
 	flatSs := ss.Flatten()
 
+	fmt.Println("⏳ Autofilling transaction...")
 	if err := client.Autofill(&flatSs); err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	fmt.Println("⏳ Signing transaction...")
 	blob, _, err := master.Sign(flatSs)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	fmt.Println("⏳ Submitting transaction...")
 	res, err := client.SubmitAndWait(blob, false)
 	if err != nil {
 		fmt.Println(err)

--- a/xrpl/transaction/account_delete.go
+++ b/xrpl/transaction/account_delete.go
@@ -59,7 +59,7 @@ func (s *AccountDelete) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(s.Destination.String()) {
+	if !addresscodec.IsValidAddress(s.Destination.String()) {
 		return false, ErrInvalidDestinationAddress
 	}
 

--- a/xrpl/transaction/amm_bid.go
+++ b/xrpl/transaction/amm_bid.go
@@ -145,7 +145,7 @@ func validateAuthAccounts(authAccounts []ledger.AuthAccounts) (bool, error) {
 	}
 
 	for _, authAccounts := range authAccounts {
-		if ok := addresscodec.IsValidClassicAddress(authAccounts.AuthAccount.Account.String()); !ok {
+		if ok := addresscodec.IsValidAddress(authAccounts.AuthAccount.Account.String()); !ok {
 			return false, ErrInvalidAccount
 		}
 	}

--- a/xrpl/transaction/deposit_preauth.go
+++ b/xrpl/transaction/deposit_preauth.go
@@ -87,11 +87,11 @@ func (s *DepositPreauth) Validate() (bool, error) {
 		return false, ErrDepositPreauthUnauthorizeCannotBeSender
 	}
 
-	if s.Authorize != "" && !addresscodec.IsValidClassicAddress(s.Authorize.String()) {
+	if s.Authorize != "" && !addresscodec.IsValidAddress(s.Authorize.String()) {
 		return false, ErrDepositPreauthInvalidAuthorize
 	}
 
-	if s.Unauthorize != "" && !addresscodec.IsValidClassicAddress(s.Unauthorize.String()) {
+	if s.Unauthorize != "" && !addresscodec.IsValidAddress(s.Unauthorize.String()) {
 		return false, ErrDepositPreauthInvalidUnauthorize
 	}
 

--- a/xrpl/transaction/escrow_cancel.go
+++ b/xrpl/transaction/escrow_cancel.go
@@ -63,7 +63,7 @@ func (e *EscrowCancel) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(e.Owner.String()) {
+	if !addresscodec.IsValidAddress(e.Owner.String()) {
 		return false, ErrEscrowCancelMissingOwner
 	}
 

--- a/xrpl/transaction/escrow_create.go
+++ b/xrpl/transaction/escrow_create.go
@@ -87,7 +87,7 @@ func (e *EscrowCreate) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(e.Destination.String()) {
+	if !addresscodec.IsValidAddress(e.Destination.String()) {
 		return false, ErrInvalidDestinationAddress
 	}
 

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -77,7 +77,7 @@ func (e *EscrowFinish) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(e.Owner.String()) {
+	if !addresscodec.IsValidAddress(e.Owner.String()) {
 		return false, ErrEscrowFinishMissingOwner
 	}
 

--- a/xrpl/transaction/nftoken_burn.go
+++ b/xrpl/transaction/nftoken_burn.go
@@ -72,7 +72,7 @@ func (n *NFTokenBurn) Validate() (bool, error) {
 	}
 
 	// check owner is a valid xrpl address
-	if n.Owner != "" && !addresscodec.IsValidClassicAddress(n.Owner.String()) {
+	if n.Owner != "" && !addresscodec.IsValidAddress(n.Owner.String()) {
 		return false, ErrInvalidOwner
 	}
 

--- a/xrpl/transaction/nftoken_create_offer.go
+++ b/xrpl/transaction/nftoken_create_offer.go
@@ -115,12 +115,12 @@ func (n *NFTokenCreateOffer) Validate() (bool, error) {
 	}
 
 	// check owner is a valid xrpl address
-	if n.Owner != "" && !addresscodec.IsValidClassicAddress(n.Owner.String()) {
+	if n.Owner != "" && !addresscodec.IsValidAddress(n.Owner.String()) {
 		return false, ErrInvalidOwner
 	}
 
 	// check destination is a valid xrpl address
-	if n.Destination != "" && !addresscodec.IsValidClassicAddress(n.Destination.String()) {
+	if n.Destination != "" && !addresscodec.IsValidAddress(n.Destination.String()) {
 		return false, ErrInvalidDestination
 	}
 

--- a/xrpl/transaction/nftoken_mint.go
+++ b/xrpl/transaction/nftoken_mint.go
@@ -151,7 +151,7 @@ func (n *NFTokenMint) Validate() (bool, error) {
 	}
 
 	// check issuer is a valid xrpl address
-	if n.Issuer != "" && !addresscodec.IsValidClassicAddress(n.Issuer.String()) {
+	if n.Issuer != "" && !addresscodec.IsValidAddress(n.Issuer.String()) {
 		return false, ErrInvalidIssuer
 	}
 

--- a/xrpl/transaction/payment.go
+++ b/xrpl/transaction/payment.go
@@ -170,7 +170,7 @@ func (p *Payment) Validate() (bool, error) {
 	}
 
 	// Check if Destination is a valid xrpl address
-	if !addresscodec.IsValidClassicAddress(p.Destination.String()) {
+	if !addresscodec.IsValidAddress(p.Destination.String()) {
 		return false, ErrInvalidDestination
 	}
 

--- a/xrpl/transaction/payment_channel_create.go
+++ b/xrpl/transaction/payment_channel_create.go
@@ -78,7 +78,7 @@ func (p *PaymentChannelCreate) Validate() (bool, error) {
 	}
 
 	// check valid xrpl address for Destination
-	if !addresscodec.IsValidClassicAddress(p.Destination.String()) {
+	if !addresscodec.IsValidAddress(p.Destination.String()) {
 		return false, ErrInvalidDestination
 	}
 

--- a/xrpl/transaction/set_regular_key.go
+++ b/xrpl/transaction/set_regular_key.go
@@ -68,7 +68,7 @@ func (s *SetRegularKey) Validate() (bool, error) {
 	}
 
 	// Check if the regular key is a valid xrpl address
-	if s.RegularKey != "" && !addresscodec.IsValidClassicAddress(s.RegularKey.String()) {
+	if s.RegularKey != "" && !addresscodec.IsValidAddress(s.RegularKey.String()) {
 		return false, ErrInvalidRegularKey
 	}
 

--- a/xrpl/transaction/set_regular_key_test.go
+++ b/xrpl/transaction/set_regular_key_test.go
@@ -77,6 +77,18 @@ func TestSetRegularKey_Validate(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name: "pass - valid SetRegularKey with X-address",
+			regularKey: &SetRegularKey{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: SetRegularKeyTx,
+				},
+				RegularKey: "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5Pesju",
+			},
+			wantValid: true,
+			wantErr:   false,
+		},
+		{
 			name: "fail - invalid SetRegularKey BaseTx",
 			regularKey: &SetRegularKey{
 				BaseTx: BaseTx{

--- a/xrpl/transaction/signer_list_set.go
+++ b/xrpl/transaction/signer_list_set.go
@@ -122,7 +122,7 @@ func (s *SignerListSet) Validate() (bool, error) {
 		}
 
 		// Check if Account is a valid xrpl address for each SignerEntry
-		if !addresscodec.IsValidClassicAddress(signerEntry.SignerEntry.Account.String()) {
+		if !addresscodec.IsValidAddress(signerEntry.SignerEntry.Account.String()) {
 			return false, ErrInvalidAccount
 		}
 	}

--- a/xrpl/transaction/signer_list_set_test.go
+++ b/xrpl/transaction/signer_list_set_test.go
@@ -148,6 +148,13 @@ func TestSignerListSet_Validate(t *testing.T) {
 							WalletLocator: types.Hash256(hex.EncodeToString([]byte("Ledger Nano"))),
 						},
 					},
+					{
+						SignerEntry: ledger.SignerEntry{
+							Account:       "XVYRdEocC28DRx94ZFGP3qNJ1D5Ln7ecXFMd3vREB5Pesju",
+							SignerWeight:  1,
+							WalletLocator: types.Hash256(hex.EncodeToString([]byte("Ledger Nano"))),
+						},
+					},
 				},
 			},
 			wantValid: true,

--- a/xrpl/transaction/tx.go
+++ b/xrpl/transaction/tx.go
@@ -165,7 +165,7 @@ func (tx *BaseTx) Flatten() FlatTransaction {
 func (tx *BaseTx) Validate() (bool, error) {
 	flattenTx := tx.Flatten()
 
-	if !addresscodec.IsValidClassicAddress(tx.Account.String()) {
+	if !addresscodec.IsValidAddress(tx.Account.String()) {
 		return false, ErrInvalidAccount
 	}
 

--- a/xrpl/transaction/types/xchain_bridge.go
+++ b/xrpl/transaction/types/xchain_bridge.go
@@ -40,16 +40,16 @@ func (x *XChainBridge) Flatten() FlatXChainBridge {
 }
 
 func (x *XChainBridge) Validate() (bool, error) {
-	if !addresscodec.IsValidClassicAddress(x.IssuingChainDoor.String()) {
+	if !addresscodec.IsValidAddress(x.IssuingChainDoor.String()) {
 		return false, ErrInvalidIssuingChainDoorAddress
 	}
-	if !addresscodec.IsValidClassicAddress(x.IssuingChainIssue.String()) {
+	if !addresscodec.IsValidAddress(x.IssuingChainIssue.String()) {
 		return false, ErrInvalidIssuingChainIssueAddress
 	}
-	if !addresscodec.IsValidClassicAddress(x.LockingChainDoor.String()) {
+	if !addresscodec.IsValidAddress(x.LockingChainDoor.String()) {
 		return false, ErrInvalidLockingChainDoorAddress
 	}
-	if !addresscodec.IsValidClassicAddress(x.LockingChainIssue.String()) {
+	if !addresscodec.IsValidAddress(x.LockingChainIssue.String()) {
 		return false, ErrInvalidLockingChainIssueAddress
 	}
 

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -96,7 +96,7 @@ func IsSigner(signerData SignerData) (bool, error) {
 		return false, errors.New("signers: Signer should have 3 fields: Account, TxnSignature, SigningPubKey")
 	}
 
-	validAccount := strings.TrimSpace(signerData.Account.String()) != "" && addresscodec.IsValidClassicAddress(signerData.Account.String())
+	validAccount := strings.TrimSpace(signerData.Account.String()) != "" && addresscodec.IsValidAddress(signerData.Account.String())
 	if !validAccount {
 		return false, errors.New("signers: Account should be a string")
 	}
@@ -157,7 +157,7 @@ func IsIssuedCurrency(input types.CurrencyAmount) (bool, error) {
 		return false, ErrInvalidTokenCurrency
 	}
 
-	if !addresscodec.IsValidClassicAddress(issuedAmount.Issuer.String()) {
+	if !addresscodec.IsValidAddress(issuedAmount.Issuer.String()) {
 		return false, ErrInvalidIssuer
 	}
 
@@ -247,7 +247,7 @@ func IsAsset(asset ledger.Asset) (bool, error) {
 		return false, ErrInvalidAssetIssuer
 	}
 
-	if asset.Currency != "" && !addresscodec.IsValidClassicAddress(asset.Issuer.String()) {
+	if asset.Currency != "" && !addresscodec.IsValidAddress(asset.Issuer.String()) {
 		return false, ErrInvalidAssetIssuer
 	}
 

--- a/xrpl/transaction/xchain_account_create_commit.go
+++ b/xrpl/transaction/xchain_account_create_commit.go
@@ -88,7 +88,7 @@ func (x *XChainAccountCreateCommit) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.Destination.String()) {
+	if !addresscodec.IsValidAddress(x.Destination.String()) {
 		return false, ErrInvalidAccount
 	}
 

--- a/xrpl/transaction/xchain_add_account_create_attestation.go
+++ b/xrpl/transaction/xchain_add_account_create_attestation.go
@@ -152,19 +152,19 @@ func (x *XChainAddAccountCreateAttestation) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.AttestationRewardAccount.String()) {
+	if !addresscodec.IsValidAddress(x.AttestationRewardAccount.String()) {
 		return false, ErrInvalidAttestationRewardAccount
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.AttestationSignerAccount.String()) {
+	if !addresscodec.IsValidAddress(x.AttestationSignerAccount.String()) {
 		return false, ErrInvalidAttestationSignerAccount
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.Destination.String()) {
+	if !addresscodec.IsValidAddress(x.Destination.String()) {
 		return false, ErrInvalidDestination
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.OtherChainSource.String()) {
+	if !addresscodec.IsValidAddress(x.OtherChainSource.String()) {
 		return false, ErrInvalidOtherChainSource
 	}
 

--- a/xrpl/transaction/xchain_add_claim_attestation.go
+++ b/xrpl/transaction/xchain_add_claim_attestation.go
@@ -161,19 +161,19 @@ func (x *XChainAddClaimAttestation) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.AttestationRewardAccount.String()) {
+	if !addresscodec.IsValidAddress(x.AttestationRewardAccount.String()) {
 		return false, ErrInvalidAttestationRewardAccount
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.AttestationSignerAccount.String()) {
+	if !addresscodec.IsValidAddress(x.AttestationSignerAccount.String()) {
 		return false, ErrInvalidAttestationSignerAccount
 	}
 
-	if x.Destination != "" && !addresscodec.IsValidClassicAddress(x.Destination.String()) {
+	if x.Destination != "" && !addresscodec.IsValidAddress(x.Destination.String()) {
 		return false, ErrInvalidDestination
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.OtherChainSource.String()) {
+	if !addresscodec.IsValidAddress(x.OtherChainSource.String()) {
 		return false, ErrInvalidOtherChainSource
 	}
 

--- a/xrpl/transaction/xchain_claim.go
+++ b/xrpl/transaction/xchain_claim.go
@@ -108,7 +108,7 @@ func (x *XChainClaim) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.Destination.String()) {
+	if !addresscodec.IsValidAddress(x.Destination.String()) {
 		return false, ErrInvalidDestinationAddress
 	}
 

--- a/xrpl/transaction/xchain_create_claim_id.go
+++ b/xrpl/transaction/xchain_create_claim_id.go
@@ -80,7 +80,7 @@ func (x *XChainCreateClaimID) Validate() (bool, error) {
 		return false, err
 	}
 
-	if !addresscodec.IsValidClassicAddress(x.OtherChainSource.String()) {
+	if !addresscodec.IsValidAddress(x.OtherChainSource.String()) {
 		return false, ErrInvalidAccount
 	}
 

--- a/xrpl/wallet/wallet.go
+++ b/xrpl/wallet/wallet.go
@@ -19,6 +19,7 @@ import (
 )
 
 var (
+	// ErrAddressTagNotZero is returned when the address tag is not zero.
 	ErrAddressTagNotZero = errors.New("address tag is not zero")
 )
 

--- a/xrpl/wallet/wallet_test.go
+++ b/xrpl/wallet/wallet_test.go
@@ -12,6 +12,7 @@ func TestNewWalletFromSeed(t *testing.T) {
 		PublicKey      string
 		PrivateKey     string
 		ClassicAddress types.Address
+		MasterAddress  types.Address
 	}{
 		{
 			Seed:           "sEd7io6yt5dFJrcePgRiFVHvmkJhJD1",
@@ -31,10 +32,16 @@ func TestNewWalletFromSeed(t *testing.T) {
 			PrivateKey:     "ED2C0EAB27E1411DBB8FACC88D531A69967DA0E45AC7821A4041A5AEE24BB8FF29",
 			ClassicAddress: "rs7cvHcsEF54DEs2y24Tpph3Xf71xUUrFu",
 		},
+		{
+			Seed:           "sh8i92YRnEjJy3fpFkL8txQSCVo79",
+			PublicKey: "03AEEFE1E8ED4BBC009DE996AC03A8C6B5713B1554794056C66E5B8D1753C7DD0E",
+			PrivateKey:     "004265A28F3E18340A490421D47B2EB8DBC2C0BF2C24CEFEA971B61CED2CABD233",
+			MasterAddress:  "rUAi7pipxGpYfPNg3LtPcf2ApiS8aw9A93",
+		},
 	}
 
 	for _, tc := range testCases {
-		wallet, err := FromSeed(tc.Seed, "")
+		wallet, err := FromSeed(tc.Seed, tc.MasterAddress.String())
 		if err != nil {
 			t.Errorf("Error generating wallet from seed: %s", err)
 		}
@@ -47,8 +54,14 @@ func TestNewWalletFromSeed(t *testing.T) {
 			t.Errorf("Private key does not match expected value. Expected: %s, got: %s", tc.PrivateKey, wallet.PrivateKey)
 		}
 
-		if wallet.ClassicAddress != tc.ClassicAddress {
-			t.Errorf("Classic address does not match expected value. Expected: %s, got: %s", tc.ClassicAddress, wallet.ClassicAddress)
+		if tc.MasterAddress != "" {
+			if wallet.ClassicAddress != tc.MasterAddress {
+				t.Errorf("Classic address does not match expected value. Expected: %s, got: %s", tc.MasterAddress, wallet.ClassicAddress)
+			}
+		} else {
+			if wallet.ClassicAddress != tc.ClassicAddress {
+				t.Errorf("Classic address does not match expected value. Expected: %s, got: %s", tc.ClassicAddress, wallet.ClassicAddress)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Title

## Description
This PR aims to fix a bug (#90) when X-Addresses are passed to a transaction. Previously only classic addresses with `r` were treated.
For example for a `SignerListSet`.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

Updates `FromJSON` in `account_id.go`.
Adds tests for `account_id.go`
Updates the Validate methods for the SignerListSet and SetRegularKey transactions.

## Notes (optional)

Describe any additional notes here.
