### PR TITLE
fix(binary-codec): Add missing Holder and Delegate fields to definitions

### DIFF
--- a/binary-codec/definitions/definitions.json
+++ b/binary-codec/definitions/definitions.json
@@ -2198,6 +2198,26 @@
       }
     ],
     [
+      "Holder",
+      {
+        "nth": 11,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "Delegate",
+      {
+        "nth": 12,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
       "HookAccount",
       {
         "nth": 16,


### PR DESCRIPTION
## Description

This PR adds the missing `Holder` (AccountID, nth=11) and `Delegate` (AccountID, nth=12) fields to the binary-codec definitions.json.

**Problem:** When using `MPTokenAuthorize` transactions with the `Holder` field (required for issuer-side authorization of MPT holders), the transaction fails with `tecNO_PERMISSION` because the `Holder` field is not being properly serialized in the binary transaction.

**Root Cause:** The `Holder` field was missing from `binary-codec/definitions/definitions.json`. The field definitions jump from `EmitCallback` (nth=10) directly to `HookAccount` (nth=16), skipping `Holder` (nth=11) and `Delegate` (nth=12).

**Solution:** Added the missing field definitions to align with the official [xrpl.js ripple-binary-codec definitions](https://github.com/XRPLF/xrpl.js/blob/main/packages/ripple-binary-codec/src/enums/definitions.json).

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Changes

- Added `Holder` field definition (AccountID, nth=11) to definitions.json
- Added `Delegate` field definition (AccountID, nth=12) to definitions.json

## Notes

This fix is required for proper MPT (Multi-Purpose Token) authorization workflows where the issuer needs to authorize holders using the `Holder` field in `MPTokenAuthorize` transactions.