### PR TITLE
fix(docs): amend broken navigation links

### DIFF
--- a/docs/docs/keypairs.md
+++ b/docs/docs/keypairs.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+pagination_next: xrpl/currency
 ---
 
 # keypairs

--- a/docs/docs/xrpl/currency.md
+++ b/docs/docs/xrpl/currency.md
@@ -1,3 +1,7 @@
+---
+pagination_prev: keypairs
+---
+
 # currency
 
 ## Overview


### PR DESCRIPTION
# fix(docs): amend broken navigation links

## Description
This PR aims to amend the broken links when navigating between the `keypairs` and `xrpl/currency` pages in the documentation.

This issue is due to Docusaurus' handling of the nested `docs/xrpl` directory. Overriding the next/previous IDs is the documented way to handle pagination that breaks the automatic sidebar flow in Docusaurus ([source](https://docusaurus.io/docs/sidebar/multiple-sidebars#generating-pagination)).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Refactoring

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes

- Update `keypairs.md` front matter: set `pagination_next` to `xrpl/currency`
- Update `xrpl/currency.md` front matter: set `pagination_prev` to `keypairs`