### PR TITLE
fix(docs): hide `address-codec` and `binary-codec` pages

### DIFF
--- a/docs/docs/address-codec.md
+++ b/docs/docs/address-codec.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 4
----
-
-Coming soon.

--- a/docs/docs/binary-codec.md
+++ b/docs/docs/binary-codec.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 3
----
-
-Coming soon.


### PR DESCRIPTION
# fix(docs): hide `address-codec` and `binary-codec` pages

## Description
This PR aims to remove `address-codec` and `binary-codec` documentation pages until done.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Removed `address-codec` doc page
- Removed `binary-codec` doc page
