### PR TITLE
fix: use int64 to avoid error when building for 32-bits target

### DIFF
--- a/pkg/crypto/secp256k1.go
+++ b/pkg/crypto/secp256k1.go
@@ -58,7 +58,7 @@ func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() byte {
 func (c SECP256K1CryptoAlgorithm) deriveScalar(bytes []byte, discrim *big.Int) *big.Int {
 
 	order := btcec.S256().N
-	for i := 0; i <= 0xffffffff; i++ {
+	for i := int64(0); i <= int64(0xffffffff); i++ {
 		hash := sha512.New()
 
 		hash.Write(bytes)


### PR DESCRIPTION
# Title

## Description
This PR aims to <insert description>. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Change 1
- Change 2

## Notes (optional)

Describe any additional notes here.
