### PR TITLE
Timeout RPC configurable + Deep Freeze examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configurable time out for the RPC client. New default time of 5 seconds instead of 1 second.
 
-#### examples
-
-- Examples to DeepFreeze a trustline for the rpc and websocket clients in the `examples` directory.
-
 ### Fixed
 
 #### xrpl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.1.6]
 
+### Added
+
+#### xrpl
+
+- Configurable time out for the RPC client. New default time of 5 seconds instead of 1 second.
+
+#### examples
+
+- Examples to DeepFreeze a trustline for the rpc and websocket clients in the `examples` directory.
+
 ### Fix
 
 #### xrpl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### xrpl
 
-- Configurable time out for the RPC client. New default time of 5 seconds instead of 1 second.
+- Configurable timeout for the RPC client. New default timeout of 5 seconds instead of 1 second.
 
 ### Fixed
 

--- a/examples/deep-freeze/rpc/main.go
+++ b/examples/deep-freeze/rpc/main.go
@@ -196,7 +196,7 @@ func main() {
 
 	submitAndWait(client, trustSet, issuer)
 
-	// -----------------------------------------------------
+	// ------------------- SHOULD FAIL ⬇️ ------------------
 
 	// Sending payment from Holder 1 to Holder 2 (which should fail), Holder 1 can't decrease its balance
 	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should fail). Holder 1 can't decrease its balance...")
@@ -213,6 +213,8 @@ func main() {
 	}
 	submitAndWait(client, payment, holderWallet1)
 
+	// ------------------- SHOULD FAIL ⬇️ ------------------
+
 	// Sending payment from Holder 2 to Holder 1 (which should fail), Holder 1 can't increase its balance
 	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should fail). Holder 1 can't increase its balance...")
 	payment = &transactions.Payment{
@@ -227,6 +229,25 @@ func main() {
 		},
 	}
 	submitAndWait(client, payment, holderWallet2)
+
+	// ------------------- SHOULD FAIL ⬇️ ------------------
+
+	// Creating OfferCreate transaction (which should fail), Holder 1 can't create an offer
+	fmt.Println("⏳ Creating OfferCreate transaction (which should fail). Holder 1 can't create an offer...")
+	offerCreate := &transactions.OfferCreate{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		TakerPays: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+		TakerGets: types.XRPCurrencyAmount(10),
+	}
+	submitAndWait(client, offerCreate, holderWallet1)
+
+	// -----------------------------------------------------
 
 	// Unfreezing and Deep Unfreezing holder 1
 	fmt.Println("⏳ Unfreezing and Deep Unfreezing holder 1 trustline...")
@@ -244,6 +265,8 @@ func main() {
 	trustSet.SetClearDeepFreezeFlag()
 	submitAndWait(client, trustSet, issuer)
 
+	// -----------------------------------------------------
+
 	// Sending payment from Holder 1 to Holder 2 (which should succeed), Holder 1 can decrease its balance
 	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should succeed). Holder 1 can decrease its balance...")
 	payment = &transactions.Payment{
@@ -258,6 +281,8 @@ func main() {
 		},
 	}
 	submitAndWait(client, payment, holderWallet1)
+
+	// -----------------------------------------------------
 
 	// Sending payment from Holder 2 to Holder 1 (which should succeed), Holder 1 can increase its balance
 	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should succeed). Holder 1 can increase its balance...")

--- a/examples/deep-freeze/rpc/main.go
+++ b/examples/deep-freeze/rpc/main.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
+	"github.com/Peersyst/xrpl-go/xrpl/faucet"
+	"github.com/Peersyst/xrpl-go/xrpl/rpc"
+	transactions "github.com/Peersyst/xrpl-go/xrpl/transaction"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+)
+
+const (
+	currencyCode = "USDA"
+)
+
+type SubmittableTransaction interface {
+	TxType() transactions.TxType
+	Flatten() transactions.FlatTransaction // Ensures all transactions can be flattened
+}
+
+func main() {
+	client := getRpcClient()
+
+	// Configure wallets
+
+	// Issuer
+	fmt.Println("⏳ Setting up issuer wallet...")
+	issuer, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating issuer wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&issuer)
+	if err != nil {
+		fmt.Printf("❌ Error funding issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Issuer wallet funded: %s\n", issuer.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 1
+	fmt.Println("⏳ Setting up holder 1 wallet...")
+	holderWallet1, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 1: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet1)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 1: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder wallet 1 funded: %s\n", holderWallet1.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 2
+	fmt.Println("⏳ Setting up holder 2 wallet...")
+	holderWallet2, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 2: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet2)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 2: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder wallet 2 funded: %s\n", holderWallet2.ClassicAddress)
+	fmt.Println()
+
+	fmt.Println("✅ Wallets setup complete!")
+	fmt.Println()
+
+	// -----------------------------------------------------
+
+	// Configuring Issuing account
+	fmt.Println("⏳ Configuring issuer address settings...")
+	accountSet := &transactions.AccountSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Domain: types.Domain("697373756572"), // issuer
+	}
+
+	accountSet.SetAsfDefaultRipple()
+	submitAndWait(client, accountSet, issuer)
+
+	// -----------------------------------------------------
+
+	// Trustline from the holder 1 to the issuer
+	fmt.Println("⏳ Setting up trustline from holder 1 to the issuer...")
+	trustSet := &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "1000000000",
+		}}
+	trustSet.SetSetNoRippleFlag()
+	submitAndWait(client, trustSet, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Trustline from the holder 2 to the issuer
+	fmt.Println("⏳ Setting up trustline from holder 2 to the issuer...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "1000000000",
+		},
+	}
+	trustSet.SetSetNoRippleFlag()
+	submitAndWait(client, trustSet, holderWallet2)
+
+	// -----------------------------------------------------
+
+	// Minting to Holder 1
+	fmt.Println("⏳ Minting to Holder 1...")
+	payment := &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "50000",
+		},
+	}
+	submitAndWait(client, payment, issuer)
+
+	// -----------------------------------------------------
+
+	// Minting to Holder 2
+	fmt.Println("⏳ Minting to Holder 2...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "40000",
+		},
+	}
+	submitAndWait(client, payment, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending payment from Holder 1 to Holder 2
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "20",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Freezing and Deep Freezing holder1
+	fmt.Println("⏳ Freezing and Deep Freezing holder 1 trustline...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(holderWallet1.ClassicAddress),
+			Value:    "0",
+		},
+	}
+	trustSet.SetSetFreezeFlag()
+	trustSet.SetSetDeepFreezeFlag()
+
+	submitAndWait(client, trustSet, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending payment from Holder 1 to Holder 2 (which should fail), Holder 1 can't decrease its balance
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should fail). Holder 1 can't decrease its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// Sending payment from Holder 2 to Holder 1 (which should fail), Holder 1 can't increase its balance
+	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should fail). Holder 1 can't increase its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet2)
+
+	// Unfreezing and Deep Unfreezing holder 1
+	fmt.Println("⏳ Unfreezing and Deep Unfreezing holder 1 trustline...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(holderWallet1.ClassicAddress),
+			Value:    "0",
+		},
+	}
+	trustSet.SetClearFreezeFlag()
+	trustSet.SetClearDeepFreezeFlag()
+	submitAndWait(client, trustSet, issuer)
+
+	// Sending payment from Holder 1 to Holder 2 (which should succeed), Holder 1 can decrease its balance
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should succeed). Holder 1 can decrease its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// Sending payment from Holder 2 to Holder 1 (which should succeed), Holder 1 can increase its balance
+	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should succeed). Holder 1 can increase its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet2)
+}
+
+// getRpcClient returns a new rpc client
+func getRpcClient() *rpc.Client {
+	cfg, err := rpc.NewClientConfig(
+		// DeepFreeze only available on Devnet as of February 2025, change to testnet/mainnet once the amendment passes.
+		"https://s.devnet.rippletest.net:51234",
+		rpc.WithFaucetProvider(faucet.NewDevnetFaucetProvider()),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return rpc.NewClient(cfg)
+}
+
+// submitAndWait submits a transaction and waits for it to be included in a validated ledger
+func submitAndWait(client *rpc.Client, txn SubmittableTransaction, wallet wallet.Wallet) {
+	fmt.Printf("⏳ Submitting %s transaction...\n", txn.TxType())
+
+	flattenedTx := txn.Flatten()
+
+	err := client.Autofill(&flattenedTx)
+	if err != nil {
+		fmt.Printf("❌ Error autofilling %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	txBlob, _, err := wallet.Sign(flattenedTx)
+	if err != nil {
+		fmt.Printf("❌ Error signing %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	response, err := client.SubmitAndWait(txBlob, false)
+	if err != nil {
+		fmt.Printf("❌ Error submitting %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	fmt.Printf("✅ %s transaction submitted\n", txn.TxType())
+	fmt.Printf("🌐 Hash: %s\n", response.Hash.String())
+	fmt.Println()
+}

--- a/examples/deep-freeze/ws/main.go
+++ b/examples/deep-freeze/ws/main.go
@@ -209,7 +209,7 @@ func main() {
 
 	submitAndWait(client, trustSet, issuer)
 
-	// -----------------------------------------------------
+	// ------------------- SHOULD FAIL ⬇️ ------------------
 
 	// Sending payment from Holder 1 to Holder 2 (which should fail), Holder 1 can't decrease its balance
 	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should fail). Holder 1 can't decrease its balance...")
@@ -226,6 +226,8 @@ func main() {
 	}
 	submitAndWait(client, payment, holderWallet1)
 
+	// ------------------- SHOULD FAIL ⬇️ ------------------
+
 	// Sending payment from Holder 2 to Holder 1 (which should fail), Holder 1 can't increase its balance
 	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should fail). Holder 1 can't increase its balance...")
 	payment = &transactions.Payment{
@@ -240,6 +242,25 @@ func main() {
 		},
 	}
 	submitAndWait(client, payment, holderWallet2)
+
+	// ------------------- SHOULD FAIL ⬇️ ------------------
+
+	// Creating OfferCreate transaction (which should fail), Holder 1 can't create an offer
+	fmt.Println("⏳ Creating OfferCreate transaction (which should fail). Holder 1 can't create an offer...")
+	offerCreate := &transactions.OfferCreate{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		TakerPays: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+		TakerGets: types.XRPCurrencyAmount(10),
+	}
+	submitAndWait(client, offerCreate, holderWallet1)
+
+	// -----------------------------------------------------
 
 	// Unfreezing and Deep Unfreezing holder 1
 	fmt.Println("⏳ Unfreezing and Deep Unfreezing holder 1 trustline...")
@@ -257,6 +278,8 @@ func main() {
 	trustSet.SetClearDeepFreezeFlag()
 	submitAndWait(client, trustSet, issuer)
 
+	// -----------------------------------------------------
+
 	// Sending payment from Holder 1 to Holder 2 (which should succeed), Holder 1 can decrease its balance
 	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should succeed). Holder 1 can decrease its balance...")
 	payment = &transactions.Payment{
@@ -271,6 +294,8 @@ func main() {
 		},
 	}
 	submitAndWait(client, payment, holderWallet1)
+
+	// -----------------------------------------------------
 
 	// Sending payment from Holder 2 to Holder 1 (which should succeed), Holder 1 can increase its balance
 	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should succeed). Holder 1 can increase its balance...")

--- a/examples/deep-freeze/ws/main.go
+++ b/examples/deep-freeze/ws/main.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
+	"github.com/Peersyst/xrpl-go/xrpl/faucet"
+	transactions "github.com/Peersyst/xrpl-go/xrpl/transaction"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+	"github.com/Peersyst/xrpl-go/xrpl/websocket"
+)
+
+const (
+	currencyCode = "USDA"
+)
+
+type SubmittableTransaction interface {
+	TxType() transactions.TxType
+	Flatten() transactions.FlatTransaction // Ensures all transactions can be flattened
+}
+
+func main() {
+	fmt.Println("⏳ Setting up client...")
+
+	client := getClient()
+	fmt.Println("Connecting to server...")
+	if err := client.Connect(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("✅ Client configured!")
+	fmt.Println()
+
+	fmt.Printf("Connection: %t", client.IsConnected())
+	fmt.Println()
+
+	// Configure wallets
+
+	// Issuer
+	fmt.Println("⏳ Setting up issuer wallet...")
+	issuer, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating issuer wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&issuer)
+	if err != nil {
+		fmt.Printf("❌ Error funding issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Issuer wallet funded: %s\n", issuer.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 1
+	fmt.Println("⏳ Setting up holder 1 wallet...")
+	holderWallet1, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 1: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet1)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 1: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder wallet 1 funded: %s\n", holderWallet1.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 2
+	fmt.Println("⏳ Setting up holder 2 wallet...")
+	holderWallet2, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder wallet 2: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet2)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder wallet 2: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder wallet 2 funded: %s\n", holderWallet2.ClassicAddress)
+	fmt.Println()
+
+	fmt.Println("✅ Wallets setup complete!")
+	fmt.Println()
+
+	// -----------------------------------------------------
+
+	// Configuring Issuing account
+	fmt.Println("⏳ Configuring issuer address settings...")
+	accountSet := &transactions.AccountSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Domain: types.Domain("697373756572"), // issuer
+	}
+
+	accountSet.SetAsfDefaultRipple()
+	submitAndWait(client, accountSet, issuer)
+
+	// -----------------------------------------------------
+
+	// Trustline from the holder 1 to the issuer
+	fmt.Println("⏳ Setting up trustline from holder 1 to the issuer...")
+	trustSet := &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "1000000000",
+		}}
+	trustSet.SetSetNoRippleFlag()
+	submitAndWait(client, trustSet, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Trustline from the holder 2 to the issuer
+	fmt.Println("⏳ Setting up trustline from holder 2 to the issuer...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "1000000000",
+		},
+	}
+	trustSet.SetSetNoRippleFlag()
+	submitAndWait(client, trustSet, holderWallet2)
+
+	// -----------------------------------------------------
+
+	// Minting to Holder 1
+	fmt.Println("⏳ Minting to Holder 1...")
+	payment := &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "50000",
+		},
+	}
+	submitAndWait(client, payment, issuer)
+
+	// -----------------------------------------------------
+
+	// Minting to Holder 2
+	fmt.Println("⏳ Minting to Holder 2...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "40000",
+		},
+	}
+	submitAndWait(client, payment, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending payment from Holder 1 to Holder 2
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "20",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Freezing and Deep Freezing holder1
+	fmt.Println("⏳ Freezing and Deep Freezing holder 1 trustline...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(holderWallet1.ClassicAddress),
+			Value:    "0",
+		},
+	}
+	trustSet.SetSetFreezeFlag()
+	trustSet.SetSetDeepFreezeFlag()
+
+	submitAndWait(client, trustSet, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending payment from Holder 1 to Holder 2 (which should fail), Holder 1 can't decrease its balance
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should fail). Holder 1 can't decrease its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// Sending payment from Holder 2 to Holder 1 (which should fail), Holder 1 can't increase its balance
+	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should fail). Holder 1 can't increase its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet2)
+
+	// Unfreezing and Deep Unfreezing holder 1
+	fmt.Println("⏳ Unfreezing and Deep Unfreezing holder 1 trustline...")
+	trustSet = &transactions.TrustSet{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(issuer.ClassicAddress),
+		},
+		LimitAmount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(holderWallet1.ClassicAddress),
+			Value:    "0",
+		},
+	}
+	trustSet.SetClearFreezeFlag()
+	trustSet.SetClearDeepFreezeFlag()
+	submitAndWait(client, trustSet, issuer)
+
+	// Sending payment from Holder 1 to Holder 2 (which should succeed), Holder 1 can decrease its balance
+	fmt.Println("⏳ Sending payment from Holder 1 to Holder 2 (which should succeed). Holder 1 can decrease its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet1.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet2.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet1)
+
+	// Sending payment from Holder 2 to Holder 1 (which should succeed), Holder 1 can increase its balance
+	fmt.Println("⏳ Sending payment from Holder 2 to Holder 1 (which should succeed). Holder 1 can increase its balance...")
+	payment = &transactions.Payment{
+		BaseTx: transactions.BaseTx{
+			Account: types.Address(holderWallet2.ClassicAddress),
+		},
+		Destination: types.Address(holderWallet1.ClassicAddress),
+		Amount: types.IssuedCurrencyAmount{
+			Currency: currency.ConvertStringToHex(currencyCode),
+			Issuer:   types.Address(issuer.ClassicAddress),
+			Value:    "10",
+		},
+	}
+	submitAndWait(client, payment, holderWallet2)
+}
+
+// getRpcClient returns a new rpc client
+func getClient() *websocket.Client {
+	client := websocket.NewClient(
+		websocket.NewClientConfig().
+			WithHost("wss://s.devnet.rippletest.net:51233").
+			WithFaucetProvider(faucet.NewDevnetFaucetProvider()),
+	)
+
+	return client
+}
+
+// submitAndWait submits a transaction and waits for it to be included in a validated ledger
+func submitAndWait(client *websocket.Client, txn SubmittableTransaction, wallet wallet.Wallet) {
+	fmt.Printf("⏳ Submitting %s transaction...\n", txn.TxType())
+
+	flattenedTx := txn.Flatten()
+
+	err := client.Autofill(&flattenedTx)
+	if err != nil {
+		fmt.Printf("❌ Error autofilling %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	txBlob, _, err := wallet.Sign(flattenedTx)
+	if err != nil {
+		fmt.Printf("❌ Error signing %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	response, err := client.SubmitAndWait(txBlob, false)
+	if err != nil {
+		fmt.Printf("❌ Error submitting %s transaction: %s\n", txn.TxType(), err)
+		fmt.Println()
+		return
+	}
+
+	fmt.Printf("✅ %s transaction submitted\n", txn.TxType())
+	fmt.Printf("🌐 Hash: %s\n", response.Hash.String())
+	fmt.Println()
+}

--- a/xrpl/common/constants.go
+++ b/xrpl/common/constants.go
@@ -15,5 +15,5 @@ const (
 	DefaultMaxFeeXRP  float32 = 2
 
 	// 5 seconds default timeout
-	DefaultTimeOut = 5 * time.Second
+	DefaultTimeout = 5 * time.Second
 )

--- a/xrpl/common/constants.go
+++ b/xrpl/common/constants.go
@@ -13,4 +13,7 @@ const (
 
 	DefaultFeeCushion float32 = 1.2
 	DefaultMaxFeeXRP  float32 = 2
+
+	// 5 seconds default timeout
+	DefaultTimeOut = 5 * time.Second
 )

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	// Faucet config
 	faucetProvider common.FaucetProvider
 
-	timeOut time.Duration
+	timeout time.Duration
 }
 
 type ConfigOpt func(c *Config)
@@ -60,9 +60,9 @@ func WithFaucetProvider(fp common.FaucetProvider) ConfigOpt {
 	}
 }
 
-func WithTimeOut(timeOut time.Duration) ConfigOpt {
+func WithTimeout(timeout time.Duration) ConfigOpt {
 	return func(c *Config) {
-		c.timeOut = timeOut
+		c.timeout = timeout
 	}
 }
 
@@ -78,7 +78,7 @@ func NewClientConfig(url string, opts ...ConfigOpt) (*Config, error) {
 	}
 
 	cfg := &Config{
-		HTTPClient: &http.Client{Timeout: common.DefaultTimeOut},
+		HTTPClient: &http.Client{Timeout: common.DefaultTimeout},
 		URL:        url,
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -30,6 +30,8 @@ type Config struct {
 
 	// Faucet config
 	faucetProvider common.FaucetProvider
+
+	timeOut time.Duration
 }
 
 type ConfigOpt func(c *Config)
@@ -58,6 +60,12 @@ func WithFaucetProvider(fp common.FaucetProvider) ConfigOpt {
 	}
 }
 
+func WithTimeOut(timeOut time.Duration) ConfigOpt {
+	return func(c *Config) {
+		c.timeOut = timeOut
+	}
+}
+
 func NewClientConfig(url string, opts ...ConfigOpt) (*Config, error) {
 
 	// validate a url has been passed in
@@ -70,7 +78,7 @@ func NewClientConfig(url string, opts ...ConfigOpt) (*Config, error) {
 	}
 
 	cfg := &Config{
-		HTTPClient: &http.Client{Timeout: time.Duration(100) * time.Second}, // default timeout value - allow custom timme out?
+		HTTPClient: &http.Client{Timeout: common.DefaultTimeOut},
 		URL:        url,
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -70,7 +70,7 @@ func NewClientConfig(url string, opts ...ConfigOpt) (*Config, error) {
 	}
 
 	cfg := &Config{
-		HTTPClient: &http.Client{Timeout: time.Duration(1) * time.Second}, // default timeout value - allow custom timme out?
+		HTTPClient: &http.Client{Timeout: time.Duration(100) * time.Second}, // default timeout value - allow custom timme out?
 		URL:        url,
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},

--- a/xrpl/rpc/config_test.go
+++ b/xrpl/rpc/config_test.go
@@ -79,9 +79,9 @@ func TestWithFaucetProvider(t *testing.T) {
 	require.Equal(t, fp, cfg.faucetProvider)
 }
 
-func TestWithTimeOut(t *testing.T) {
+func TestWithTimeout(t *testing.T) {
 	timeOut := 11 * time.Second // 11 seconds
-	cfg, _ := NewClientConfig("http://s1.ripple.com:51234", WithTimeOut(timeOut))
+	cfg, _ := NewClientConfig("http://s1.ripple.com:51234", WithTimeout(timeOut))
 
-	require.Equal(t, timeOut, cfg.timeOut)
+	require.Equal(t, timeOut, cfg.timeout)
 }

--- a/xrpl/rpc/config_test.go
+++ b/xrpl/rpc/config_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Peersyst/xrpl-go/xrpl/common"
 	"github.com/Peersyst/xrpl-go/xrpl/faucet"
@@ -76,4 +77,11 @@ func TestWithFaucetProvider(t *testing.T) {
 	cfg, _ := NewClientConfig("http://s1.ripple.com:51234", WithFaucetProvider(fp))
 
 	require.Equal(t, fp, cfg.faucetProvider)
+}
+
+func TestWithTimeOut(t *testing.T) {
+	timeOut := 11 * time.Second // 11 seconds
+	cfg, _ := NewClientConfig("http://s1.ripple.com:51234", WithTimeOut(timeOut))
+
+	require.Equal(t, timeOut, cfg.timeOut)
 }

--- a/xrpl/transaction/offer_cancel.go
+++ b/xrpl/transaction/offer_cancel.go
@@ -37,6 +37,9 @@ func (*OfferCancel) TxType() TxType {
 // Flatten returns the flattened map of the OfferCancel transaction.
 func (o *OfferCancel) Flatten() FlatTransaction {
 	flattened := o.BaseTx.Flatten()
+
+	flattened["TransactionType"] = o.TxType().String()
+
 	flattened["OfferSequence"] = o.OfferSequence
 	return flattened
 }

--- a/xrpl/transaction/offer_create.go
+++ b/xrpl/transaction/offer_create.go
@@ -82,6 +82,8 @@ func (*OfferCreate) TxType() TxType {
 func (o *OfferCreate) Flatten() FlatTransaction {
 	flattened := o.BaseTx.Flatten()
 
+	flattened["TransactionType"] = o.TxType().String()
+
 	if o.Expiration != 0 {
 		flattened["Expiration"] = o.Expiration
 	}


### PR DESCRIPTION
# Title

## Description
This PR aims to add an example for the DeepFreeze (XLS-77) feature currently deployed on DevNet.

I also updated the default timeout to 5 seconds for the RPC client as Devnet didn't work with the previous settings (1 second).

I made the rpc timeout configurable with a new function `WithTimeOut`.

I added the missing `TransactionType` for the Flatten function to `OfferCreate` and `OfferCancel`.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

## Notes (optional)

Describe any additional notes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable RPC timeout that now defaults to 5 seconds, offering greater flexibility.
	- Enhanced transaction processing to support zero or empty values in key fields.
	- Added sample applications showcasing comprehensive wallet management, trustline configuration, and transaction workflows on the XRP Ledger.

- **Bug Fixes**
	- Improved handling of transaction validations to accommodate more flexible input values for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->