### PR TITLE
Adds fields related to Credentials to several transaction types

### DIFF
--- a/examples/clients/submission.go
+++ b/examples/clients/submission.go
@@ -20,7 +20,7 @@ type TransactionClient interface {
 }
 
 // SubmitAndWait submits a transaction and waits for it to be included in a validated ledger
-func SubmitAndWait(client TransactionClient, txn SubmittableTransaction, wallet wallet.Wallet) {
+func SubmitAndWait(client TransactionClient, txn SubmittableTransaction, wallet wallet.Wallet) *requests.TxResponse {
 	fmt.Println()
 	fmt.Printf("⏳ Submitting %s transaction...\n", txn.TxType())
 
@@ -30,24 +30,26 @@ func SubmitAndWait(client TransactionClient, txn SubmittableTransaction, wallet 
 	if err != nil {
 		fmt.Printf("❌ Error autofilling %s transaction: %s\n", txn.TxType(), err)
 		fmt.Println()
-		return
+		return nil
 	}
 
 	txBlob, _, err := wallet.Sign(flattenedTx)
 	if err != nil {
 		fmt.Printf("❌ Error signing %s transaction: %s\n", txn.TxType(), err)
 		fmt.Println()
-		return
+		return nil
 	}
 
 	response, err := client.SubmitAndWait(txBlob, false)
 	if err != nil {
 		fmt.Printf("❌ Error submitting %s transaction: %s\n", txn.TxType(), err)
 		fmt.Println()
-		return
+		return nil
 	}
 
 	fmt.Printf("✅ %s transaction submitted\n", txn.TxType())
 	fmt.Printf("🌐 Hash: %s\n", response.Hash.String())
 	fmt.Println()
+
+	return response
 }

--- a/examples/deposit-preauth/rpc/main.go
+++ b/examples/deposit-preauth/rpc/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/Peersyst/xrpl-go/examples/clients"
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	rippleTime "github.com/Peersyst/xrpl-go/xrpl/time"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+)
+
+func main() {
+	client := clients.GetDevnetRpcClient()
+
+	// Configure wallets
+
+	// Issuer
+	fmt.Println("⏳ Setting up credential issuer wallet...")
+	issuer, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating credential issuer wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&issuer)
+	if err != nil {
+		fmt.Printf("❌ Error funding credential issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Credential issuer wallet funded: %s\n", issuer.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 1
+	fmt.Println("⏳ Setting up holder 1 wallet...")
+	holderWallet1, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder 1 wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet1)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder 1 wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder 1 wallet funded: %s\n", holderWallet1.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Enabling DepositAuth on the issuer account with an AccountSet transaction
+	fmt.Println("⏳ Enabling DepositAuth on the issuer account...")
+	accountSetTx := &transaction.AccountSet{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.AccountSetTx,
+		},
+	}
+	accountSetTx.SetAsfDepositAuth()
+
+	clients.SubmitAndWait(client, accountSetTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Creating the CredentialCreate transaction
+	fmt.Println("⏳ Creating the CredentialCreate transaction...")
+
+	expiration, err := rippleTime.IsoTimeToRippleTime(time.Now().Add(time.Hour * 24).Format(time.RFC3339))
+	if err != nil {
+		fmt.Printf("❌ Error converting expiration to ripple time: %s\n", err)
+		return
+	}
+	credentialType := types.CredentialType("6D795F63726564656E7469616C") // my_credential
+
+	credentialCreateTx := &transaction.CredentialCreate{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.CredentialCreateTx,
+		},
+		Expiration:     uint32(expiration),
+		CredentialType: credentialType,
+		Subject:        types.Address(holderWallet1.ClassicAddress),
+		URI:            hex.EncodeToString([]byte("https://example.com")),
+	}
+
+	clients.SubmitAndWait(client, credentialCreateTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Creating the CredentialAccept transaction
+	fmt.Println("⏳ Creating the CredentialAccept transaction...")
+
+	credentialAcceptTx := &transaction.CredentialAccept{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.CredentialAcceptTx,
+		},
+		CredentialType: credentialType,
+		Issuer:         types.Address(issuer.ClassicAddress),
+	}
+
+	clients.SubmitAndWait(client, credentialAcceptTx, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Creating the DepositPreauth transaction
+	fmt.Println("⏳ Creating the DepositPreauth transaction using AuthorizeCredentials...")
+
+	depositPreauthTx := &transaction.DepositPreauth{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.DepositPreauthTx,
+		},
+		AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
+			{
+				Credential: types.AuthorizeCredentials{
+					Issuer:         issuer.ClassicAddress,
+					CredentialType: credentialType,
+				},
+			},
+		},
+	}
+
+	clients.SubmitAndWait(client, depositPreauthTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Get the credential ID
+	fmt.Println("⏳ Getting the credential ID from the holder 1 account...")
+
+	objectsRequest := &account.ObjectsRequest{
+		Account:     holderWallet1.ClassicAddress,
+		Type:        account.CredentialObject,
+		LedgerIndex: common.Validated,
+	}
+
+	objectsResponse, err := client.GetAccountObjects(objectsRequest)
+	if err != nil {
+		fmt.Printf("❌ Error getting the credential ID: %s\n", err)
+		return
+	}
+
+	credentialID := objectsResponse.AccountObjects[0]["index"].(string)
+	fmt.Printf("✅ Credential ID: %s\n", credentialID)
+	fmt.Println()
+
+	// -----------------------------------------------------
+
+	// Sending XRP to the holder 1 account
+	fmt.Println("⏳ Sending XRP to the issuer account, should succeed...")
+
+	sendTx := &transaction.Payment{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.PaymentTx,
+		},
+		Amount:        types.XRPCurrencyAmount(1000000),
+		Destination:   issuer.ClassicAddress,
+		CredentialIDs: types.CredentialIDs{credentialID},
+	}
+
+	clients.SubmitAndWait(client, sendTx, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Unauthorizing the holder 1 account
+	fmt.Println("⏳ Unauthorizing the holder 1 account with the DepositPreauth transaction and the UnauthorizeCredentials field...")
+
+	unauthorizeTx := &transaction.DepositPreauth{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.DepositPreauthTx,
+		},
+		UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
+			{
+				Credential: types.AuthorizeCredentials{
+					Issuer:         issuer.ClassicAddress,
+					CredentialType: credentialType,
+				},
+			},
+		},
+	}
+
+	clients.SubmitAndWait(client, unauthorizeTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending XRP to the holder 1 account again (which should fail)
+	fmt.Println("⏳ Sending XRP to the issuer account again (which should fail)...")
+
+	sendTx2 := &transaction.Payment{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.PaymentTx,
+		},
+		Amount:        types.XRPCurrencyAmount(1000000),
+		Destination:   issuer.ClassicAddress,
+		CredentialIDs: types.CredentialIDs{credentialID},
+	}
+
+	clients.SubmitAndWait(client, sendTx2, holderWallet1)
+}

--- a/examples/deposit-preauth/ws/main.go
+++ b/examples/deposit-preauth/ws/main.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/Peersyst/xrpl-go/examples/clients"
+	"github.com/Peersyst/xrpl-go/pkg/crypto"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	rippleTime "github.com/Peersyst/xrpl-go/xrpl/time"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+)
+
+func main() {
+
+	fmt.Println("⏳ Setting up client...")
+
+	client := clients.GetDevnetWebsocketClient()
+	fmt.Println("Connecting to server...")
+	if err := client.Connect(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("✅ Client configured!")
+	fmt.Println()
+
+	fmt.Printf("Connection: %t", client.IsConnected())
+	fmt.Println()
+
+	// Configure wallets
+
+	// Issuer
+	fmt.Println("⏳ Setting up credential issuer wallet...")
+	issuer, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating credential issuer wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&issuer)
+	if err != nil {
+		fmt.Printf("❌ Error funding credential issuer wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Credential issuer wallet funded: %s\n", issuer.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Holder 1
+	fmt.Println("⏳ Setting up holder 1 wallet...")
+	holderWallet1, err := wallet.New(crypto.ED25519())
+	if err != nil {
+		fmt.Printf("❌ Error creating holder 1 wallet: %s\n", err)
+		return
+	}
+
+	err = client.FundWallet(&holderWallet1)
+	if err != nil {
+		fmt.Printf("❌ Error funding holder 1 wallet: %s\n", err)
+		return
+	}
+	fmt.Printf("✅ Holder 1 wallet funded: %s\n", holderWallet1.ClassicAddress)
+
+	// -----------------------------------------------------
+
+	// Enabling DepositAuth on the issuer account with an AccountSet transaction
+	fmt.Println("⏳ Enabling DepositAuth on the issuer account...")
+	accountSetTx := &transaction.AccountSet{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.AccountSetTx,
+		},
+	}
+	accountSetTx.SetAsfDepositAuth()
+
+	clients.SubmitAndWait(client, accountSetTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Creating the CredentialCreate transaction
+	fmt.Println("⏳ Creating the CredentialCreate transaction...")
+
+	expiration, err := rippleTime.IsoTimeToRippleTime(time.Now().Add(time.Hour * 24).Format(time.RFC3339))
+	if err != nil {
+		fmt.Printf("❌ Error converting expiration to ripple time: %s\n", err)
+		return
+	}
+	credentialType := types.CredentialType("6D795F63726564656E7469616C") // my_credential
+
+	credentialCreateTx := &transaction.CredentialCreate{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.CredentialCreateTx,
+		},
+		Expiration:     uint32(expiration),
+		CredentialType: credentialType,
+		Subject:        types.Address(holderWallet1.ClassicAddress),
+		URI:            hex.EncodeToString([]byte("https://example.com")),
+	}
+
+	clients.SubmitAndWait(client, credentialCreateTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Creating the CredentialAccept transaction
+	fmt.Println("⏳ Creating the CredentialAccept transaction...")
+
+	credentialAcceptTx := &transaction.CredentialAccept{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.CredentialAcceptTx,
+		},
+		CredentialType: credentialType,
+		Issuer:         types.Address(issuer.ClassicAddress),
+	}
+
+	clients.SubmitAndWait(client, credentialAcceptTx, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Creating the DepositPreauth transaction
+	fmt.Println("⏳ Creating the DepositPreauth transaction using AuthorizeCredentials...")
+
+	depositPreauthTx := &transaction.DepositPreauth{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.DepositPreauthTx,
+		},
+		AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
+			{
+				Credential: types.AuthorizeCredentials{
+					Issuer:         issuer.ClassicAddress,
+					CredentialType: credentialType,
+				},
+			},
+		},
+	}
+
+	clients.SubmitAndWait(client, depositPreauthTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Get the credential ID
+	fmt.Println("⏳ Getting the credential ID from the holder 1 account...")
+
+	objectsRequest := &account.ObjectsRequest{
+		Account:     holderWallet1.ClassicAddress,
+		Type:        account.CredentialObject,
+		LedgerIndex: common.Validated,
+	}
+
+	objectsResponse, err := client.GetAccountObjects(objectsRequest)
+	if err != nil {
+		fmt.Printf("❌ Error getting the credential ID: %s\n", err)
+		return
+	}
+
+	credentialID := objectsResponse.AccountObjects[0]["index"].(string)
+	fmt.Printf("✅ Credential ID: %s\n", credentialID)
+	fmt.Println()
+
+	// -----------------------------------------------------
+
+	// Sending XRP to the holder 1 account
+	fmt.Println("⏳ Sending XRP to the issuer account, should succeed...")
+
+	sendTx := &transaction.Payment{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.PaymentTx,
+		},
+		Amount:        types.XRPCurrencyAmount(1000000),
+		Destination:   issuer.ClassicAddress,
+		CredentialIDs: types.CredentialIDs{credentialID},
+	}
+
+	clients.SubmitAndWait(client, sendTx, holderWallet1)
+
+	// -----------------------------------------------------
+
+	// Unauthorizing the holder 1 account
+	fmt.Println("⏳ Unauthorizing the holder 1 account with the DepositPreauth transaction and the UnauthorizeCredentials field...")
+
+	unauthorizeTx := &transaction.DepositPreauth{
+		BaseTx: transaction.BaseTx{
+			Account:         issuer.ClassicAddress,
+			TransactionType: transaction.DepositPreauthTx,
+		},
+		UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
+			{
+				Credential: types.AuthorizeCredentials{
+					Issuer:         issuer.ClassicAddress,
+					CredentialType: credentialType,
+				},
+			},
+		},
+	}
+
+	clients.SubmitAndWait(client, unauthorizeTx, issuer)
+
+	// -----------------------------------------------------
+
+	// Sending XRP to the holder 1 account again (which should fail)
+	fmt.Println("⏳ Sending XRP to the issuer account again (which should fail)...")
+
+	sendTx2 := &transaction.Payment{
+		BaseTx: transaction.BaseTx{
+			Account:         holderWallet1.ClassicAddress,
+			TransactionType: transaction.PaymentTx,
+		},
+		Amount:        types.XRPCurrencyAmount(1000000),
+		Destination:   issuer.ClassicAddress,
+		CredentialIDs: types.CredentialIDs{credentialID},
+	}
+
+	clients.SubmitAndWait(client, sendTx2, holderWallet1)
+}

--- a/xrpl/queries/account/objects.go
+++ b/xrpl/queries/account/objects.go
@@ -11,6 +11,7 @@ type ObjectType string
 
 const (
 	CheckObject          ObjectType = "check"
+	CredentialObject     ObjectType = "credential"
 	DepositPreauthObject ObjectType = "deposit_preauth"
 	EscrowObject         ObjectType = "escrow"
 	NFTOfferObject       ObjectType = "nft_offer"

--- a/xrpl/transaction/account_delete.go
+++ b/xrpl/transaction/account_delete.go
@@ -24,6 +24,10 @@ import (
 // ```
 type AccountDelete struct {
 	BaseTx
+	// Set of Credentials to authorize a deposit made by this transaction.
+	// Each member of the array must be the ledger entry ID of a Credential entry in the ledger.
+	// For details see https://xrpl.org/docs/references/protocol/transactions/types/payment#credential-ids
+	CredentialIDs types.CredentialIDs `json:",omitempty"`
 	// The address of an account to receive any leftover XRP after deleting the sending account.
 	// Must be a funded account in the ledger, and must not be the sending account.
 	Destination types.Address

--- a/xrpl/transaction/account_delete.go
+++ b/xrpl/transaction/account_delete.go
@@ -46,6 +46,10 @@ func (s *AccountDelete) Flatten() FlatTransaction {
 	flatTx := s.BaseTx.Flatten()
 	flatTx["TransactionType"] = s.TxType().String()
 
+	if len(s.CredentialIDs) > 0 {
+		flatTx["CredentialIDs"] = s.CredentialIDs.Flatten()
+	}
+
 	if s.Destination != "" {
 		flatTx["Destination"] = s.Destination.String()
 	}
@@ -61,6 +65,10 @@ func (s *AccountDelete) Validate() (bool, error) {
 	_, err := s.BaseTx.Validate()
 	if err != nil {
 		return false, err
+	}
+
+	if s.CredentialIDs != nil && !s.CredentialIDs.IsValid() {
+		return false, ErrInvalidCredentialIDs
 	}
 
 	if !addresscodec.IsValidAddress(s.Destination.String()) {

--- a/xrpl/transaction/account_delete_test.go
+++ b/xrpl/transaction/account_delete_test.go
@@ -41,11 +41,27 @@ func TestAccountDelete_Flatten(t *testing.T) {
 				"DestinationTag":  uint32(13),
 			},
 		},
+		{
+			name: "pass - with credential IDs",
+			tx: &AccountDelete{
+				BaseTx: BaseTx{
+					Account: types.Address("rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm"),
+				},
+				Destination:   types.Address("rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"),
+				CredentialIDs: types.CredentialIDs{"1234567890abcdef"},
+			},
+			expected: FlatTransaction{
+				"Account":         "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
+				"TransactionType": AccountDeleteTx.String(),
+				"Destination":     "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+				"CredentialIDs":   []string{"1234567890abcdef"},
+			},
+		},
 	}
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			require.Equal(t, testcase.tx.Flatten(), testcase.expected)
+			require.Equal(t, testcase.expected, testcase.tx.Flatten())
 		})
 	}
 }
@@ -78,6 +94,18 @@ func TestAccountDelete_Validate(t *testing.T) {
 			},
 			valid: false,
 			err:   ErrInvalidDestinationAddress,
+		},
+		{
+			name: "fail - invalid CredentialIDs",
+			tx: &AccountDelete{
+				BaseTx: BaseTx{
+					Account:         types.Address("rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm"),
+					TransactionType: AccountDeleteTx,
+				},
+				CredentialIDs: types.CredentialIDs{"invalid"},
+			},
+			valid: false,
+			err:   ErrInvalidCredentialIDs,
 		},
 		{
 			name: "pass - basic",

--- a/xrpl/transaction/deposit_preauth.go
+++ b/xrpl/transaction/deposit_preauth.go
@@ -40,11 +40,11 @@ type DepositPreauth struct {
 	// (Optional) The XRP Ledger address of the sender to preauthorize.
 	Authorize types.Address `json:",omitempty"`
 	// A set of credentials to authorize.
-	AuthorizeCredentials []types.AuthorizeCredentials `json:",omitempty"`
+	AuthorizeCredentials []types.AuthorizeCredentialsWrapper `json:",omitempty"`
 	// (Optional) The XRP Ledger address of a sender whose preauthorization should be revoked.
 	Unauthorize types.Address `json:",omitempty"`
 	// A set of credentials whose preauthorization should be revoked.
-	UnauthorizeCredentials []types.AuthorizeCredentials `json:",omitempty"`
+	UnauthorizeCredentials []types.AuthorizeCredentialsWrapper `json:",omitempty"`
 }
 
 // TxType implements the TxType method for the DepositPreauth struct.
@@ -67,17 +67,23 @@ func (d *DepositPreauth) Flatten() FlatTransaction {
 	}
 
 	if len(d.AuthorizeCredentials) > 0 {
-		flattenedAuthorizeCredentials := make([]interface{}, len(d.AuthorizeCredentials))
-		for i, credential := range d.AuthorizeCredentials {
-			flattenedAuthorizeCredentials[i] = credential.Flatten()
+		flattenedAuthorizeCredentials := make([]any, 0, len(d.AuthorizeCredentials))
+		for _, credential := range d.AuthorizeCredentials {
+			flattenedAuthorizeCredential := credential.Flatten()
+			if flattenedAuthorizeCredential != nil {
+				flattenedAuthorizeCredentials = append(flattenedAuthorizeCredentials, flattenedAuthorizeCredential)
+			}
 		}
 		flattened["AuthorizeCredentials"] = flattenedAuthorizeCredentials
 	}
 
 	if len(d.UnauthorizeCredentials) > 0 {
-		flattenedUnauthorizeCredentials := make([]interface{}, len(d.UnauthorizeCredentials))
-		for i, credential := range d.UnauthorizeCredentials {
-			flattenedUnauthorizeCredentials[i] = credential.Flatten()
+		flattenedUnauthorizeCredentials := make([]any, 0, len(d.UnauthorizeCredentials))
+		for _, credential := range d.UnauthorizeCredentials {
+			flattenedUnauthorizeCredential := credential.Flatten()
+			if flattenedUnauthorizeCredential != nil {
+				flattenedUnauthorizeCredentials = append(flattenedUnauthorizeCredentials, flattenedUnauthorizeCredential)
+			}
 		}
 		flattened["UnauthorizeCredentials"] = flattenedUnauthorizeCredentials
 	}
@@ -115,7 +121,7 @@ func (d *DepositPreauth) Validate() (bool, error) {
 
 	if len(d.AuthorizeCredentials) > 0 {
 		for _, credential := range d.AuthorizeCredentials {
-			if !credential.IsValid() {
+			if !credential.Credential.IsValid() {
 				return false, ErrDepositPreauthInvalidAuthorizeCredentials
 			}
 		}
@@ -123,7 +129,7 @@ func (d *DepositPreauth) Validate() (bool, error) {
 
 	if len(d.UnauthorizeCredentials) > 0 {
 		for _, credential := range d.UnauthorizeCredentials {
-			if !credential.IsValid() {
+			if !credential.Credential.IsValid() {
 				return false, ErrDepositPreauthInvalidUnauthorizeCredentials
 			}
 		}

--- a/xrpl/transaction/deposit_preauth.go
+++ b/xrpl/transaction/deposit_preauth.go
@@ -53,30 +53,30 @@ func (*DepositPreauth) TxType() TxType {
 }
 
 // Flatten implements the Flatten method for the DepositPreauth struct.
-func (s *DepositPreauth) Flatten() FlatTransaction {
-	flattened := s.BaseTx.Flatten()
+func (d *DepositPreauth) Flatten() FlatTransaction {
+	flattened := d.BaseTx.Flatten()
 
 	flattened["TransactionType"] = DepositPreauthTx.String()
 
-	if s.Authorize != "" {
-		flattened["Authorize"] = s.Authorize.String()
+	if d.Authorize != "" {
+		flattened["Authorize"] = d.Authorize.String()
 	}
 
-	if s.Unauthorize != "" {
-		flattened["Unauthorize"] = s.Unauthorize.String()
+	if d.Unauthorize != "" {
+		flattened["Unauthorize"] = d.Unauthorize.String()
 	}
 
-	if len(s.AuthorizeCredentials) > 0 {
-		flattenedAuthorizeCredentials := make([]interface{}, len(s.AuthorizeCredentials))
-		for i, credential := range s.AuthorizeCredentials {
+	if len(d.AuthorizeCredentials) > 0 {
+		flattenedAuthorizeCredentials := make([]interface{}, len(d.AuthorizeCredentials))
+		for i, credential := range d.AuthorizeCredentials {
 			flattenedAuthorizeCredentials[i] = credential.Flatten()
 		}
 		flattened["AuthorizeCredentials"] = flattenedAuthorizeCredentials
 	}
 
-	if len(s.UnauthorizeCredentials) > 0 {
-		flattenedUnauthorizeCredentials := make([]interface{}, len(s.UnauthorizeCredentials))
-		for i, credential := range s.UnauthorizeCredentials {
+	if len(d.UnauthorizeCredentials) > 0 {
+		flattenedUnauthorizeCredentials := make([]interface{}, len(d.UnauthorizeCredentials))
+		for i, credential := range d.UnauthorizeCredentials {
 			flattenedUnauthorizeCredentials[i] = credential.Flatten()
 		}
 		flattened["UnauthorizeCredentials"] = flattenedUnauthorizeCredentials
@@ -86,43 +86,43 @@ func (s *DepositPreauth) Flatten() FlatTransaction {
 }
 
 // Validate implements the Validate method for the DepositPreauth struct.
-func (s *DepositPreauth) Validate() (bool, error) {
-	_, err := s.BaseTx.Validate()
+func (d *DepositPreauth) Validate() (bool, error) {
+	_, err := d.BaseTx.Validate()
 	if err != nil {
 		return false, err
 	}
 
 	// check that one of the four fields (Authorize, AuthorizeCredentials, Unauthorize, UnauthorizeCredentials) only is set
-	if !s.IsOnlyOneFieldSet() {
+	if !d.IsOnlyOneFieldSet() {
 		return false, ErrDepositPreauthMustSetOnlyOneField
 	}
 
-	if s.Authorize != "" && s.Authorize.String() == s.Account.String() {
+	if d.Authorize != "" && d.Authorize.String() == d.Account.String() {
 		return false, ErrDepositPreauthAuthorizeCannotBeSender
 	}
 
-	if s.Unauthorize != "" && s.Unauthorize.String() == s.Account.String() {
+	if d.Unauthorize != "" && d.Unauthorize.String() == d.Account.String() {
 		return false, ErrDepositPreauthUnauthorizeCannotBeSender
 	}
 
-	if s.Authorize != "" && !addresscodec.IsValidAddress(s.Authorize.String()) {
+	if d.Authorize != "" && !addresscodec.IsValidAddress(d.Authorize.String()) {
 		return false, ErrDepositPreauthInvalidAuthorize
 	}
 
-	if s.Unauthorize != "" && !addresscodec.IsValidAddress(s.Unauthorize.String()) {
+	if d.Unauthorize != "" && !addresscodec.IsValidAddress(d.Unauthorize.String()) {
 		return false, ErrDepositPreauthInvalidUnauthorize
 	}
 
-	if len(s.AuthorizeCredentials) > 0 {
-		for _, credential := range s.AuthorizeCredentials {
+	if len(d.AuthorizeCredentials) > 0 {
+		for _, credential := range d.AuthorizeCredentials {
 			if !credential.IsValid() {
 				return false, ErrDepositPreauthInvalidAuthorizeCredentials
 			}
 		}
 	}
 
-	if len(s.UnauthorizeCredentials) > 0 {
-		for _, credential := range s.UnauthorizeCredentials {
+	if len(d.UnauthorizeCredentials) > 0 {
+		for _, credential := range d.UnauthorizeCredentials {
 			if !credential.IsValid() {
 				return false, ErrDepositPreauthInvalidUnauthorizeCredentials
 			}

--- a/xrpl/transaction/deposit_preauth_test.go
+++ b/xrpl/transaction/deposit_preauth_test.go
@@ -58,8 +58,49 @@ func TestDepositPreauth_Flatten(t *testing.T) {
 				"Unauthorize":     "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
 			},
 		},
+		{
+			name: "pass - authorize credentials",
+			tx: &DepositPreauth{
+				BaseTx: BaseTx{
+					Account: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+				},
+				AuthorizeCredentials: []types.AuthorizeCredentials{
+					{
+						Issuer:         "rIssuer",
+						CredentialType: "6D795F63726564656E7469616C",
+					},
+				},
+			},
+			expected: FlatTransaction{
+				"Account":         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+				"TransactionType": "DepositPreauth",
+				"AuthorizeCredentials": []interface{}{
+					map[string]interface{}{"Issuer": "rIssuer", "CredentialType": "6D795F63726564656E7469616C"},
+				},
+			},
+		},
+		{
+			name: "pass - unauthorize credentials",
+			tx: &DepositPreauth{
+				BaseTx: BaseTx{
+					Account: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+				},
+				UnauthorizeCredentials: []types.AuthorizeCredentials{
+					{
+						Issuer:         "rIssuer",
+						CredentialType: "6D795F63726564656E7469616C",
+					},
+				},
+			},
+			expected: FlatTransaction{
+				"Account":         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+				"TransactionType": "DepositPreauth",
+				"UnauthorizeCredentials": []interface{}{
+					map[string]interface{}{"Issuer": "rIssuer", "CredentialType": "6D795F63726564656E7469616C"},
+				},
+			},
+		},
 	}
-
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			require.Equal(t, testcase.expected, testcase.tx.Flatten())

--- a/xrpl/transaction/deposit_preauth_test.go
+++ b/xrpl/transaction/deposit_preauth_test.go
@@ -64,18 +64,25 @@ func TestDepositPreauth_Flatten(t *testing.T) {
 				BaseTx: BaseTx{
 					Account: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				},
-				AuthorizeCredentials: []types.AuthorizeCredentials{
+				AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
 			expected: FlatTransaction{
 				"Account":         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				"TransactionType": "DepositPreauth",
-				"AuthorizeCredentials": []interface{}{
-					map[string]interface{}{"Issuer": "rIssuer", "CredentialType": "6D795F63726564656E7469616C"},
+				"AuthorizeCredentials": []any{
+					map[string]any{
+						"Credential": map[string]any{
+							"Issuer":         "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+							"CredentialType": "6D795F63726564656E7469616C",
+						},
+					},
 				},
 			},
 		},
@@ -85,18 +92,25 @@ func TestDepositPreauth_Flatten(t *testing.T) {
 				BaseTx: BaseTx{
 					Account: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				},
-				UnauthorizeCredentials: []types.AuthorizeCredentials{
+				UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
 			expected: FlatTransaction{
 				"Account":         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				"TransactionType": "DepositPreauth",
-				"UnauthorizeCredentials": []interface{}{
-					map[string]interface{}{"Issuer": "rIssuer", "CredentialType": "6D795F63726564656E7469616C"},
+				"UnauthorizeCredentials": []any{
+					map[string]any{
+						"Credential": map[string]any{
+							"Issuer":         "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+							"CredentialType": "6D795F63726564656E7469616C",
+						},
+					},
 				},
 			},
 		},
@@ -215,10 +229,12 @@ func TestDepositPreauth_IsOnlyOneFieldSet(t *testing.T) {
 		{
 			name: "pass - only AuthorizeCredentials set",
 			dp: &DepositPreauth{
-				AuthorizeCredentials: []types.AuthorizeCredentials{
+				AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
@@ -234,10 +250,12 @@ func TestDepositPreauth_IsOnlyOneFieldSet(t *testing.T) {
 		{
 			name: "pass - only UnauthorizeCredentials set",
 			dp: &DepositPreauth{
-				UnauthorizeCredentials: []types.AuthorizeCredentials{
+				UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
@@ -251,11 +269,13 @@ func TestDepositPreauth_IsOnlyOneFieldSet(t *testing.T) {
 		{
 			name: "fail - Authorize and AuthorizeCredentials set",
 			dp: &DepositPreauth{
-				Authorize: "rAuthorize",
-				AuthorizeCredentials: []types.AuthorizeCredentials{
+				Authorize: "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+				AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
@@ -264,24 +284,28 @@ func TestDepositPreauth_IsOnlyOneFieldSet(t *testing.T) {
 		{
 			name: "fail - Authorize and Unauthorize set",
 			dp: &DepositPreauth{
-				Authorize:   "rAuthorize",
-				Unauthorize: "rUnauthorize",
+				Authorize:   "rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de",
+				Unauthorize: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 			},
 			expected: false,
 		},
 		{
 			name: "fail - AuthorizeCredentials and UnauthorizeCredentials set",
 			dp: &DepositPreauth{
-				AuthorizeCredentials: []types.AuthorizeCredentials{
+				AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
-				UnauthorizeCredentials: []types.AuthorizeCredentials{
+				UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},
@@ -291,17 +315,21 @@ func TestDepositPreauth_IsOnlyOneFieldSet(t *testing.T) {
 			name: "fail - all fields set",
 			dp: &DepositPreauth{
 				Authorize: "rAuthorize",
-				AuthorizeCredentials: []types.AuthorizeCredentials{
+				AuthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 				Unauthorize: "rUnauthorize",
-				UnauthorizeCredentials: []types.AuthorizeCredentials{
+				UnauthorizeCredentials: []types.AuthorizeCredentialsWrapper{
 					{
-						Issuer:         "rIssuer",
-						CredentialType: "6D795F63726564656E7469616C",
+						Credential: types.AuthorizeCredentials{
+							Issuer:         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+							CredentialType: "6D795F63726564656E7469616C",
+						},
 					},
 				},
 			},

--- a/xrpl/transaction/errors.go
+++ b/xrpl/transaction/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrInvalidCheckID = errors.New("invalid CheckID, must be a valid 64-character hexadecimal string")
 	// ErrInvalidCredentialType is returned when the CredentialType is not a valid hexadecimal string between 1 and 64 bytes.
 	ErrInvalidCredentialType = errors.New("invalid credential type, must be a hexadecimal string between 1 and 64 bytes")
+	// ErrInvalidCredentialIDs is returned when the CredentialIDs field is empty or not a valid hexadecimal string array.
+	ErrInvalidCredentialIDs = errors.New("invalid credential IDs, must be a valid hexadecimal string array")
 	// ErrInvalidDestination is returned when the Destination field does not meet XRPL address standards.
 	ErrInvalidDestination = errors.New("invalid xrpl address for Destination")
 	// ErrInvalidIssuer is returned when the issuer address is an invalid xrpl address.

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -30,6 +30,10 @@ var (
 // ````
 type EscrowFinish struct {
 	BaseTx
+	// Set of Credentials to authorize a deposit made by this transaction.
+	// Each member of the array must be the ledger entry ID of a Credential entry in the ledger.
+	// For details see https://xrpl.org/docs/references/protocol/transactions/types/payment#credential-ids
+	CredentialIDs types.CredentialIDs `json:",omitempty"`
 	// Address of the source account that funded the held payment.
 	Owner types.Address
 	// Transaction sequence of EscrowCreate transaction that created the held payment to finish.

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -71,6 +71,10 @@ func (e *EscrowFinish) Flatten() FlatTransaction {
 		flattened["Fulfillment"] = e.Fulfillment
 	}
 
+	if len(e.CredentialIDs) > 0 {
+		flattened["CredentialIDs"] = e.CredentialIDs.Flatten()
+	}
+
 	return flattened
 }
 
@@ -87,6 +91,10 @@ func (e *EscrowFinish) Validate() (bool, error) {
 
 	if e.OfferSequence == 0 {
 		return false, ErrEscrowFinishMissingOfferSequence
+	}
+
+	if e.CredentialIDs != nil && !e.CredentialIDs.IsValid() {
+		return false, ErrInvalidCredentialIDs
 	}
 
 	return true, nil

--- a/xrpl/transaction/escrow_finish_test.go
+++ b/xrpl/transaction/escrow_finish_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +30,7 @@ func TestEscrowFinish_Flatten(t *testing.T) {
 				OfferSequence: 7,
 				Condition:     "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
 				Fulfillment:   "A0028000",
+				CredentialIDs: types.CredentialIDs{"1234567890abcdef"},
 			},
 			expected: `{
 				"TransactionType": "EscrowFinish",
@@ -36,7 +38,8 @@ func TestEscrowFinish_Flatten(t *testing.T) {
 				"Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 				"OfferSequence":   7,
 				"Condition": "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
-				"Fulfillment": "A0028000"
+				"Fulfillment": "A0028000",
+				"CredentialIDs": ["1234567890abcdef"]
 			}`,
 		},
 		{
@@ -134,6 +137,20 @@ func TestEscrowFinish_Validate(t *testing.T) {
 					TransactionType: EscrowFinishTx,
 				},
 				Owner: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+			},
+			wantValid: false,
+			wantErr:   true,
+		},
+		{
+			name: "fail - invalid CredentialIDs",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				OfferSequence: 7,
+				CredentialIDs: types.CredentialIDs{"invalid"},
 			},
 			wantValid: false,
 			wantErr:   true,

--- a/xrpl/transaction/payment.go
+++ b/xrpl/transaction/payment.go
@@ -37,6 +37,11 @@ type Payment struct {
 	// If the tfPartialPayment flag is set, deliver up to this amount instead.
 	Amount types.CurrencyAmount
 
+	// Set of Credentials to authorize a deposit made by this transaction.
+	// Each member of the array must be the ledger entry ID of a Credential entry in the ledger.
+	// For details see https://xrpl.org/docs/references/protocol/transactions/types/payment#credential-ids
+	CredentialIDs types.CredentialIDs `json:",omitempty"`
+
 	// API v2: Only available in API v2.
 	// The maximum amount of currency to deliver.
 	// For non-XRP amounts, the nested field names MUST be lower-case.

--- a/xrpl/transaction/payment.go
+++ b/xrpl/transaction/payment.go
@@ -92,6 +92,10 @@ func (p *Payment) Flatten() FlatTransaction {
 		flattened["Amount"] = p.Amount.Flatten()
 	}
 
+	if len(p.CredentialIDs) > 0 {
+		flattened["CredentialIDs"] = p.CredentialIDs.Flatten()
+	}
+
 	if p.DeliverMax != nil {
 		flattened["DeliverMax"] = p.DeliverMax.Flatten()
 	}
@@ -199,6 +203,11 @@ func (p *Payment) Validate() (bool, error) {
 	// Check if the field DeliverMin is valid
 	if ok, err := IsAmount(p.DeliverMin, "DeliverMin", false); !ok {
 		return false, err
+	}
+
+	// Check if the field CredentialIDs is valid
+	if p.CredentialIDs != nil && !p.CredentialIDs.IsValid() {
+		return false, ErrInvalidCredentialIDs
 	}
 
 	// Check partial payment fields

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -68,6 +68,10 @@ type PaymentChannelClaim struct {
 	BaseTx
 	// The unique ID of the channel, as a 64-character hexadecimal string.
 	Channel types.Hash256
+	// Set of Credentials to authorize a deposit made by this transaction.
+	// Each member of the array must be the ledger entry ID of a Credential entry in the ledger.
+	// For details see https://xrpl.org/docs/references/protocol/transactions/types/payment#credential-ids
+	CredentialIDs types.CredentialIDs `json:",omitempty"`
 	// (Optional) Total amount of XRP, in drops, delivered by this channel after processing this claim. Required to deliver XRP.
 	// Must be more than the total amount delivered by the channel so far, but not greater than the Amount of the signed claim. Must be provided except when closing the channel.
 	Balance types.XRPCurrencyAmount `json:",omitempty"`

--- a/xrpl/transaction/payment_channel_claim.go
+++ b/xrpl/transaction/payment_channel_claim.go
@@ -113,6 +113,9 @@ func (p *PaymentChannelClaim) Flatten() FlatTransaction {
 	if p.PublicKey != "" {
 		flattened["PublicKey"] = p.PublicKey
 	}
+	if len(p.CredentialIDs) > 0 {
+		flattened["CredentialIDs"] = p.CredentialIDs.Flatten()
+	}
 	return flattened
 }
 
@@ -159,6 +162,10 @@ func (p *PaymentChannelClaim) Validate() (bool, error) {
 
 	if p.PublicKey != "" && !typecheck.IsHex(p.PublicKey) {
 		return false, ErrInvalidHexPublicKey
+	}
+
+	if p.CredentialIDs != nil && !p.CredentialIDs.IsValid() {
+		return false, ErrInvalidCredentialIDs
 	}
 
 	return true, nil

--- a/xrpl/transaction/payment_channel_claim_test.go
+++ b/xrpl/transaction/payment_channel_claim_test.go
@@ -114,11 +114,12 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					TransactionType: PaymentChannelClaimTx,
 				},
-				Channel:   types.Hash256("ABC123"),
-				Balance:   types.XRPCurrencyAmount(1000),
-				Amount:    types.XRPCurrencyAmount(2000),
-				Signature: "ABCDEF",
-				PublicKey: "123456",
+				Channel:       types.Hash256("ABC123"),
+				Balance:       types.XRPCurrencyAmount(1000),
+				Amount:        types.XRPCurrencyAmount(2000),
+				Signature:     "ABCDEF",
+				PublicKey:     "123456",
+				CredentialIDs: types.CredentialIDs{"1234567890abcdef"},
 			},
 			expected: `{
 				"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -127,7 +128,8 @@ func TestPaymentChannelClaim_Flatten(t *testing.T) {
 				"Balance": "1000",
 				"Amount": "2000",
 				"Signature": "ABCDEF",
-				"PublicKey": "123456"
+				"PublicKey": "123456",
+				"CredentialIDs": ["1234567890abcdef"]
 			}`,
 		},
 	}
@@ -155,10 +157,11 @@ func TestPaymentChannelClaim_Validate(t *testing.T) {
 					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
 					TransactionType: PaymentChannelClaimTx,
 				},
-				Balance:   types.XRPCurrencyAmount(1000),
-				Channel:   "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
-				Signature: "ABCDEF",
-				PublicKey: "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				Balance:       types.XRPCurrencyAmount(1000),
+				Channel:       "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				Signature:     "ABCDEF",
+				PublicKey:     "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				CredentialIDs: types.CredentialIDs{"1234567890abcdef"},
 			},
 			wantValid: true,
 			wantErr:   false,
@@ -229,6 +232,20 @@ func TestPaymentChannelClaim_Validate(t *testing.T) {
 			wantValid:   false,
 			wantErr:     true,
 			expectedErr: ErrInvalidHexPublicKey,
+		},
+		{
+			name: "fail - invalid CredentialIDs",
+			claim: PaymentChannelClaim{
+				BaseTx: BaseTx{
+					Account:         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					TransactionType: PaymentChannelClaimTx,
+				},
+				Channel:       "ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC123ABC1",
+				CredentialIDs: types.CredentialIDs{"invalid"},
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidCredentialIDs,
 		},
 	}
 

--- a/xrpl/transaction/payment_test.go
+++ b/xrpl/transaction/payment_test.go
@@ -109,6 +109,7 @@ func TestPayment_Validate(t *testing.T) {
 				},
 				Destination:    "rDgHn3T2P7eNAaoHh43iRudhAUjAHmDgEP",
 				DestinationTag: types.DestinationTag(123),
+				CredentialIDs:  types.CredentialIDs{"0000000000000000000000000000000000000000000000000000000000000000"},
 			},
 			wantValid: true,
 			wantErr:   false,
@@ -407,6 +408,21 @@ func TestPayment_Validate(t *testing.T) {
 			wantErr:     true,
 			expectedErr: ErrPartialPaymentFlagRequired,
 		},
+		{
+			name: "fail - invalid CredentialIDs",
+			payment: Payment{
+				BaseTx: BaseTx{
+					Account:         "r3EeETxLb1JwmN2xWuZZdKrrEkqw7qgeYf",
+					TransactionType: PaymentTx,
+				},
+				Amount:        types.XRPCurrencyAmount(1),
+				Destination:   "ra2ASKcVifxurMgUpTnb59mGDAf7JSVyzh",
+				CredentialIDs: types.CredentialIDs{"invalid"},
+			},
+			wantValid:   false,
+			wantErr:     true,
+			expectedErr: ErrInvalidCredentialIDs,
+		},
 	}
 
 	for _, tt := range tests {
@@ -478,6 +494,10 @@ func TestPayment_Flatten(t *testing.T) {
 					Issuer:   "r3dFAtNXwRFCyBGz5BcWhMj9a4cm7qkzzn",
 					Value:    "3",
 				},
+				CredentialIDs: types.CredentialIDs{
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"6D795F63726564656E7469616C",
+				},
 			},
 			expected: FlatTransaction{
 				"Account":         "rJwjoukM94WwKwxM428V7b9npHjpkSvif",
@@ -520,6 +540,10 @@ func TestPayment_Flatten(t *testing.T) {
 					"currency": "USD",
 					"issuer":   "r3dFAtNXwRFCyBGz5BcWhMj9a4cm7qkzzn",
 					"value":    "3",
+				},
+				"CredentialIDs": []string{
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"6D795F63726564656E7469616C",
 				},
 			},
 		},

--- a/xrpl/transaction/types/authorize_credentials.go
+++ b/xrpl/transaction/types/authorize_credentials.go
@@ -4,6 +4,10 @@ import (
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
 )
 
+type AuthorizeCredentialsWrapper struct {
+	Credential AuthorizeCredentials
+}
+
 type AuthorizeCredentials struct {
 	// The issuer of the credential.
 	Issuer Address
@@ -17,11 +21,24 @@ func (a *AuthorizeCredentials) IsValid() bool {
 }
 
 // Flatten returns a map of the authorize credentials.
+func (a *AuthorizeCredentialsWrapper) Flatten() map[string]interface{} {
+	flattened := make(map[string]interface{})
+
+	flattened["Credential"] = a.Credential.Flatten()
+
+	return flattened
+}
+
+// Flatten returns a map of the authorize credentials.
 func (a *AuthorizeCredentials) Flatten() map[string]interface{} {
 	flattened := make(map[string]interface{})
 
-	flattened["Issuer"] = a.Issuer.String()
-	flattened["CredentialType"] = a.CredentialType.String()
+	if a.Issuer != "" {
+		flattened["Issuer"] = a.Issuer.String()
+	}
+	if a.CredentialType != "" {
+		flattened["CredentialType"] = a.CredentialType.String()
+	}
 
 	return flattened
 }

--- a/xrpl/transaction/types/authorize_credentials.go
+++ b/xrpl/transaction/types/authorize_credentials.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+)
+
+type AuthorizeCredentials struct {
+	// The issuer of the credential.
+	Issuer Address
+	// The credential type of the credential.
+	CredentialType CredentialType
+}
+
+// IsValid returns true if the authorize credentials are valid.
+func (a *AuthorizeCredentials) IsValid() bool {
+	return addresscodec.IsValidAddress(a.Issuer.String()) && a.CredentialType.IsValid()
+}
+
+// Flatten returns a map of the authorize credentials.
+func (a *AuthorizeCredentials) Flatten() map[string]interface{} {
+	flattened := make(map[string]interface{})
+
+	flattened["Issuer"] = a.Issuer.String()
+	flattened["CredentialType"] = a.CredentialType.String()
+
+	return flattened
+}

--- a/xrpl/transaction/types/authorize_credentials_test.go
+++ b/xrpl/transaction/types/authorize_credentials_test.go
@@ -49,18 +49,22 @@ func TestAuthorizeCredentials_IsValid(t *testing.T) {
 func TestAuthorizeCredentials_Flatten(t *testing.T) {
 	tests := []struct {
 		name       string
-		credential AuthorizeCredentials
+		credential AuthorizeCredentialsWrapper
 		expected   map[string]interface{}
 	}{
 		{
 			name: "pass - valid authorize credentials",
-			credential: AuthorizeCredentials{
-				Issuer:         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
-				CredentialType: "6D795F63726564656E7469616C",
+			credential: AuthorizeCredentialsWrapper{
+				Credential: AuthorizeCredentials{
+					Issuer:         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+					CredentialType: "6D795F63726564656E7469616C",
+				},
 			},
 			expected: map[string]interface{}{
-				"Issuer":         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
-				"CredentialType": "6D795F63726564656E7469616C",
+				"Credential": map[string]interface{}{
+					"Issuer":         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+					"CredentialType": "6D795F63726564656E7469616C",
+				},
 			},
 		},
 	}

--- a/xrpl/transaction/types/authorize_credentials_test.go
+++ b/xrpl/transaction/types/authorize_credentials_test.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizeCredentials_IsValid(t *testing.T) {
+	tests := []struct {
+		name       string
+		credential AuthorizeCredentials
+		expected   bool
+	}{
+		{
+			name: "pass - valid authorize credentials",
+			credential: AuthorizeCredentials{
+				Issuer:         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+				CredentialType: "6D795F63726564656E7469616C",
+			},
+			expected: true,
+		},
+		{
+			name: "fail - invalid credential type",
+			credential: AuthorizeCredentials{
+				Issuer:         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+				CredentialType: "invalid",
+			},
+			expected: false,
+		},
+		{
+			name: "fail - invalid issuer",
+			credential: AuthorizeCredentials{
+				Issuer:         "invalid",
+				CredentialType: "6D795F63726564656E7469616C",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.credential.IsValid()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestAuthorizeCredentials_Flatten(t *testing.T) {
+	tests := []struct {
+		name       string
+		credential AuthorizeCredentials
+		expected   map[string]interface{}
+	}{
+		{
+			name: "pass - valid authorize credentials",
+			credential: AuthorizeCredentials{
+				Issuer:         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+				CredentialType: "6D795F63726564656E7469616C",
+			},
+			expected: map[string]interface{}{
+				"Issuer":         "rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8",
+				"CredentialType": "6D795F63726564656E7469616C",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.credential.Flatten()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/xrpl/transaction/types/credential_ids.go
+++ b/xrpl/transaction/types/credential_ids.go
@@ -1,0 +1,19 @@
+package types
+
+import "github.com/Peersyst/xrpl-go/pkg/typecheck"
+
+type CredentialIDs []string
+
+func (c *CredentialIDs) IsValid() bool {
+	if len(*c) == 0 {
+		return false
+	}
+
+	for _, id := range *c {
+		if !typecheck.IsHex(id) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/xrpl/transaction/types/credential_ids.go
+++ b/xrpl/transaction/types/credential_ids.go
@@ -4,16 +4,20 @@ import "github.com/Peersyst/xrpl-go/pkg/typecheck"
 
 type CredentialIDs []string
 
-func (c *CredentialIDs) IsValid() bool {
-	if len(*c) == 0 {
+func (c CredentialIDs) IsValid() bool {
+	if len(c) == 0 {
 		return false
 	}
 
-	for _, id := range *c {
+	for _, id := range c {
 		if !typecheck.IsHex(id) {
 			return false
 		}
 	}
 
 	return true
+}
+
+func (c CredentialIDs) Flatten() []string {
+	return c
 }

--- a/xrpl/transaction/types/credential_ids_test.go
+++ b/xrpl/transaction/types/credential_ids_test.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialIDs_IsValid(t *testing.T) {
+	tests := []struct {
+		name          string
+		credentialIDs CredentialIDs
+		expected      bool
+	}{
+		{
+			name:          "empty",
+			credentialIDs: CredentialIDs{},
+			expected:      false,
+		},
+		{
+			name:          "valid",
+			credentialIDs: CredentialIDs{"0000000000000000000000000000000000000000000000000000000000000000"},
+			expected:      true,
+		},
+		{
+			name: "invalid",
+			credentialIDs: CredentialIDs{
+				"0000000000000000000000000000000000000000000000000000000000000000",
+				"6D795F63726564656E7469616C",
+			},
+			expected: true,
+		},
+		{
+			name: "invalid",
+			credentialIDs: CredentialIDs{
+				"0000000000000000000000000000000000000000000000000000000000000000",
+				"invalid",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.credentialIDs.IsValid()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/xrpl/transaction/types/credential_ids_test.go
+++ b/xrpl/transaction/types/credential_ids_test.go
@@ -13,17 +13,17 @@ func TestCredentialIDs_IsValid(t *testing.T) {
 		expected      bool
 	}{
 		{
-			name:          "empty",
+			name:          "fail - empty",
 			credentialIDs: CredentialIDs{},
 			expected:      false,
 		},
 		{
-			name:          "valid",
+			name:          "pass -valid",
 			credentialIDs: CredentialIDs{"0000000000000000000000000000000000000000000000000000000000000000"},
 			expected:      true,
 		},
 		{
-			name: "invalid",
+			name: "pass - valid with two ids",
 			credentialIDs: CredentialIDs{
 				"0000000000000000000000000000000000000000000000000000000000000000",
 				"6D795F63726564656E7469616C",
@@ -31,7 +31,7 @@ func TestCredentialIDs_IsValid(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "invalid",
+			name: "fail - invalid id, not hex",
 			credentialIDs: CredentialIDs{
 				"0000000000000000000000000000000000000000000000000000000000000000",
 				"invalid",
@@ -43,6 +43,37 @@ func TestCredentialIDs_IsValid(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.credentialIDs.IsValid()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestCredentialIDs_Flatten(t *testing.T) {
+	tests := []struct {
+		name          string
+		credentialIDs CredentialIDs
+		expected      []string
+	}{
+		{
+			name:          "pass -empty",
+			credentialIDs: CredentialIDs{},
+			expected:      []string{},
+		},
+		{
+			name:          "pass - valid",
+			credentialIDs: CredentialIDs{"0000000000000000000000000000000000000000000000000000000000000000"},
+			expected:      []string{"0000000000000000000000000000000000000000000000000000000000000000"},
+		},
+		{
+			name:          "pass - valid with two ids",
+			credentialIDs: CredentialIDs{"0000000000000000000000000000000000000000000000000000000000000000", "6D795F63726564656E7469616C"},
+			expected:      []string{"0000000000000000000000000000000000000000000000000000000000000000", "6D795F63726564656E7469616C"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.credentialIDs.Flatten()
 			require.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
# Title

## Description
This PR aims to:
- add several fields related to the Credential amendment to several transaction types
	- DepositPreauth
	- Payment
	- PaymentChannelClaim
	- AccountDelete
	- EscrowFinish
- add a new ledger object type for the "account_objects" query
- updates the tests associated with the transaction types
- add a new CredentialIDs type + tests
- add examples with rpc and ws for the DepositPreauth transaction with `AuthorizedCredentials` and `UnauthorizedCredentials`. 

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective
- [X] New and existing unit tests pass locally with my changes

## Changes

- Change 1
- Change 2

## Notes (optional)

Describe any additional notes here.
