### PR TITLE
[TA-4187]: Get balance changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### xrpl
+
+- Added `BalanceChanges` to the `Transaction` type.
+
+### Changed
+
+#### xrpl
+
+- Updated `AffectedNode` type fields to be a pointer to allow nil values.
+
 ## [v0.1.7]
 
 ### Added

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -5,8 +5,8 @@ import type * as Preset from '@docusaurus/preset-classic';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'XRPL Go',
-  tagline: 'XRPL Go',
+  title: 'XRPL GO',
+  tagline: 'XRPL GO',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
@@ -22,6 +22,9 @@ const config: Config = {
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+
+  deploymentBranch: 'gh-pages',
+  trailingSlash: false,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -40,22 +43,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-        },
-        blog: {
-          showReadingTime: true,
-          feedOptions: {
-            type: ['rss', 'atom'],
-            xslt: true,
-          },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-          // Useful options to enforce blogging best practices
-          onInlineTags: 'warn',
-          onInlineAuthors: 'warn',
-          onUntruncatedBlogPosts: 'warn',
+            'https://github.com/Peersyst/xrpl-go/tree/main/docs',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/xrpl/transaction/balance_changes.go
+++ b/xrpl/transaction/balance_changes.go
@@ -1,0 +1,289 @@
+package transaction
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/Peersyst/xrpl-go/xrpl/currency"
+	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+type Balance struct {
+	Value    string `json:"amount"`
+	Currency string `json:"currency"`
+	Issuer   string `json:"issuer,omitempty"`
+}
+
+type BalanceChange struct {
+	Account types.Address `json:"account"`
+	Balance `json:"balance"`
+}
+
+type AccountBalanceChanges struct {
+	Account  types.Address `json:"account"`
+	Balances []Balance     `json:"balances"`
+}
+
+type Fields struct {
+	Account   types.Address
+	Balance   types.CurrencyAmount
+	LowLimit  types.IssuedCurrencyAmount
+	HighLimit types.IssuedCurrencyAmount
+}
+
+type NormalizedNode struct {
+	NodeType          string
+	LedgerEntryType   ledger.EntryType
+	LedgerIndex       string
+	NewFields         ledger.FlatLedgerObject
+	FinalFields       ledger.FlatLedgerObject
+	PreviousFields    ledger.FlatLedgerObject
+	PreviousTxnID     string
+	PreviousTxnLgrSeq uint64
+}
+
+func NewNormalizedNode(node AffectedNode) *NormalizedNode {
+	switch {
+	case node.CreatedNode != nil:
+		return &NormalizedNode{
+			NodeType:          "CreatedNode",
+			LedgerEntryType:   node.CreatedNode.LedgerEntryType,
+			LedgerIndex:       node.CreatedNode.LedgerIndex,
+			NewFields:         node.CreatedNode.NewFields,
+			FinalFields:       nil,
+			PreviousFields:    nil,
+			PreviousTxnID:     "",
+			PreviousTxnLgrSeq: 0,
+		}
+	case node.ModifiedNode != nil:
+		return &NormalizedNode{
+			NodeType:          "ModifiedNode",
+			LedgerEntryType:   node.ModifiedNode.LedgerEntryType,
+			LedgerIndex:       node.ModifiedNode.LedgerIndex,
+			NewFields:         nil,
+			FinalFields:       node.ModifiedNode.FinalFields,
+			PreviousFields:    node.ModifiedNode.PreviousFields,
+			PreviousTxnID:     node.ModifiedNode.PreviousTxnID,
+			PreviousTxnLgrSeq: node.ModifiedNode.PreviousTxnLgrSeq,
+		}
+	case node.DeletedNode != nil:
+		return &NormalizedNode{
+			NodeType:        "DeletedNode",
+			LedgerEntryType: node.DeletedNode.LedgerEntryType,
+			LedgerIndex:     node.DeletedNode.LedgerIndex,
+			FinalFields:     node.DeletedNode.FinalFields,
+		}
+	default:
+		return nil
+	}
+}
+
+func GetBalanceChanges(meta *TxObjMeta) ([]AccountBalanceChanges, error) {
+	nodes := normalizeNodes(meta.AffectedNodes)
+
+	balanceChanges := make([]BalanceChange, 0, len(nodes))
+
+	for _, node := range nodes {
+		switch node.LedgerEntryType {
+		case ledger.AccountRootEntry:
+			xrpBalance, err := getXRPQuantity(node)
+			if err != nil {
+				return nil, err
+			}
+			if xrpBalance != nil {
+				balanceChanges = append(balanceChanges, *xrpBalance)
+			}
+		case ledger.RippleStateEntry:
+			trustlineChanges, err := getTrustlineQuantity(node)
+			if err != nil {
+				return nil, err
+			}
+			if len(trustlineChanges) > 0 {
+				balanceChanges = append(balanceChanges, trustlineChanges...)
+			}
+		default:
+			continue
+		}
+	}
+
+	return groupByAccount(balanceChanges), nil
+}
+
+func normalizeNodes(nodes []AffectedNode) []*NormalizedNode {
+	normalizedNodes := make([]*NormalizedNode, len(nodes))
+	for i, node := range nodes {
+		normalizedNodes[i] = NewNormalizedNode(node)
+	}
+	return normalizedNodes
+}
+
+func getXRPQuantity(node *NormalizedNode) (*BalanceChange, error) {
+	var account string
+	if finalFieldsAccount, ok := node.FinalFields["Account"]; ok {
+		account = finalFieldsAccount.(string)
+	} else if newFieldsAccount, ok := node.NewFields["Account"]; ok {
+		account = newFieldsAccount.(string)
+	}
+
+	value, err := computeBalanceChange(node)
+	if err != nil {
+		return nil, err
+	}
+
+	var isNegative bool
+	if strings.HasPrefix(value, "-") {
+		isNegative = true
+		value = strings.TrimPrefix(value, "-")
+	}
+
+	xrpAmount, err := currency.DropsToXrp(value)
+	if err != nil {
+		return nil, err
+	}
+
+	if isNegative {
+		xrpAmount = strings.Join([]string{"-", xrpAmount}, "")
+	}
+
+	return &BalanceChange{
+		Account: types.Address(account),
+		Balance: Balance{
+			Currency: "XRP",
+			Value:    xrpAmount,
+		},
+	}, nil
+}
+
+func getTrustlineQuantity(node *NormalizedNode) ([]BalanceChange, error) {
+	value, err := computeBalanceChange(node)
+	if err != nil {
+		return nil, err
+	}
+
+	var fields ledger.FlatLedgerObject
+	if node.NewFields != nil {
+		fields = node.NewFields
+	} else {
+		fields = node.FinalFields
+	}
+
+	lowLimitIssuer, ok := fields["LowLimit"].(map[string]interface{})["issuer"]
+	if !ok {
+		return nil, errors.New("low limit issuer not found")
+	}
+	highLimitIssuer, ok := fields["HighLimit"].(map[string]interface{})["issuer"]
+	if !ok {
+		return nil, errors.New("high limit issuer not found")
+	}
+	balanceCurrency, ok := fields["Balance"].(map[string]interface{})["currency"]
+	if !ok {
+		return nil, errors.New("balance currency not found")
+	}
+
+	result := BalanceChange{
+		Account: types.Address(lowLimitIssuer.(string)),
+		Balance: Balance{
+			Issuer:   highLimitIssuer.(string),
+			Currency: balanceCurrency.(string),
+			Value:    value,
+		},
+	}
+
+	bigFloatValue, ok := new(big.Float).SetString(value)
+	if !ok {
+		return nil, errors.New("invalid balance value")
+	}
+	negatedValue := new(big.Float).Neg(bigFloatValue)
+
+	flippedResult := BalanceChange{
+		Account: types.Address(result.Balance.Issuer),
+		Balance: Balance{
+			Issuer:   result.Account.String(),
+			Currency: result.Balance.Currency,
+			Value:    negatedValue.String(),
+		},
+	}
+
+	return []BalanceChange{result, flippedResult}, nil
+}
+
+func computeBalanceChange(node *NormalizedNode) (string, error) {
+	newBalance, okNewBalance := node.NewFields["Balance"]
+	previousBalance, okPreviousBalance := node.PreviousFields["Balance"]
+	finalBalance, okFinalBalance := node.FinalFields["Balance"]
+
+	var value *big.Float
+	var ok bool
+	if okNewBalance {
+		balanceValue, err := getValue(newBalance)
+		if err != nil {
+			return "", err
+		}
+
+		value, ok = new(big.Float).SetString(balanceValue)
+		if !ok {
+			return "", errors.New("invalid balance value")
+		}
+	} else if okPreviousBalance && okFinalBalance {
+		balanceValue, err := getValue(previousBalance)
+		if err != nil {
+			return "", err
+		}
+
+		previousBalanceBigDecimal, ok := new(big.Float).SetString(balanceValue)
+		if !ok {
+			return "", errors.New("invalid balance value")
+		}
+		balanceValue, err = getValue(finalBalance)
+		if err != nil {
+			return "", err
+		}
+
+		finalBalanceBigInt, ok := new(big.Float).SetString(balanceValue)
+		if !ok {
+			return "", errors.New("invalid balance value")
+		}
+
+		value = finalBalanceBigInt.Sub(finalBalanceBigInt, previousBalanceBigDecimal)
+	}
+
+	return value.String(), nil
+}
+
+func getValue(balance interface{}) (string, error) {
+	if value, ok := balance.(string); ok {
+		return value, nil
+	} else if balanceMap, ok := balance.(map[string]interface{}); ok {
+		return balanceMap["value"].(string), nil
+	}
+	return "", errors.New("invalid balance value")
+}
+
+func groupByAccount(balanceChanges []BalanceChange) []AccountBalanceChanges {
+	accountBalances := make(map[string][]BalanceChange)
+
+	// Group balance changes by account address
+	for _, change := range balanceChanges {
+		account := change.Account.String()
+		accountBalances[account] = append(accountBalances[account], change)
+	}
+
+	// Convert map back to slice
+	result := make([]AccountBalanceChanges, 0)
+	for account, changes := range accountBalances {
+		if len(changes) > 0 {
+			balances := make([]Balance, len(changes))
+			for i, change := range changes {
+				balances[i] = change.Balance
+			}
+			result = append(result, AccountBalanceChanges{
+				Account:  types.Address(account),
+				Balances: balances,
+			})
+		}
+	}
+
+	return result
+}

--- a/xrpl/transaction/balance_changes_test.go
+++ b/xrpl/transaction/balance_changes_test.go
@@ -450,7 +450,7 @@ func TestGetBalanceChanges(t *testing.T) {
 					Balances: []Balance{
 						{
 							Value:    "-0.01",
-							Currency: "USD", 
+							Currency: "USD",
 							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
 						},
 						{

--- a/xrpl/transaction/balance_changes_test.go
+++ b/xrpl/transaction/balance_changes_test.go
@@ -1,0 +1,498 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBalanceChanges(t *testing.T) {
+	tt := []struct {
+		name     string
+		meta     *TxObjMeta
+		expected []AccountBalanceChanges
+	}{
+		{
+			name: "pass - USD payment to account with no USD",
+			meta: &TxObjMeta{
+				AffectedNodes: []AffectedNode{
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.535330905250352",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: ledger.RippleStateEntry,
+							LedgerIndex:     "2F323020B4288ACD4066CC64C89DAD2E4D5DFC2D44571942A51C005BF79D6E25",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.545330905250352",
+								},
+							},
+							PreviousTxnID:     "CEB7B6040C2989B9849C8D7E49F710457EDDE1D95ECDF1E298FD30CF2AC5BE11",
+							PreviousTxnLgrSeq: 10424776,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0.01",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: ledger.RippleStateEntry,
+							LedgerIndex:     "AAE13AF5192EFBFD49A8EEE5869595563FEB73228C0B38FED9CC3D20EE74F399",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0",
+								},
+							},
+							PreviousTxnID:     "A788447CF5FD7108CBF49416E2335F95ED3F5A9FC016686C8F9EFB34BBEA613A",
+							PreviousTxnLgrSeq: 10425088,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Account":    "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+								"Balance":    "239807992",
+								"Flags":      0,
+								"OwnerCount": 1,
+								"Sequence":   17,
+							},
+							LedgerEntryType: ledger.AccountRootEntry,
+							LedgerIndex:     "E9A39B0BA8703D5FFD05D9EAD01EE6C0E7A15CF33C2C6B7269107BD2BD535818",
+							PreviousFields: map[string]interface{}{
+								"Balance":  "239819992",
+								"Sequence": 16,
+							},
+							PreviousTxnID:     "3109F5A0F891CCA20B4D891EB7437973F40A7664C5176092EB2E5C0A949992AD",
+							PreviousTxnLgrSeq: 10424942,
+						},
+					},
+				},
+				TransactionIndex:  3,
+				TransactionResult: "tesSUCCESS",
+			},
+			expected: []AccountBalanceChanges{
+				{
+					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+					Balances: []Balance{
+						{
+							Value:    "-0.01",
+							Currency: "USD",
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						},
+						{
+							Value:    "-0.012",
+							Currency: "XRP",
+						},
+					},
+				},
+				{
+					Account: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+					Balances: []Balance{
+						{
+							Value:    "0.01",
+							Currency: "USD",
+							Issuer:   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+						},
+						{
+							Value:    "-0.01",
+							Currency: "USD",
+							Issuer:   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+						},
+					},
+				},
+				{
+					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+					Balances: []Balance{
+						{
+							Value:    "0.01",
+							Currency: "USD",
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pass - XRP create account",
+			meta: &TxObjMeta{
+				AffectedNodes: []AffectedNode{
+					{
+						CreatedNode: &CreatedNode{
+							LedgerEntryType: ledger.AccountRootEntry,
+							LedgerIndex:     "C24354B286600B8F28E51233B4AC41A3B4DDD0FDC9BCF96BB171573F6B40A4AE",
+							NewFields: ledger.FlatLedgerObject{
+								"Account":  "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+								"Balance":  "100000000",
+								"Sequence": 1,
+							},
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Account":    "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+								"Balance":    "339903994",
+								"Flags":      0,
+								"OwnerCount": 0,
+								"Sequence":   9,
+							},
+							LedgerEntryType: ledger.AccountRootEntry,
+							LedgerIndex:     "E9A39B0BA8703D5FFD05D9EAD01EE6C0E7A15CF33C2C6B7269107BD2BD535818",
+							PreviousFields: map[string]interface{}{
+								"Balance":  "439915994",
+								"Sequence": 8,
+							},
+							PreviousTxnID:     "0E6CF1A13C6A804BE50B08C1D0446C7405D8461254CC6B62337CA9FEA4DF13EC",
+							PreviousTxnLgrSeq: 10424064,
+						},
+					},
+				},
+			},
+			expected: []AccountBalanceChanges{
+				{
+					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+					Balances: []Balance{
+						{
+							Value:    "100",
+							Currency: "XRP",
+						},
+					},
+				},
+				{
+					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+					Balances: []Balance{
+						{
+							Value:    "-100.012",
+							Currency: "XRP",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pass - USD payment of all USD in source account",
+			meta: &TxObjMeta{
+				AffectedNodes: []AffectedNode{
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.545330905250352",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: ledger.RippleStateEntry,
+							LedgerIndex:     "2F323020B4288ACD4066CC64C89DAD2E4D5DFC2D44571942A51C005BF79D6E25",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.345330905250352",
+								},
+							},
+							PreviousTxnID:     "24525F80080EAC8857F1A29A47AEF23FD2B0A52DAF7DC3900A4E31831187FCB1",
+							PreviousTxnLgrSeq: 10443886,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: ledger.RippleStateEntry,
+							LedgerIndex:     "AAE13AF5192EFBFD49A8EEE5869595563FEB73228C0B38FED9CC3D20EE74F399",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0.2",
+								},
+							},
+							PreviousTxnID:     "24525F80080EAC8857F1A29A47AEF23FD2B0A52DAF7DC3900A4E31831187FCB1",
+							PreviousTxnLgrSeq: 10443886,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Account":    "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+								"Balance":    "99976002",
+								"Flags":      0,
+								"OwnerCount": 1,
+								"Sequence":   3,
+							},
+							LedgerEntryType: ledger.AccountRootEntry,
+							LedgerIndex:     "C24354B286600B8F28E51233B4AC41A3B4DDD0FDC9BCF96BB171573F6B40A4AE",
+							PreviousFields: map[string]interface{}{
+								"Balance":  "99988002",
+								"Sequence": 2,
+							},
+							PreviousTxnID:     "A788447CF5FD7108CBF49416E2335F95ED3F5A9FC016686C8F9EFB34BBEA613A",
+							PreviousTxnLgrSeq: 10425088,
+						},
+					},
+				},
+			},
+			expected: []AccountBalanceChanges{
+				{
+					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+					Balances: []Balance{
+						{
+							Value:    "0.2",
+							Currency: "USD",
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						},
+					},
+				},
+				{
+					Account: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+					Balances: []Balance{
+						{
+							Value:    "-0.2",
+							Currency: "USD",
+							Issuer:   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+						},
+
+						{
+							Value:    "0.2",
+							Currency: "USD",
+							Issuer:   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+						},
+					},
+				},
+				{
+					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+					Balances: []Balance{
+						{
+							Value:    "-0.2",
+							Currency: "USD",
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						},
+
+						{
+							Value:    "-0.012",
+							Currency: "XRP",
+							Issuer:   "",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pass - USD payment to account with USD",
+			meta: &TxObjMeta{
+				AffectedNodes: []AffectedNode{
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.525330905250352",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: "RippleState",
+							LedgerIndex:     "2F323020B4288ACD4066CC64C89DAD2E4D5DFC2D44571942A51C005BF79D6E25",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "1.535330905250352",
+								},
+							},
+							PreviousTxnID:     "DC061E6F47B1B6E9A496A31B1AF87194B4CB24B2EBF8A59F35E31E12509238BD",
+							PreviousTxnLgrSeq: 10459364,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0.02",
+								},
+								"Flags": 1114112,
+								"HighLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+									"value":    "0",
+								},
+								"HighNode": "00000000000001E8",
+								"LowLimit": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+									"value":    "1000000000",
+								},
+								"LowNode": "0000000000000000",
+							},
+							LedgerEntryType: "RippleState",
+							LedgerIndex:     "AAE13AF5192EFBFD49A8EEE5869595563FEB73228C0B38FED9CC3D20EE74F399",
+							PreviousFields: map[string]interface{}{
+								"Balance": map[string]interface{}{
+									"currency": "USD",
+									"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
+									"value":    "0.01",
+								},
+							},
+							PreviousTxnID:     "DC061E6F47B1B6E9A496A31B1AF87194B4CB24B2EBF8A59F35E31E12509238BD",
+							PreviousTxnLgrSeq: 10459364,
+						},
+					},
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: map[string]interface{}{
+								"Account":    "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+								"Balance":    "239555992",
+								"Flags":      0,
+								"OwnerCount": 1,
+								"Sequence":   38,
+							},
+							LedgerEntryType: "AccountRoot",
+							LedgerIndex:     "E9A39B0BA8703D5FFD05D9EAD01EE6C0E7A15CF33C2C6B7269107BD2BD535818",
+							PreviousFields: map[string]interface{}{
+								"Balance":  "239567992",
+								"Sequence": 37,
+							},
+							PreviousTxnID:     "DC061E6F47B1B6E9A496A31B1AF87194B4CB24B2EBF8A59F35E31E12509238BD",
+							PreviousTxnLgrSeq: 10459364,
+						},
+					},
+				},
+			},
+			expected: []AccountBalanceChanges{
+				{
+					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+					Balances: []Balance{
+						{
+							Value:    "-0.01",
+							Currency: "USD", 
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+						},
+						{
+							Value:    "-0.012",
+							Currency: "XRP",
+						},
+					},
+				},
+				{
+					Account: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+					Balances: []Balance{
+						{
+							Issuer:   "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+							Currency: "USD",
+							Value:    "0.01",
+						},
+						{
+							Issuer:   "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+							Currency: "USD",
+							Value:    "-0.01",
+						},
+					},
+				},
+				{
+					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+					Balances: []Balance{
+						{
+							Issuer:   "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+							Currency: "USD",
+							Value:    "0.01",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			balanceChanges, err := GetBalanceChanges(tc.meta)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, balanceChanges)
+		})
+	}
+}

--- a/xrpl/transaction/balance_changes_test.go
+++ b/xrpl/transaction/balance_changes_test.go
@@ -375,7 +375,7 @@ func TestGetBalanceChanges(t *testing.T) {
 								},
 								"LowNode": "0000000000000000",
 							},
-							LedgerEntryType: "RippleState",
+							LedgerEntryType: ledger.RippleStateEntry,
 							LedgerIndex:     "2F323020B4288ACD4066CC64C89DAD2E4D5DFC2D44571942A51C005BF79D6E25",
 							PreviousFields: map[string]interface{}{
 								"Balance": map[string]interface{}{
@@ -410,7 +410,7 @@ func TestGetBalanceChanges(t *testing.T) {
 								},
 								"LowNode": "0000000000000000",
 							},
-							LedgerEntryType: "RippleState",
+							LedgerEntryType: ledger.RippleStateEntry,
 							LedgerIndex:     "AAE13AF5192EFBFD49A8EEE5869595563FEB73228C0B38FED9CC3D20EE74F399",
 							PreviousFields: map[string]interface{}{
 								"Balance": map[string]interface{}{
@@ -432,7 +432,7 @@ func TestGetBalanceChanges(t *testing.T) {
 								"OwnerCount": 1,
 								"Sequence":   38,
 							},
-							LedgerEntryType: "AccountRoot",
+							LedgerEntryType: ledger.AccountRootEntry,
 							LedgerIndex:     "E9A39B0BA8703D5FFD05D9EAD01EE6C0E7A15CF33C2C6B7269107BD2BD535818",
 							PreviousFields: map[string]interface{}{
 								"Balance":  "239567992",

--- a/xrpl/transaction/balance_changes_test.go
+++ b/xrpl/transaction/balance_changes_test.go
@@ -190,19 +190,19 @@ func TestGetBalanceChanges(t *testing.T) {
 			},
 			expected: []AccountBalanceChanges{
 				{
-					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
 					Balances: []Balance{
 						{
-							Value:    "100",
+							Value:    "-100.012",
 							Currency: "XRP",
 						},
 					},
 				},
 				{
-					Account: "rKmBGxocj9Abgy25J51Mk1iqFzW9aVF9Tc",
+					Account: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
 					Balances: []Balance{
 						{
-							Value:    "-100.012",
+							Value:    "100",
 							Currency: "XRP",
 						},
 					},
@@ -492,7 +492,7 @@ func TestGetBalanceChanges(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			balanceChanges, err := GetBalanceChanges(tc.meta)
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, balanceChanges)
+			require.ElementsMatch(t, tc.expected, balanceChanges)
 		})
 	}
 }

--- a/xrpl/transaction/transaction_metadata.go
+++ b/xrpl/transaction/transaction_metadata.go
@@ -22,9 +22,9 @@ type TxObjMeta struct {
 func (TxObjMeta) TxMeta() {}
 
 type AffectedNode struct {
-	CreatedNode  CreatedNode  `json:"CreatedNode,omitempty"`
-	ModifiedNode ModifiedNode `json:"ModifiedNode,omitempty"`
-	DeletedNode  DeletedNode  `json:"DeletedNode,omitempty"`
+	CreatedNode  *CreatedNode  `json:"CreatedNode,omitempty"`
+	ModifiedNode *ModifiedNode `json:"ModifiedNode,omitempty"`
+	DeletedNode  *DeletedNode  `json:"DeletedNode,omitempty"`
 }
 
 type CreatedNode struct {


### PR DESCRIPTION
# [TA-4187]: Get balance changes

## Description
This PR aims to add the `GetBalanceChanges` util to calculate all balance changes within a transaction `meta` field object. This PR satisfies the #111 issue.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Add `GetBalanceChanges` util
- Refactor `AffectedNode` `CreatedNode`, `ModifiedNode` and `DeleteNode` fields to pointers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking of ledger transaction balance changes to provide more detailed insights into account updates.
  - Introduced new data structures for managing balance changes in transactions.
  
- **Refactor**
  - Updated transaction data handling to allow optional fields for more flexible representation of transaction details.

- **Tests**
  - Added tests to validate the behavior of balance change retrieval across various transaction scenarios, ensuring accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->