### PR TITLE
Fix "account_info" request field: "signer_lists"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.2]
+
+### Fixed
+
+#### xrpl
+
+- The `InfoRequest` for the `account_info` method had an incorrect field `signer_list` (an `s` was missing). The correct field is now `signer_lists`.  
+  Link to the documentation [here](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_info#request-format).
+
 ## [v0.1.1]
 
 ### Added

--- a/xrpl/queries/account/info.go
+++ b/xrpl/queries/account/info.go
@@ -19,7 +19,7 @@ type InfoRequest struct {
 	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
 	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
 	Queue       bool                   `json:"queue,omitempty"`
-	SignerList  bool                   `json:"signer_list,omitempty"`
+	SignerLists bool                   `json:"signer_lists,omitempty"`
 	Strict      bool                   `json:"strict,omitempty"`
 }
 

--- a/xrpl/queries/account/info_test.go
+++ b/xrpl/queries/account/info_test.go
@@ -15,11 +15,11 @@ func TestAccountInfoRequest(t *testing.T) {
 		Account:     "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
 		LedgerIndex: common.Closed,
 		Queue:       true,
-		SignerList:  false,
+		SignerLists: false,
 		Strict:      true,
 	}
 
-	// SignerList assigned to default, omitted due to omitempty
+	// SignerLists assigned to default, omitted due to omitempty
 	j := `{
 	"account": "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
 	"ledger_index": "closed",


### PR DESCRIPTION
# Title

## Description
This PR fixes a typo for the "account_info" request. An `s` was missing for the `signer_lists` field.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

Updated `signer_list` to `signer_lists` for the "account_info" request.

## Notes (optional)

Describe any additional notes here.
