### PR TITLE
[TA-5164] Add PermissionedDomain ledger entry type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### xrpl
+
+- Adds `PermissionedDomain` ledger entry type (XLS-80d).
+
 ## [v0.1.11]
 
 ### BREAKING CHANGES

--- a/xrpl/ledger-entry-types/ledger_object.go
+++ b/xrpl/ledger-entry-types/ledger_object.go
@@ -27,6 +27,7 @@ const (
 	OfferEntry                           EntryType = "Offer"
 	OracleEntry                          EntryType = "Oracle"
 	PayChannelEntry                      EntryType = "PayChannel"
+	PermissionedDomainEntry              EntryType = "PermissionedDomain"
 	RippleStateEntry                     EntryType = "RippleState"
 	SignerListEntry                      EntryType = "SignerList"
 	TicketEntry                          EntryType = "Ticket"
@@ -84,6 +85,8 @@ func EmptyLedgerObject(t string) (Object, error) {
 		return &Oracle{}, nil
 	case PayChannelEntry:
 		return &PayChannel{}, nil
+	case PermissionedDomainEntry:
+		return &PermissionedDomain{}, nil
 	case RippleStateEntry:
 		return &RippleState{}, nil
 	case SignerListEntry:
@@ -147,6 +150,8 @@ func UnmarshalLedgerObject(data []byte) (Object, error) {
 		o = &Oracle{}
 	case PayChannelEntry:
 		o = &PayChannel{}
+	case PermissionedDomainEntry:
+		o = &PermissionedDomain{}
 	case RippleStateEntry:
 		o = &RippleState{}
 	case SignerListEntry:

--- a/xrpl/ledger-entry-types/permissioned_domain.go
+++ b/xrpl/ledger-entry-types/permissioned_domain.go
@@ -1,0 +1,63 @@
+package ledger
+
+import "github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+
+// A PermissionedDomain ledger entry describes a single permissioned domain instance.
+// You can create a permissioned domain by sending a PermissionedDomainSet transaction.
+//
+// ```json
+//
+// {
+// 	"LedgerEntryType": "PermissionedDomain",
+// 	"Fee": "10",
+// 	"Flags": 0,
+// 	"Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+// 	"OwnerNode": "0000000000000000",
+// 	"Sequence": 390,
+// 	"AcceptedCredentials": [
+// 	  {
+// 		  "Credential": {
+// 			  "Issuer": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+// 			  "CredentialType": "6D795F63726564656E7469616C"
+// 		  }
+// 	  }
+// 	],
+// 	"PreviousTxnID": "E7E3F2BBAAF48CF893896E48DC4A02BDA0C747B198D5AE18BC3D7567EE64B904",
+// 	"PreviousTxnLgrSeq": 8734523,
+// 	"index": "3DFA1DDEA27AF7E466DE395CCB16158E07ECA6BC4EB5580F75EBD39DE833645F"
+//   }
+//
+// ```
+
+type PermissionedDomain struct {
+	// The unique ID for this ledger entry.
+	// In JSON, this field is represented with different names depending on the context and API method.
+	// (Note, even though this is specified as "optional" in the code, every ledger entry should have one unless it's legacy data from very early in the XRP Ledger's history.)
+	Index types.Hash256 `json:"index,omitempty"`
+	// The value 0x0082, mapped to the string PermissionedDomain, indicates that this is a PermissionedDomain ledger entry.
+	LedgerEntryType EntryType
+	// Fee is the transaction cost, in drops of XRP, that was paid by the
+	// PermissionedDomainSet transaction which created or most recently modified
+	// this PermissionedDomain ledger entry.
+	Fee types.XRPCurrencyAmount
+	// Set of bit-flags for this ledger entry.
+	Flags uint32
+	// 	The address of the account that owns this domain.
+	Owner types.Address
+	// A hint indicating which page of the owner directory links to this entry,
+	// in case the directory consists of multiple pages.
+	OwnerNode string
+	// The Sequence value of the transaction that created this entry.
+	Sequence uint32
+	// A list of 1 to 10 Credential objects that grant access to this domain.
+	// The array is stored sorted by issuer.
+	AcceptedCredentials types.AuthorizeCredentialList
+	// The identifying hash of the transaction that most recently modified this entry.
+	PreviousTxnID types.Hash256
+	// The index of the ledger that contains the transaction that most recently modified this object.
+	PreviousTxnLgrSeq uint32
+}
+
+func (*PermissionedDomain) EntryType() EntryType {
+	return PermissionedDomainEntry
+}

--- a/xrpl/ledger-entry-types/permissioned_domain_test.go
+++ b/xrpl/ledger-entry-types/permissioned_domain_test.go
@@ -1,0 +1,72 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/testutil"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionedDomain_EntryType(t *testing.T) {
+	permissionedDomain := &PermissionedDomain{}
+	require.Equal(t, permissionedDomain.EntryType(), PermissionedDomainEntry)
+}
+
+func TestPermissionedDomain(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		permissionedDomain *PermissionedDomain
+		expected           string
+	}{
+		{
+			name: "pass - valid PermissionedDomain",
+			permissionedDomain: &PermissionedDomain{
+				Index:           types.Hash256("3DFA1DDEA27AF7E466DE395CCB16158E07ECA6BC4EB5580F75EBD39DE833645F"),
+				LedgerEntryType: PermissionedDomainEntry,
+				Fee:             types.XRPCurrencyAmount(10),
+				Flags:           0,
+				Owner:           types.Address("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"),
+				OwnerNode:       "0000000000000000",
+				Sequence:        390,
+				AcceptedCredentials: types.AuthorizeCredentialList{
+					{
+						Credential: types.Credential{
+							Issuer:         types.Address("ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"),
+							CredentialType: types.CredentialType("6D795F63726564656E7469616C"),
+						},
+					},
+				},
+				PreviousTxnID:     types.Hash256("E7E3F2BBAAF48CF893896E48DC4A02BDA0C747B198D5AE18BC3D7567EE64B904"),
+				PreviousTxnLgrSeq: 8734523,
+			},
+			expected: `{
+	"index": "3DFA1DDEA27AF7E466DE395CCB16158E07ECA6BC4EB5580F75EBD39DE833645F",
+	"LedgerEntryType": "PermissionedDomain",
+	"Fee": "10",
+	"Flags": 0,
+	"Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+	"OwnerNode": "0000000000000000",
+	"Sequence": 390,
+	"AcceptedCredentials": [
+		{
+			"Credential": {
+				"Issuer": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+				"CredentialType": "6D795F63726564656E7469616C"
+			}
+		}
+	],
+	"PreviousTxnID": "E7E3F2BBAAF48CF893896E48DC4A02BDA0C747B198D5AE18BC3D7567EE64B904",
+	"PreviousTxnLgrSeq": 8734523
+}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, test.permissionedDomain, test.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/xrpl/rpc/types/client_options.go
+++ b/xrpl/rpc/types/client_options.go
@@ -9,10 +9,3 @@ type SubmitOptions struct {
 	Wallet   *wallet.Wallet
 	FailHard bool
 }
-
-type SubmitBatchOptions struct {
-	Autofill bool
-	Wallet   *wallet.Wallet
-	FailHard bool
-	NSigners uint64
-}

--- a/xrpl/websocket/types/client_options.go
+++ b/xrpl/websocket/types/client_options.go
@@ -9,10 +9,3 @@ type SubmitOptions struct {
 	Wallet   *wallet.Wallet
 	FailHard bool
 }
-
-type SubmitBatchOptions struct {
-	Autofill bool
-	Wallet   *wallet.Wallet
-	FailHard bool
-	NSigners uint64
-}


### PR DESCRIPTION
# [TA-5164] Add PermissionedDomain ledger entry type

## Description
This PR aims to add the PermissionedDomain ledger entry type (XLS-80d)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes

- Add `PermissionedDomain` ledger entry type.
- Add tests for it

## Notes (optional)

- Removed unused types `SubmitBatchOptions`. 
