### PR TITLE
refactor(address-codec): set ed25519 family seed prefix

### DIFF
--- a/address-codec/codec.go
+++ b/address-codec/codec.go
@@ -118,12 +118,10 @@ func EncodeSeed(entropy []byte, encodingType interfaces.CryptoImplementation) (s
 		return "", &EncodeLengthError{Instance: "Entropy", Input: len(entropy), Expected: FamilySeedLength}
 	}
 
-	if encodingType == crypto.ED25519() {
-		prefix := []byte{0x01, 0xe1, 0x4b}
-		return Encode(entropy, prefix, FamilySeedLength)
+	if ed25519 := crypto.ED25519(); encodingType == ed25519 {
+		return Encode(entropy, ed25519.FamilySeedPrefix(), FamilySeedLength)
 	} else if secp256k1 := crypto.SECP256K1(); encodingType == secp256k1 {
-		prefix := []byte{secp256k1.FamilySeedPrefix()}
-		return Encode(entropy, prefix, FamilySeedLength)
+		return Encode(entropy, secp256k1.FamilySeedPrefix(), FamilySeedLength)
 	}
 	return "", errors.New("encoding type must be `ed25519` or `secp256k1`")
 

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -13,13 +13,13 @@ const (
 )
 
 var (
-	_ Algorithm = &ED25519CryptoAlgorithm{}
+	_                       Algorithm = &ED25519CryptoAlgorithm{}
+	ed25519FamilySeedPrefix           = []byte{0x01, 0xe1, 0x4b}
 )
 
 // ED25519CryptoAlgorithm is the implementation of the ED25519 cryptographic algorithm.
 type ED25519CryptoAlgorithm struct {
-	prefix           byte
-	familySeedPrefix byte
+	prefix byte
 }
 
 // ED25519 returns the ED25519 cryptographic algorithm.
@@ -35,8 +35,8 @@ func (c ED25519CryptoAlgorithm) Prefix() byte {
 }
 
 // FamilySeedPrefix returns the family seed prefix for the ED25519 cryptographic algorithm.
-func (c ED25519CryptoAlgorithm) FamilySeedPrefix() byte {
-	return c.familySeedPrefix
+func (c ED25519CryptoAlgorithm) FamilySeedPrefix() []byte {
+	return ed25519FamilySeedPrefix
 }
 
 // DeriveKeypair derives a keypair from a seed.

--- a/pkg/crypto/ed25519_test.go
+++ b/pkg/crypto/ed25519_test.go
@@ -11,7 +11,7 @@ func TestED25519_Prefix(t *testing.T) {
 }
 
 func TestED25519_FamilySeedPrefix(t *testing.T) {
-	require.Zero(t, ED25519().FamilySeedPrefix())
+	require.Equal(t, ed25519FamilySeedPrefix, ED25519().FamilySeedPrefix())
 }
 
 func TestED25519DeriveKeypair(t *testing.T) {

--- a/pkg/crypto/secp256k1.go
+++ b/pkg/crypto/secp256k1.go
@@ -14,25 +14,23 @@ import (
 const (
 	// SECP256K1 prefix - value is 0
 	secp256K1Prefix byte = 0x00
-	// SECP256K1 family seed prefix - value is 33
-	secp256K1FamilySeedPrefix byte = 0x21
 )
 
 var (
 	_ Algorithm = SECP256K1CryptoAlgorithm{}
+	// SECP256K1 family seed prefix - value is 33
+	secp256K1FamilySeedPrefix = []byte{0x21}
 )
 
 // SECP256K1CryptoAlgorithm is the implementation of the SECP256K1 algorithm.
 type SECP256K1CryptoAlgorithm struct {
-	prefix           byte
-	familySeedPrefix byte
+	prefix byte
 }
 
 // SECP256K1 returns a new SECP256K1CryptoAlgorithm instance.
 func SECP256K1() SECP256K1CryptoAlgorithm {
 	return SECP256K1CryptoAlgorithm{
-		prefix:           secp256K1Prefix,
-		familySeedPrefix: secp256K1FamilySeedPrefix,
+		prefix: secp256K1Prefix,
 	}
 }
 
@@ -42,8 +40,8 @@ func (c SECP256K1CryptoAlgorithm) Prefix() byte {
 }
 
 // FamilySeedPrefix returns the family seed prefix for the SECP256K1 algorithm.
-func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() byte {
-	return c.familySeedPrefix
+func (c SECP256K1CryptoAlgorithm) FamilySeedPrefix() []byte {
+	return secp256K1FamilySeedPrefix
 }
 
 // deriveScalar derives a scalar from a seed.

--- a/pkg/crypto/types.go
+++ b/pkg/crypto/types.go
@@ -3,5 +3,5 @@ package crypto
 // Algorithm defines the interface for cryptographic algorithms used in XRPL key generation and signing.
 type Algorithm interface {
 	Prefix() byte
-	FamilySeedPrefix() byte
+	FamilySeedPrefix() []byte
 }


### PR DESCRIPTION
# refactor(address-codec): set ed25519 family seed prefix

## Description
This PR aims to refactor family seed prefix check for ed25519.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### address-codec
- Refactor family seed prefix check for ed25519