### PR TITLE
[TA-4885]: Add MPTCurrency Amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### binary-codec
 
-- Added `MPToken` definitions. 
+- Adds `MPToken` definitions.
 - Adds `Hash192` type.
+- Adds functions to serialize and deserialize `MPTCurrencyAmount`.
+- Adds unit tests for `MPTCurrencyAmount`.
 
 #### xrpl
 
 - Adds `MPTokenAuthorize`, `MPTokenIssuanceCreate`, `MPTokenIssuanceDestroy`, `MPTokenIssuanceSet` transactions. It also adds the `types.Holder`, `types.AssetScale`, `types.MPTokenMetadata` and `types.TransferFee` types to represent the holder of the token, the asset scale, the metadata and the transfer fee of the token respectively.
+- Adds `MPTCurrencyAmount` for currency kinds.
+- Adds unit tests for `MPTCurrencyAmount`.
 
 ## [v0.1.10]
 

--- a/xrpl/transaction/types/currency_amount.go
+++ b/xrpl/transaction/types/currency_amount.go
@@ -10,6 +10,7 @@ type CurrencyKind int
 const (
 	XRP CurrencyKind = iota
 	ISSUED
+	MPT
 )
 
 type CurrencyAmount interface {
@@ -23,6 +24,19 @@ func UnmarshalCurrencyAmount(data []byte) (CurrencyAmount, error) {
 	}
 	switch data[0] {
 	case '{':
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, err
+		}
+
+		if _, hasMPTID := raw["mpt_issuance_id"]; hasMPTID {
+			var m MPTCurrencyAmount
+			if err := json.Unmarshal(data, &m); err != nil {
+				return nil, err
+			}
+			return m, nil
+		}
+
 		var i IssuedCurrencyAmount
 		if err := json.Unmarshal(data, &i); err != nil {
 			return nil, err
@@ -113,4 +127,24 @@ func (a *XRPCurrencyAmount) UnmarshalText(data []byte) error {
 	}
 	*a = XRPCurrencyAmount(v)
 	return nil
+}
+
+type MPTCurrencyAmount struct {
+	MPTIssuanceID string `json:"mpt_issuance_id"`
+	Value         string `json:"value"`
+}
+
+func (MPTCurrencyAmount) Kind() CurrencyKind {
+	return MPT
+}
+
+func (m MPTCurrencyAmount) Flatten() interface{} {
+	json := make(map[string]interface{})
+	if m.MPTIssuanceID != "" {
+		json["mpt_issuance_id"] = m.MPTIssuanceID
+	}
+	if m.Value != "" {
+		json["value"] = m.Value
+	}
+	return json
 }

--- a/xrpl/transaction/types/currency_amount_test.go
+++ b/xrpl/transaction/types/currency_amount_test.go
@@ -53,3 +53,91 @@ func TestIssuedCurrencyAmount_IsZero(t *testing.T) {
 		})
 	}
 }
+
+func TestMPTCurrencyAmount_Kind(t *testing.T) {
+	mpt := MPTCurrencyAmount{}
+	if kind := mpt.Kind(); kind != MPT {
+		t.Errorf("MPTCurrencyAmount.Kind() = %v, want %v", kind, MPT)
+	}
+}
+
+func TestMPTCurrencyAmount_Flatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		mpt      MPTCurrencyAmount
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Empty MPT amount",
+			mpt:      MPTCurrencyAmount{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "With MPT issuance ID only",
+			mpt: MPTCurrencyAmount{
+				MPTIssuanceID: "00000000000000000000000000000000",
+			},
+			expected: map[string]interface{}{
+				"mpt_issuance_id": "00000000000000000000000000000000",
+			},
+		},
+		{
+			name: "With value only",
+			mpt: MPTCurrencyAmount{
+				Value: "100",
+			},
+			expected: map[string]interface{}{
+				"value": "100",
+			},
+		},
+		{
+			name: "With both issuance ID and value",
+			mpt: MPTCurrencyAmount{
+				MPTIssuanceID: "00000000000000000000000000000000",
+				Value:         "100",
+			},
+			expected: map[string]interface{}{
+				"mpt_issuance_id": "00000000000000000000000000000000",
+				"value":           "100",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mpt.Flatten()
+			flattened, ok := result.(map[string]interface{})
+			if !ok {
+				t.Fatalf("Expected map[string]interface{}, got %T", result)
+			}
+
+			if len(flattened) != len(tt.expected) {
+				t.Errorf("Expected map of length %d, got %d", len(tt.expected), len(flattened))
+			}
+
+			for key, expectedValue := range tt.expected {
+				actualValue, exists := flattened[key]
+				if !exists {
+					t.Errorf("Expected key %q not found in flattened output", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("For key %q, expected value %v, got %v", key, expectedValue, actualValue)
+				}
+			}
+		})
+	}
+}
+
+func TestUnmarshalCurrencyAmount_MPT(t *testing.T) {
+	raw := `{"mpt_issuance_id":"issuance","value":"42"}`
+	amt, err := UnmarshalCurrencyAmount([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := amt.(MPTCurrencyAmount)
+	if !ok {
+		t.Fatalf("expected MPTCurrencyAmount, got %T", amt)
+	}
+	if m.MPTIssuanceID != "issuance" || m.Value != "42" {
+		t.Errorf("unmarshaled %#v", m)
+	}
+}


### PR DESCRIPTION
# [TA-4885]: Add MPTCurrency Amount

## Changes :hammer_and_wrench:

### binary-codec/types

- Add functions to serialize and deserialize `MPTCurrencyAmount`
- Add unit tests

### xrpl/transaction

- Add `MPTCurrencyAmount` for currency kinds
- Add unit tests



- Changelog