### PR TITLE
[TA-4326]: Uint8 codec type decodes zero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### binary-codec
+
+- Added native `uint8` type support for `Uint8` type.
+
 ### big-decimal
 
 - Fixed `BigDecimal` precision.

--- a/binary-codec/types/uint8.go
+++ b/binary-codec/types/uint8.go
@@ -30,6 +30,8 @@ func (u *UInt8) FromJSON(value any) ([]byte, error) {
 		intValue = v
 	case int32:
 		intValue = int(v)
+	case uint8:
+		intValue = int(v)
 	}
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
# [TA-4326]: Uint8 codec type decodes zero value

## Description
This PR aims to fix the problem in issue #129. `Uint8` codec type was not handling native `uint8` value types, which cause to return a non-initialized `int` with its default value (`0`). 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Support go `uint8`  type in `Uint8` codec type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced binary processing with native support for 8-bit unsigned integers, improving data handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->