### PR TITLE
signer list set quorum fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### xrpl
 
-- Updated SignerQuorum in SignerListSet to be a pointer (\*uint32) instead of a value (uint32).
+- Updated SignerQuorum in SignerListSet to be an interface instead of a value (uint32).
   - This allows distinguishing between an unset (nil) and an explicitly set value, including 0 to delete a signer list.
   - Ensures SignerQuorum is only included in the Flatten() output when explicitly defined.
   - Updates the `Validate` method to make sure `SignerEntries` is not set when `SignerQuorum` is set to 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### xrpl
 
-- Updated SignerQuorum in SignerListSet to be an interface instead of a value (uint32).
+- Updated SignerQuorum in SignerListSet to be an interface{} with uint32 type assertion instead of a value (uint32).
   - This allows distinguishing between an unset (nil) and an explicitly set value, including 0 to delete a signer list.
   - Ensures SignerQuorum is only included in the Flatten() output when explicitly defined.
   - Updates the `Validate` method to make sure `SignerEntries` is not set when `SignerQuorum` is set to 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.1.4]
+
+### Fixed
+
+#### xrpl
+
+- Updated SignerQuorum in SignerListSet to be a pointer (\*uint32) instead of a value (uint32).
+  - This allows distinguishing between an unset (nil) and an explicitly set value, including 0 to delete a signer list.
+  - Ensures SignerQuorum is only included in the Flatten() output when explicitly defined.
+  - Updates the `Validate` method to make sure `SignerEntries` is not set when `SignerQuorum` is set to 0
+
+## [v0.1.3]
 
 ### Added
 

--- a/examples/multisigning/rpc/main.go
+++ b/examples/multisigning/rpc/main.go
@@ -70,7 +70,7 @@ func main() {
 		BaseTx: transaction.BaseTx{
 			Account: master.GetAddress(),
 		},
-		SignerQuorum: uint32Ptr(2),
+		SignerQuorum: uint32(2),
 		SignerEntries: []ledger.SignerEntryWrapper{
 			{
 				SignerEntry: ledger.SignerEntry{
@@ -162,9 +162,4 @@ func main() {
 
 	fmt.Println("✅ Multisigned transaction submitted!")
 	fmt.Printf("🌐 Result: %s\n", mRes.EngineResult)
-}
-
-// Utility function to create a pointer to uint32
-func uint32Ptr(value uint32) *uint32 {
-	return &value
 }

--- a/examples/multisigning/rpc/main.go
+++ b/examples/multisigning/rpc/main.go
@@ -70,7 +70,7 @@ func main() {
 		BaseTx: transaction.BaseTx{
 			Account: master.GetAddress(),
 		},
-		SignerQuorum: 2,
+		SignerQuorum: uint32Ptr(2),
 		SignerEntries: []ledger.SignerEntryWrapper{
 			{
 				SignerEntry: ledger.SignerEntry{
@@ -162,4 +162,9 @@ func main() {
 
 	fmt.Println("✅ Multisigned transaction submitted!")
 	fmt.Printf("🌐 Result: %s\n", mRes.EngineResult)
+}
+
+// Utility function to create a pointer to uint32
+func uint32Ptr(value uint32) *uint32 {
+	return &value
 }

--- a/examples/multisigning/ws/main.go
+++ b/examples/multisigning/ws/main.go
@@ -81,7 +81,7 @@ func main() {
 		BaseTx: transaction.BaseTx{
 			Account: master.GetAddress(),
 		},
-		SignerQuorum: uint32Ptr(2),
+		SignerQuorum: uint32(2),
 		SignerEntries: []ledger.SignerEntryWrapper{
 			{
 				SignerEntry: ledger.SignerEntry{
@@ -177,9 +177,4 @@ func main() {
 
 	fmt.Println("✅ Multisigned transaction submitted!")
 	fmt.Printf("🌐 Result: %s\n", mRes.EngineResult)
-}
-
-// Utility function to create a pointer to uint32
-func uint32Ptr(value uint32) *uint32 {
-	return &value
 }

--- a/examples/multisigning/ws/main.go
+++ b/examples/multisigning/ws/main.go
@@ -81,7 +81,7 @@ func main() {
 		BaseTx: transaction.BaseTx{
 			Account: master.GetAddress(),
 		},
-		SignerQuorum: 2,
+		SignerQuorum: uint32Ptr(2),
 		SignerEntries: []ledger.SignerEntryWrapper{
 			{
 				SignerEntry: ledger.SignerEntry{
@@ -177,4 +177,9 @@ func main() {
 
 	fmt.Println("✅ Multisigned transaction submitted!")
 	fmt.Printf("🌐 Result: %s\n", mRes.EngineResult)
+}
+
+// Utility function to create a pointer to uint32
+func uint32Ptr(value uint32) *uint32 {
+	return &value
 }

--- a/xrpl/transaction/signer_list_set.go
+++ b/xrpl/transaction/signer_list_set.go
@@ -62,8 +62,8 @@ const (
 type SignerListSet struct {
 	BaseTx
 	// A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the signatures provided is greater than or equal to this value.
-	// To delete a signer list, use the value 0.
-	SignerQuorum *uint32
+	// To delete a signer list, use the value 0. Needs to be an uint32.
+	SignerQuorum interface{}
 	// (Omitted when deleting) Array of SignerEntry objects, indicating the addresses and weights of signers in this list.
 	// This signer list must have at least 1 member and no more than 32 members.
 	// No address may appear more than once in the list, nor may the Account submitting the transaction appear in the list.
@@ -82,7 +82,7 @@ func (s *SignerListSet) Flatten() FlatTransaction {
 	flattened["TransactionType"] = "SignerListSet"
 
 	if s.SignerQuorum != nil {
-		flattened["SignerQuorum"] = *s.SignerQuorum
+		flattened["SignerQuorum"] = s.SignerQuorum
 	}
 
 	if len(s.SignerEntries) > 0 {
@@ -106,12 +106,15 @@ func (s *SignerListSet) Validate() (bool, error) {
 		return false, err
 	}
 
+	sq, ok := s.SignerQuorum.(uint32)
+	zeroQuorum := ((ok && sq == uint32(0)) || s.SignerQuorum == nil)
+
 	// All other checks are for if SignerQuorum is greater than 0
-	if *s.SignerQuorum == 0 && len(s.SignerEntries) == 0 {
+	if zeroQuorum && len(s.SignerEntries) == 0 {
 		return true, nil
 	}
 
-	if *s.SignerQuorum == 0 && len(s.SignerEntries) > 0 {
+	if zeroQuorum && len(s.SignerEntries) > 0 {
 		return false, ErrInvalidQuorumAndEntries
 	}
 
@@ -137,7 +140,7 @@ func (s *SignerListSet) Validate() (bool, error) {
 	for _, signerEntry := range s.SignerEntries {
 		sumSignerWeights += signerEntry.SignerEntry.SignerWeight
 	}
-	if *s.SignerQuorum > uint32(sumSignerWeights) {
+	if sq > uint32(sumSignerWeights) {
 		return false, ErrSignerQuorumGreaterThanSumOfSignerWeights
 	}
 

--- a/xrpl/transaction/signer_list_set_test.go
+++ b/xrpl/transaction/signer_list_set_test.go
@@ -28,7 +28,7 @@ func TestSignerListSet_Flatten(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -84,7 +84,7 @@ func TestSignerListSet_Flatten(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(0),
+				SignerQuorum: uint32(0),
 			},
 			expected: `{
 				"TransactionType": "SignerListSet",
@@ -133,7 +133,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -168,7 +168,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -195,7 +195,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 			},
 			wantValid: false,
 			wantErr:   true,
@@ -208,7 +208,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 				SignerEntries: func() []ledger.SignerEntryWrapper {
 					entries := make([]ledger.SignerEntryWrapper, 33)
 					for i := range entries {
@@ -233,7 +233,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(3),
+				SignerQuorum: uint32(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -255,7 +255,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(5),
+				SignerQuorum: uint32(5),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -282,7 +282,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(2),
+				SignerQuorum: uint32(2),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -309,7 +309,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(0),
+				SignerQuorum: uint32(0),
 			},
 			wantValid: true,
 			wantErr:   false,
@@ -322,7 +322,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: uint32Ptr(0),
+				SignerQuorum: uint32(0),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -355,9 +355,4 @@ func TestSignerListSet_Validate(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Utility function to create a pointer to uint32
-func uint32Ptr(value uint32) *uint32 {
-	return &value
 }

--- a/xrpl/transaction/signer_list_set_test.go
+++ b/xrpl/transaction/signer_list_set_test.go
@@ -28,7 +28,7 @@ func TestSignerListSet_Flatten(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -84,12 +84,13 @@ func TestSignerListSet_Flatten(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 0,
+				SignerQuorum: uint32Ptr(0),
 			},
 			expected: `{
 				"TransactionType": "SignerListSet",
 				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-				"Fee": "12"
+				"Fee": "12",
+				"SignerQuorum": 0
 			}`,
 		},
 		{
@@ -132,7 +133,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -167,7 +168,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					Fee:     types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -194,7 +195,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 			},
 			wantValid: false,
 			wantErr:   true,
@@ -207,7 +208,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 				SignerEntries: func() []ledger.SignerEntryWrapper {
 					entries := make([]ledger.SignerEntryWrapper, 33)
 					for i := range entries {
@@ -232,7 +233,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 3,
+				SignerQuorum: uint32Ptr(3),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -254,7 +255,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 5,
+				SignerQuorum: uint32Ptr(5),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -281,7 +282,7 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 2,
+				SignerQuorum: uint32Ptr(2),
 				SignerEntries: []ledger.SignerEntryWrapper{
 					{
 						SignerEntry: ledger.SignerEntry{
@@ -308,10 +309,37 @@ func TestSignerListSet_Validate(t *testing.T) {
 					TransactionType: SignerListSetTx,
 					Fee:             types.XRPCurrencyAmount(12),
 				},
-				SignerQuorum: 0,
+				SignerQuorum: uint32Ptr(0),
 			},
 			wantValid: true,
 			wantErr:   false,
+		},
+		{
+			name: "fail - invalid SignerListSet with SignerQuorum 0 but a SignerEntries not empty",
+			entry: &SignerListSet{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: SignerListSetTx,
+					Fee:             types.XRPCurrencyAmount(12),
+				},
+				SignerQuorum: uint32Ptr(0),
+				SignerEntries: []ledger.SignerEntryWrapper{
+					{
+						SignerEntry: ledger.SignerEntry{
+							Account:      "invalid",
+							SignerWeight: 2,
+						},
+					},
+					{
+						SignerEntry: ledger.SignerEntry{
+							Account:      "rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v",
+							SignerWeight: 1,
+						},
+					},
+				},
+			},
+			wantValid: false,
+			wantErr:   true,
 		},
 	}
 
@@ -327,4 +355,9 @@ func TestSignerListSet_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Utility function to create a pointer to uint32
+func uint32Ptr(value uint32) *uint32 {
+	return &value
 }


### PR DESCRIPTION
# Title

## Description
This PR aims to:

- Updated SignerQuorum in SignerListSet to be a pointer (\*uint32) instead of a value (uint32).
  - This allows distinguishing between an unset (nil) and an explicitly set value, including 0 to delete a signer list.
  - Ensures SignerQuorum is only included in the Flatten() output when explicitly defined.
  - Updates the `Validate` method to make sure `SignerEntries` is not set when `SignerQuorum` is set to 0

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

- Change 1: SignerQuorum in SignerListSet to be a pointer (\*uint32) instead of a value (uint32).
- Change 2: New error `ErrInvalidQuorumAndEntries` introduced

## Notes (optional)

Describe any additional notes here.
