### PR TITLE
[TA-4223]: Amounts transcoding fix

### DIFF
--- a/pkg/big-decimal/big_decimal.go
+++ b/pkg/big-decimal/big_decimal.go
@@ -35,7 +35,7 @@ func (bd *BigDecimal) GetScaledValue() string {
 	// Use SetPrec to maintain full precision
 	unscaled := new(big.Float).SetPrec(512) // Use high precision to avoid scientific notation
 	unscaled, _ = unscaled.SetString(bd.UnscaledValue)
-	
+
 	scalingFactor := new(big.Float).SetPrec(512).SetFloat64(1)
 	for i := 0; i < abs(bd.Scale); i++ {
 		scalingFactor.Mul(scalingFactor, big.NewFloat(10))

--- a/pkg/big-decimal/big_decimal.go
+++ b/pkg/big-decimal/big_decimal.go
@@ -12,6 +12,7 @@ import (
 const (
 	AllowedCharacters = "0123456789.-eE"
 	BigDecRegEx       = "-?(?:[0|1-9]\\d*)(?:\\.\\d+)?(?:[eE][+\\-]?\\d+)?"
+	Precision         = 128
 )
 
 var (
@@ -33,19 +34,19 @@ func (bd *BigDecimal) GetScaledValue() string {
 	}
 
 	// Use SetPrec to maintain full precision
-	unscaled := new(big.Float).SetPrec(512) // Use high precision to avoid scientific notation
+	unscaled := new(big.Float).SetPrec(Precision) // Use high precision to avoid scientific notation
 	unscaled, _ = unscaled.SetString(bd.UnscaledValue)
 
-	scalingFactor := new(big.Float).SetPrec(512).SetFloat64(1)
+	scalingFactor := new(big.Float).SetPrec(Precision).SetFloat64(1)
 	for i := 0; i < abs(bd.Scale); i++ {
 		scalingFactor.Mul(scalingFactor, big.NewFloat(10))
 	}
 
 	var scaledValue *big.Float
 	if bd.Scale >= 0 {
-		scaledValue = new(big.Float).SetPrec(512).Mul(unscaled, scalingFactor)
+		scaledValue = new(big.Float).SetPrec(Precision).Mul(unscaled, scalingFactor)
 	} else {
-		scaledValue = new(big.Float).SetPrec(512).Quo(unscaled, scalingFactor)
+		scaledValue = new(big.Float).SetPrec(Precision).Quo(unscaled, scalingFactor)
 	}
 
 	if bd.Sign == 1 {

--- a/pkg/big-decimal/big_decimal.go
+++ b/pkg/big-decimal/big_decimal.go
@@ -143,8 +143,6 @@ func valNoDecimalNoE(_ int, prefix, decP string) (sc int, uv string) {
 func valNoDecimalHasE(scale int, prefix, _ string) (sc int, uv string) {
 	uv = strings.Trim(prefix, "0")
 	sc = scale + len(strings.TrimLeft(prefix, "0")) - len(uv)
-	fmt.Println("uv", uv)
-	fmt.Println("sc", sc)
 	return
 
 }

--- a/pkg/big-decimal/big_decimal_test.go
+++ b/pkg/big-decimal/big_decimal_test.go
@@ -62,6 +62,16 @@ func TestGetScaledValue(t *testing.T) {
 			},
 			expected: "-23.005",
 		},
+		{
+			description: "large value",
+			bd: &BigDecimal{
+				Scale:         7,
+				UnscaledValue: "999999999999999",
+				Precision:     16,
+				Sign:          0,
+			},
+			expected: "9999999999999990000000",
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
# [TA-4223]: Amounts transcoding fix

## Description
This PR aims to fix issue #118, were specific IOU amounts were not being decoded successfully.


### Detection

What was causing the issue was the `GetScaledValue` of the `BigDecimal` struct in `x/pkg/big-decimal`. This function parses the `UnscaledValue` of the `BigDecimal` and initialises a `big.Float` with that value. The issue was that the `big.Float` did not have enough precision to initialise the value correctly, therefore causing an invalid `UnscaledValue` representation. 

### Solution

To fix this issue, we set `big.Float` a precision of `128` bits (approximately 38-39 decimal digits).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Refactor `GetScaledValue` to handle `big.Float` precision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced precision in numerical calculations ensures clear, non-scientific notation output and robust handling of empty or edge-case inputs.
- **Tests**
  - Expanded test coverage to verify accurate computation with large numerical values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->