### PR TITLE
[TA-4185]: Ledger response when Expand is false

### DIFF
--- a/xrpl/queries/ledger/ledger.go
+++ b/xrpl/queries/ledger/ledger.go
@@ -14,16 +14,23 @@ import (
 // Retrieve information about the public ledger.
 type Request struct {
 	common.BaseRequest
-	LedgerHash   common.LedgerHash      `json:"ledger_hash,omitempty"`
-	LedgerIndex  common.LedgerSpecifier `json:"ledger_index,omitempty"`
-	Full         bool                   `json:"full,omitempty"`
-	Accounts     bool                   `json:"accounts,omitempty"`
-	Expand       bool                   `json:"expand,omitempty"`
-	Transactions bool                   `json:"transactions,omitempty"`
-	OwnerFunds   bool                   `json:"owner_funds,omitempty"`
-	Binary       bool                   `json:"binary,omitempty"`
-	Queue        bool                   `json:"queue,omitempty"`
-	Type         ledger.EntryType       `json:"type,omitempty"`
+	// A 32-byte hex string for the ledger version to use. (See Specifying Ledgers).
+	LedgerHash common.LedgerHash `json:"ledger_hash,omitempty"`
+	// The ledger index of the ledger to use, or a shortcut string to choose a ledger automatically. (See Specifying Ledgers)
+	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Full        bool                   `json:"full,omitempty"`
+	Accounts    bool                   `json:"accounts,omitempty"`
+	// Provide full JSON-formatted information for transaction/account information instead of only hashes. The default is false. Ignored unless you request transactions, accounts, or both.
+	Expand bool `json:"expand,omitempty"`
+	// If true, return information on transactions in the specified ledger version. The default is false. Ignored if you did not specify a ledger version.
+	Transactions bool `json:"transactions,omitempty"`
+	// If true, include owner_funds field in the metadata of OfferCreate transactions in the response. The default is false. Ignored unless transactions are included and expand is true.
+	OwnerFunds bool `json:"owner_funds,omitempty"`
+	// If true, and transactions and expand are both also true, return transaction information in binary format (hexadecimal string) instead of JSON format. The default is false. Ignored unless transactions and expand are both true.
+	Binary bool `json:"binary,omitempty"`
+	// If true, and the command is requesting the current ledger, includes an array of queued transactions in the results. The default is false.
+	Queue bool             `json:"queue,omitempty"`
+	Type  ledger.EntryType `json:"type,omitempty"`
 }
 
 func (*Request) Method() string {

--- a/xrpl/queries/ledger/types/ledger.go
+++ b/xrpl/queries/ledger/types/ledger.go
@@ -8,20 +8,20 @@ import (
 )
 
 type BaseLedger struct {
-	AccountHash         string                        `json:"account_hash"`
-	AccountState        []ledger.FlatLedgerObject     `json:"accountState,omitempty"`
-	CloseFlags          int                           `json:"close_flags"`
-	CloseTime           int                           `json:"close_time"`
-	CloseTimeHuman      string                        `json:"close_time_human"`
-	CloseTimeResolution int                           `json:"close_time_resolution"`
-	Closed              bool                          `json:"closed"`
-	LedgerHash          string                        `json:"ledger_hash"`
-	LedgerIndex         common.LedgerIndex            `json:"ledger_index"`
-	ParentCloseTime     int                           `json:"parent_close_time"`
-	ParentHash          string                        `json:"parent_hash"`
-	TotalCoins          types.XRPCurrencyAmount       `json:"total_coins"`
-	TransactionHash     string                        `json:"transaction_hash"`
-	Transactions        []transaction.FlatTransaction `json:"transactions,omitempty"`
+	AccountHash         string                    `json:"account_hash"`
+	AccountState        []ledger.FlatLedgerObject `json:"accountState,omitempty"`
+	CloseFlags          int                       `json:"close_flags"`
+	CloseTime           int                       `json:"close_time"`
+	CloseTimeHuman      string                    `json:"close_time_human"`
+	CloseTimeResolution int                       `json:"close_time_resolution"`
+	Closed              bool                      `json:"closed"`
+	LedgerHash          string                    `json:"ledger_hash"`
+	LedgerIndex         common.LedgerIndex        `json:"ledger_index"`
+	ParentCloseTime     int                       `json:"parent_close_time"`
+	ParentHash          string                    `json:"parent_hash"`
+	TotalCoins          types.XRPCurrencyAmount   `json:"total_coins"`
+	TransactionHash     string                    `json:"transaction_hash"`
+	Transactions        []interface{}             `json:"transactions,omitempty"`
 }
 
 type QueueData struct {

--- a/xrpl/queries/ledger/v1/ledger.go
+++ b/xrpl/queries/ledger/v1/ledger.go
@@ -47,7 +47,7 @@ func (*Request) Validate() error {
 type Response struct {
 	Ledger      ledgertypesv1.BaseLedger  `json:"ledger"`
 	LedgerHash  string                    `json:"ledger_hash"`
-	LedgerIndex common.LedgerIndex        `json:"ledger_index"`
+	LedgerIndex string                    `json:"ledger_index"`
 	Validated   bool                      `json:"validated,omitempty"`
 	QueueData   []ledgertypesv1.QueueData `json:"queue_data,omitempty"`
 }

--- a/xrpl/queries/ledger/v1/ledger_test.go
+++ b/xrpl/queries/ledger/v1/ledger_test.go
@@ -39,7 +39,7 @@ func TestLedgerResponse(t *testing.T) {
 			TransactionHash:     "50B3A8FE2C5620E43AA57564209AEDFEA3E868CFA2F6E4AB4B9E55A7A62AAF7B",
 		},
 		LedgerHash:  "1723099E269C77C4BDE86C83FA6415D71CF20AA5CB4A94E5C388ED97123FB55B",
-		LedgerIndex: 54300932,
+		LedgerIndex: "54300932",
 		Validated:   true,
 	}
 	j := `{
@@ -58,7 +58,7 @@ func TestLedgerResponse(t *testing.T) {
 		"transaction_hash": "50B3A8FE2C5620E43AA57564209AEDFEA3E868CFA2F6E4AB4B9E55A7A62AAF7B"
 	},
 	"ledger_hash": "1723099E269C77C4BDE86C83FA6415D71CF20AA5CB4A94E5C388ED97123FB55B",
-	"ledger_index": 54300932,
+	"ledger_index": "54300932",
 	"validated": true
 }`
 	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {


### PR DESCRIPTION
# [TA-4185]: Ledger response when Expand is false

## Description
This PR aims to fix the issue #109 . `BaseLedger` `Transactions` field is now an `[]interface{}` due to type conflicts when `Expand` field is true or false in `ledger` request.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Change `BaseLedger.Transactions` type
- Update `ledger.Response` `LedgerIndex` v1 type 