### PR TITLE
fix(big-decimal): adjust big.Float precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+## Fixed
+
+### big-decimal
+
+- Fixed `BigDecimal` precision.
+
 ## [v0.1.8]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 
 FROM install AS lint
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 RUN make lint
 
 FROM lint AS test

--- a/pkg/big-decimal/big_decimal.go
+++ b/pkg/big-decimal/big_decimal.go
@@ -12,7 +12,7 @@ import (
 const (
 	AllowedCharacters = "0123456789.-eE"
 	BigDecRegEx       = "-?(?:[0|1-9]\\d*)(?:\\.\\d+)?(?:[eE][+\\-]?\\d+)?"
-	Precision         = 128
+	Precision         = 512
 )
 
 var (


### PR DESCRIPTION
# fix(big-decimal): adjust big.Float precision

## Description
This PR aims to adjust the `big.Float` precision to cover `MinIOUExponent` and `MaxIOUExponent`. This PR fixes the issue #126.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Set `Precision` to 512 bits

