### PR TITLE
feat(client): poll validated ledger in FundWallet and add GetXrpBalanceValidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### xrpl/rpc
+
+- `GetXrpBalanceValidated` retrieves the XRP balance from the most recently validated ledger.
+
+#### xrpl/websocket
+
+- `GetXrpBalanceValidated` retrieves the XRP balance from the most recently validated ledger.
+
 ### Changed
 
 #### xrpl/rpc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### xrpl/rpc
+
+- `FundWallet` now polls the validated ledger after calling the faucet, treats `actNotFound` as an unfunded account while polling, and returns `ErrFundWalletBalanceNotUpdated` if the balance never increases.
+
+#### xrpl/websocket
+
+- `FundWallet` now polls the validated ledger after calling the faucet, treats `actNotFound` as an unfunded account while polling, and returns `ErrFundWalletBalanceNotUpdated` if the balance never increases.
+
 ## [v0.1.18]
 
 ### Added

--- a/xrpl/rpc/client.go
+++ b/xrpl/rpc/client.go
@@ -320,7 +320,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	// Starting balance. An error here (typically actNotFound for a
 	// brand-new account) is treated as a zero balance so polling can still
 	// detect the faucet deposit.
-	startBalance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+	startBalance, err := c.getValidatedBalance(wallet.ClassicAddress)
 	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
@@ -331,7 +331,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 
 	for range fundWalletMaxAttempts {
 		time.Sleep(fundWalletPollInterval)
-		balance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+		balance, err := c.getValidatedBalance(wallet.ClassicAddress)
 		if err != nil {
 			if isFundWalletActNotFound(err) {
 				continue

--- a/xrpl/rpc/client.go
+++ b/xrpl/rpc/client.go
@@ -4,6 +4,7 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -17,6 +18,11 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 
 	"github.com/Peersyst/xrpl-go/xrpl/wallet"
+)
+
+var (
+	fundWalletMaxAttempts  = 20
+	fundWalletPollInterval = 1 * time.Second
 )
 
 // Client is an XRPL RPC client for sending requests and managing transactions.
@@ -302,18 +308,47 @@ func (c *Client) FaucetProvider() common.FaucetProvider {
 	return c.cfg.faucetProvider
 }
 
-// FundWallet funds a wallet with the client's faucet provider.
+// FundWallet funds a wallet with the client's faucet provider and polls the
+// validated ledger until the account's balance increases. It returns
+// ErrFundWalletBalanceNotUpdated if the balance fails to update within the
+// poll window.
 func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	if wallet.ClassicAddress == "" {
 		return ErrCannotFundWalletWithoutClassicAddress
 	}
 
-	err := c.cfg.faucetProvider.FundWallet(wallet.ClassicAddress)
-	if err != nil {
+	// Starting balance. An error here (typically actNotFound for a
+	// brand-new account) is treated as a zero balance so polling can still
+	// detect the faucet deposit.
+	startBalance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
 
-	return nil
+	if err := c.cfg.faucetProvider.FundWallet(wallet.ClassicAddress); err != nil {
+		return err
+	}
+
+	for range fundWalletMaxAttempts {
+		time.Sleep(fundWalletPollInterval)
+		balance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+		if err != nil {
+			if isFundWalletActNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if balance > startBalance {
+			return nil
+		}
+	}
+
+	return ErrFundWalletBalanceNotUpdated
+}
+
+func isFundWalletActNotFound(err error) bool {
+	var clientErr *ClientError
+	return errors.As(err, &clientErr) && clientErr.ErrorString == actNotFound
 }
 
 func (c *Client) autofillRawTransactions(tx *transaction.FlatTransaction) error {

--- a/xrpl/rpc/client.go
+++ b/xrpl/rpc/client.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	binarycodec "github.com/Peersyst/xrpl-go/binary-codec"
-	"github.com/Peersyst/xrpl-go/xrpl/common"
+	commonconstants "github.com/Peersyst/xrpl-go/xrpl/common"
 	"github.com/Peersyst/xrpl-go/xrpl/hash"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	requests "github.com/Peersyst/xrpl-go/xrpl/queries/transactions"
 	rpctypes "github.com/Peersyst/xrpl-go/xrpl/rpc/types"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
@@ -304,7 +305,7 @@ func (c *Client) AutofillMultisigned(tx *transaction.FlatTransaction, nSigners u
 }
 
 // FaucetProvider returns the faucet provider for the client.
-func (c *Client) FaucetProvider() common.FaucetProvider {
+func (c *Client) FaucetProvider() commonconstants.FaucetProvider {
 	return c.cfg.faucetProvider
 }
 
@@ -320,7 +321,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	// Starting balance. An error here (typically actNotFound for a
 	// brand-new account) is treated as a zero balance so polling can still
 	// detect the faucet deposit.
-	startBalance, err := c.getValidatedBalance(wallet.ClassicAddress)
+	startBalance, err := c.getXrpDropsBalance(wallet.ClassicAddress, common.Validated)
 	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
@@ -331,7 +332,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 
 	for range fundWalletMaxAttempts {
 		time.Sleep(fundWalletPollInterval)
-		balance, err := c.getValidatedBalance(wallet.ClassicAddress)
+		balance, err := c.getXrpDropsBalance(wallet.ClassicAddress, common.Validated)
 		if err != nil {
 			if isFundWalletActNotFound(err) {
 				continue

--- a/xrpl/rpc/client_test.go
+++ b/xrpl/rpc/client_test.go
@@ -16,6 +16,7 @@ import (
 	rpctypes "github.com/Peersyst/xrpl-go/xrpl/rpc/types"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -876,4 +877,150 @@ func setupTestRPCClientForAutofill(t *testing.T, mockResponses []string) *Client
 	require.NoError(t, err)
 
 	return NewClient(cfg)
+}
+
+// mockFaucetProvider is a test double for common.FaucetProvider.
+type mockFaucetProvider struct {
+	err error
+}
+
+func (m *mockFaucetProvider) FundWallet(_ types.Address) error {
+	return m.err
+}
+
+func TestClient_FundWallet(t *testing.T) {
+	const testAddr = "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"
+	prevMaxAttempts := fundWalletMaxAttempts
+	prevPollInterval := fundWalletPollInterval
+	fundWalletMaxAttempts = 3
+	fundWalletPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		fundWalletMaxAttempts = prevMaxAttempts
+		fundWalletPollInterval = prevPollInterval
+	})
+
+	accountInfoResponse := func(balance string) string {
+		return `{
+			"result": {
+				"account_data": {
+					"Account": "` + testAddr + `",
+					"Balance": "` + balance + `",
+					"Flags": 0,
+					"LedgerEntryType": "AccountRoot",
+					"OwnerCount": 0
+				}
+			}
+		}`
+	}
+
+	actNotFoundResponse := `{
+		"result": {
+			"error": "` + actNotFound + `",
+			"status": "error"
+		}
+	}`
+	ledgerIndexMalformedResponse := `{
+		"result": {
+			"error": "ledgerIndexMalformed",
+			"status": "error"
+		}
+	}`
+
+	tests := []struct {
+		name        string
+		address     types.Address
+		faucetErr   error
+		responses   []string
+		expectedErr error
+	}{
+		{
+			name:      "pass - new account funded successfully",
+			address:   testAddr,
+			faucetErr: nil,
+			responses: []string{
+				actNotFoundResponse,
+				accountInfoResponse("1000000000"),
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "pass - existing account balance increases",
+			address:   testAddr,
+			faucetErr: nil,
+			responses: []string{
+				accountInfoResponse("1000"),
+				accountInfoResponse("1000"),
+				accountInfoResponse("2000"),
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "fail - balance never updates",
+			address:   testAddr,
+			faucetErr: nil,
+			responses: []string{
+				accountInfoResponse("1000"),
+				accountInfoResponse("1000"),
+				accountInfoResponse("1000"),
+				accountInfoResponse("1000"),
+			},
+			expectedErr: ErrFundWalletBalanceNotUpdated,
+		},
+		{
+			name:      "fail - polling balance error returns immediately",
+			address:   testAddr,
+			faucetErr: nil,
+			responses: []string{
+				accountInfoResponse("1000"),
+				ledgerIndexMalformedResponse,
+			},
+			expectedErr: errors.New("ledgerIndexMalformed"),
+		},
+		{
+			name:        "fail - faucet returns error",
+			address:     testAddr,
+			faucetErr:   errors.New("faucet unavailable"),
+			responses:   []string{actNotFoundResponse},
+			expectedErr: errors.New("faucet unavailable"),
+		},
+		{
+			name:        "fail - missing classic address",
+			address:     "",
+			expectedErr: ErrCannotFundWalletWithoutClassicAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := &testutil.JSONRPCMockClient{}
+			callIdx := 0
+			mc.DoFunc = func(req *http.Request) (*http.Response, error) {
+				idx := callIdx
+				callIdx++
+				if idx < len(tt.responses) {
+					return testutil.MockResponse(tt.responses[idx], 200, mc)(req)
+				}
+				return testutil.MockResponse(actNotFoundResponse, 200, mc)(req)
+			}
+
+			cfg, err := NewClientConfig(
+				"http://testnode/",
+				WithHTTPClient(mc),
+				WithFaucetProvider(&mockFaucetProvider{err: tt.faucetErr}),
+			)
+			require.NoError(t, err)
+
+			client := NewClient(cfg)
+			w := &wallet.Wallet{ClassicAddress: tt.address}
+
+			err = client.FundWallet(w)
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/xrpl/rpc/errors.go
+++ b/xrpl/rpc/errors.go
@@ -8,6 +8,8 @@ import (
 const (
 	// txnNotFound is the error message returned by the xrpl node when requesting for a not found transaction.
 	txnNotFound = "txnNotFound"
+	// actNotFound is the error message returned by the xrpl node when requesting for a not found account.
+	actNotFound = "actNotFound"
 )
 
 var (
@@ -56,6 +58,8 @@ var (
 
 	// ErrCannotFundWalletWithoutClassicAddress is returned when attempting to fund a wallet without a classic address.
 	ErrCannotFundWalletWithoutClassicAddress = errors.New("cannot fund wallet without a classic address")
+	// ErrFundWalletBalanceNotUpdated is returned when the wallet balance does not update on the validated ledger after polling.
+	ErrFundWalletBalanceNotUpdated = errors.New("fund wallet: balance did not update on validated ledger after polling")
 
 	// fees
 

--- a/xrpl/rpc/queries.go
+++ b/xrpl/rpc/queries.go
@@ -83,34 +83,27 @@ func (c *Client) GetAccountLines(req *account.LinesRequest) (*account.LinesRespo
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
-	balance, err := c.getXrpBalance(address, nil)
-	if err != nil {
-		return "", err
-	}
-	return currency.DropsToXrp(balance.String())
+	return c.getXrpBalance(address, nil)
 }
 
 // GetXrpBalanceValidated retrieves the XRP balance of a given account address
 // from the most recently validated ledger. It returns the balance as a string
 // in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalanceValidated(address types.Address) (string, error) {
-	balance, err := c.getXrpBalance(address, common.Validated)
+	return c.getXrpBalance(address, common.Validated)
+}
+
+func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (string, error) {
+	balance, err := c.getXrpDropsBalance(address, ledgerIndex)
 	if err != nil {
 		return "", err
 	}
 	return currency.DropsToXrp(balance.String())
 }
 
-// getValidatedBalance returns the account balance in drops on the validated
-// ledger. FundWallet uses it to compare balances before and after the faucet
-// deposit, querying the validated ledger avoids racing against open ledger state.
-func (c *Client) getValidatedBalance(address types.Address) (types.XRPCurrencyAmount, error) {
-	return c.getXrpBalance(address, common.Validated)
-}
-
-// getXrpBalance returns the account's XRP balance in drops at the given
+// getXrpDropsBalance returns the account's XRP balance in drops at the given
 // ledger specifier. A nil ledgerIndex lets rippled apply its default.
-func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
+func (c *Client) getXrpDropsBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
 		Account:     address,
 		LedgerIndex: ledgerIndex,

--- a/xrpl/rpc/queries.go
+++ b/xrpl/rpc/queries.go
@@ -83,17 +83,33 @@ func (c *Client) GetAccountLines(req *account.LinesRequest) (*account.LinesRespo
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
+	balance, err := c.getAccountBalance(address, nil)
+	if err != nil {
+		return "", err
+	}
+	return currency.DropsToXrp(balance.String())
+}
+
+// getFundWalletBalance returns the account balance in drops on the validated
+// ledger. FundWallet uses it to detect confirmed faucet deposits; querying
+// the validated ledger avoids racing against open ledger state.
+func (c *Client) getFundWalletBalance(address types.Address) (types.XRPCurrencyAmount, error) {
+	return c.getAccountBalance(address, common.Validated)
+}
+
+// getAccountBalance returns the account's XRP balance in drops at the given
+// ledger specifier. A nil ledgerIndex lets rippled apply its default. It is
+// the shared account_info fetch used by GetXrpBalance (default ledger, XRP
+// string output) and FundWallet (validated ledger, drops comparison).
+func (c *Client) getAccountBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
-		Account: address,
+		Account:     address,
+		LedgerIndex: ledgerIndex,
 	})
 	if err != nil {
-		return "", err
+		return 0, err
 	}
-	xrpBalance, err := currency.DropsToXrp(res.AccountData.Balance.String())
-	if err != nil {
-		return "", err
-	}
-	return xrpBalance, nil
+	return res.AccountData.Balance, nil
 }
 
 // GetAccountNFTs retrieves a list of NFTs owned by an account on the XRP Ledger.

--- a/xrpl/rpc/queries.go
+++ b/xrpl/rpc/queries.go
@@ -83,25 +83,34 @@ func (c *Client) GetAccountLines(req *account.LinesRequest) (*account.LinesRespo
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
-	balance, err := c.getAccountBalance(address, nil)
+	balance, err := c.getXrpBalance(address, nil)
 	if err != nil {
 		return "", err
 	}
 	return currency.DropsToXrp(balance.String())
 }
 
-// getFundWalletBalance returns the account balance in drops on the validated
-// ledger. FundWallet uses it to detect confirmed faucet deposits; querying
-// the validated ledger avoids racing against open ledger state.
-func (c *Client) getFundWalletBalance(address types.Address) (types.XRPCurrencyAmount, error) {
-	return c.getAccountBalance(address, common.Validated)
+// GetXrpBalanceValidated retrieves the XRP balance of a given account address
+// from the most recently validated ledger. It returns the balance as a string
+// in XRP (not drops) and any error encountered.
+func (c *Client) GetXrpBalanceValidated(address types.Address) (string, error) {
+	balance, err := c.getXrpBalance(address, common.Validated)
+	if err != nil {
+		return "", err
+	}
+	return currency.DropsToXrp(balance.String())
 }
 
-// getAccountBalance returns the account's XRP balance in drops at the given
-// ledger specifier. A nil ledgerIndex lets rippled apply its default. It is
-// the shared account_info fetch used by GetXrpBalance (default ledger, XRP
-// string output) and FundWallet (validated ledger, drops comparison).
-func (c *Client) getAccountBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
+// getValidatedBalance returns the account balance in drops on the validated
+// ledger. FundWallet uses it to compare balances before and after the faucet
+// deposit, querying the validated ledger avoids racing against open ledger state.
+func (c *Client) getValidatedBalance(address types.Address) (types.XRPCurrencyAmount, error) {
+	return c.getXrpBalance(address, common.Validated)
+}
+
+// getXrpBalance returns the account's XRP balance in drops at the given
+// ledger specifier. A nil ledgerIndex lets rippled apply its default.
+func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
 		Account:     address,
 		LedgerIndex: ledgerIndex,

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -197,7 +197,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	// Starting balance. An error here (typically actNotFound for a
 	// brand-new account) is treated as a zero balance so polling can still
 	// detect the faucet deposit.
-	startBalance, err := c.getValidatedBalance(wallet.ClassicAddress)
+	startBalance, err := c.getXrpDropsBalance(wallet.ClassicAddress, common.Validated)
 	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 
 	for range fundWalletMaxAttempts {
 		time.Sleep(fundWalletPollInterval)
-		balance, err := c.getValidatedBalance(wallet.ClassicAddress)
+		balance, err := c.getXrpDropsBalance(wallet.ClassicAddress, common.Validated)
 		if err != nil {
 			if isFundWalletActNotFound(err) {
 				continue

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -197,7 +197,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	// Starting balance. An error here (typically actNotFound for a
 	// brand-new account) is treated as a zero balance so polling can still
 	// detect the faucet deposit.
-	startBalance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+	startBalance, err := c.getValidatedBalance(wallet.ClassicAddress)
 	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 
 	for range fundWalletMaxAttempts {
 		time.Sleep(fundWalletPollInterval)
-		balance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+		balance, err := c.getValidatedBalance(wallet.ClassicAddress)
 		if err != nil {
 			if isFundWalletActNotFound(err) {
 				continue

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -3,6 +3,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -45,6 +46,11 @@ const (
 	RestrictedNetworks = 1024
 	// RequiredNetworkIDVersion is the minimum XRPL server build version after which specifying NetworkID is required for restricted networks.
 	RequiredNetworkIDVersion = "1.11.0"
+)
+
+var (
+	fundWalletMaxAttempts  = 20
+	fundWalletPollInterval = 1 * time.Second
 )
 
 // Client is a WebSocket client for interacting with an XRPL server.
@@ -178,19 +184,48 @@ func (c *Client) AutofillMultisigned(tx *transaction.FlatTransaction, nSigners u
 	return nil
 }
 
-// FundWallet funds a wallet with XRP from the faucet.
-// If the wallet does not have a classic address, it will return an error.
+// FundWallet funds a wallet with XRP from the faucet and polls the validated
+// ledger until the account's balance increases. It returns
+// ErrFundWalletBalanceNotUpdated if the balance fails to update within the
+// poll window. If the wallet does not have a classic address, it returns an
+// error.
 func (c *Client) FundWallet(wallet *wallet.Wallet) error {
 	if wallet.ClassicAddress == "" {
 		return ErrCannotFundWalletWithoutClassicAddress
 	}
 
-	err := c.cfg.faucetProvider.FundWallet(wallet.ClassicAddress)
-	if err != nil {
+	// Starting balance. An error here (typically actNotFound for a
+	// brand-new account) is treated as a zero balance so polling can still
+	// detect the faucet deposit.
+	startBalance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+	if err != nil && !isFundWalletActNotFound(err) {
 		return err
 	}
 
-	return nil
+	if err := c.cfg.faucetProvider.FundWallet(wallet.ClassicAddress); err != nil {
+		return err
+	}
+
+	for range fundWalletMaxAttempts {
+		time.Sleep(fundWalletPollInterval)
+		balance, err := c.getFundWalletBalance(wallet.ClassicAddress)
+		if err != nil {
+			if isFundWalletActNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if balance > startBalance {
+			return nil
+		}
+	}
+
+	return ErrFundWalletBalanceNotUpdated
+}
+
+func isFundWalletActNotFound(err error) bool {
+	var wsErr *ErrorWebsocketClientXrplResponse
+	return errors.As(err, &wsErr) && wsErr.Type == actNotFound
 }
 
 // Request sends a request to the server and returns the response.

--- a/xrpl/websocket/client_test.go
+++ b/xrpl/websocket/client_test.go
@@ -5,12 +5,14 @@ import (
 	"maps"
 	"reflect"
 	"testing"
+	"time"
 
 	commonconstants "github.com/Peersyst/xrpl-go/xrpl/common"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/Peersyst/xrpl-go/xrpl/wallet"
 	"github.com/Peersyst/xrpl-go/xrpl/websocket/interfaces"
 	"github.com/Peersyst/xrpl-go/xrpl/websocket/testutil"
 	"github.com/gorilla/websocket"
@@ -1651,4 +1653,152 @@ func setupTestClientForAutofill(t *testing.T, serverMessages []map[string]any) (
 		cl.Disconnect()
 		s.Close()
 	}
+}
+
+type mockFaucetProvider struct {
+	err error
+}
+
+func (m *mockFaucetProvider) FundWallet(_ types.Address) error {
+	return m.err
+}
+
+func TestClient_FundWallet(t *testing.T) {
+	const testAddr = "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn"
+	prevMaxAttempts := fundWalletMaxAttempts
+	prevPollInterval := fundWalletPollInterval
+	fundWalletMaxAttempts = 3
+	fundWalletPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		fundWalletMaxAttempts = prevMaxAttempts
+		fundWalletPollInterval = prevPollInterval
+	})
+
+	accountInfoMsg := func(id int, balance string) map[string]any {
+		return map[string]any{
+			"id": id,
+			"result": map[string]any{
+				"account_data": map[string]any{
+					"Account": testAddr,
+					"Balance": balance,
+				},
+			},
+		}
+	}
+
+	actNotFoundMsg := func(id int) map[string]any {
+		return map[string]any{
+			"id":    id,
+			"error": actNotFound,
+		}
+	}
+	invalidParamsMsg := func(id int) map[string]any {
+		return map[string]any{
+			"id":    id,
+			"error": "invalidParams",
+		}
+	}
+
+	tests := []struct {
+		name           string
+		address        string
+		faucetErr      error
+		serverMessages []map[string]any
+		expectedErr    error
+	}{
+		{
+			name:      "pass - new account funded successfully",
+			address:   testAddr,
+			faucetErr: nil,
+			serverMessages: []map[string]any{
+				actNotFoundMsg(1),
+				accountInfoMsg(2, "1000000000"),
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "pass - existing account balance increases",
+			address:   testAddr,
+			faucetErr: nil,
+			serverMessages: []map[string]any{
+				accountInfoMsg(1, "1000"),
+				accountInfoMsg(2, "1000"),
+				accountInfoMsg(3, "2000"),
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "fail - balance never updates",
+			address:   testAddr,
+			faucetErr: nil,
+			serverMessages: []map[string]any{
+				accountInfoMsg(1, "1000"),
+				accountInfoMsg(2, "1000"),
+				accountInfoMsg(3, "1000"),
+				accountInfoMsg(4, "1000"),
+			},
+			expectedErr: ErrFundWalletBalanceNotUpdated,
+		},
+		{
+			name:      "fail - polling balance error returns immediately",
+			address:   testAddr,
+			faucetErr: nil,
+			serverMessages: []map[string]any{
+				accountInfoMsg(1, "1000"),
+				invalidParamsMsg(2),
+			},
+			expectedErr: &ErrorWebsocketClientXrplResponse{Type: "invalidParams"},
+		},
+		{
+			name:      "fail - faucet returns error",
+			address:   testAddr,
+			faucetErr: errors.New("faucet unavailable"),
+			serverMessages: []map[string]any{
+				actNotFoundMsg(1),
+			},
+			expectedErr: errors.New("faucet unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &testutil.MockWebSocketServer{Msgs: tt.serverMessages}
+			s := ws.TestWebSocketServer(func(c *websocket.Conn) {
+				for _, m := range tt.serverMessages {
+					if err := c.WriteJSON(m); err != nil {
+						t.Errorf("error writing message: %v", err)
+					}
+				}
+			})
+			defer s.Close()
+
+			url, _ := testutil.ConvertHTTPToWS(s.URL)
+			cl := NewClient(
+				NewClientConfig().
+					WithHost(url).
+					WithTimeout(1 * time.Second).
+					WithFaucetProvider(&mockFaucetProvider{err: tt.faucetErr}),
+			)
+
+			require.NoError(t, cl.Connect())
+			defer cl.Disconnect()
+
+			w := &wallet.Wallet{ClassicAddress: types.Address(tt.address)}
+			err := cl.FundWallet(w)
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("fail - missing classic address", func(t *testing.T) {
+		cl := NewClient(*NewClientConfig())
+		w := &wallet.Wallet{ClassicAddress: ""}
+		err := cl.FundWallet(w)
+		require.ErrorIs(t, err, ErrCannotFundWalletWithoutClassicAddress)
+	})
 }

--- a/xrpl/websocket/errors.go
+++ b/xrpl/websocket/errors.go
@@ -8,6 +8,8 @@ import (
 const (
 	// txnNotFound is the error message returned by the xrpl node when requesting for a not found transaction.
 	txnNotFound = "txnNotFound"
+	// actNotFound is the error message returned by the xrpl node when requesting for a not found account.
+	actNotFound = "actNotFound"
 )
 
 var (
@@ -64,6 +66,8 @@ var (
 
 	// ErrCannotFundWalletWithoutClassicAddress is returned when attempting to fund a wallet without a classic address.
 	ErrCannotFundWalletWithoutClassicAddress = errors.New("cannot fund a wallet without a classic address")
+	// ErrFundWalletBalanceNotUpdated is returned when the wallet balance does not update on the validated ledger after polling.
+	ErrFundWalletBalanceNotUpdated = errors.New("fund wallet: balance did not update on validated ledger after polling")
 
 	// fees
 

--- a/xrpl/websocket/queries.go
+++ b/xrpl/websocket/queries.go
@@ -69,25 +69,34 @@ func (c *Client) GetAccountObjects(req *account.ObjectsRequest) (*account.Object
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
-	balance, err := c.getAccountBalance(address, nil)
+	balance, err := c.getXrpBalance(address, nil)
 	if err != nil {
 		return "", err
 	}
 	return currency.DropsToXrp(balance.String())
 }
 
-// getFundWalletBalance returns the account balance in drops on the validated
-// ledger. FundWallet uses it to detect confirmed faucet deposits; querying
-// the validated ledger avoids racing against open ledger state.
-func (c *Client) getFundWalletBalance(address types.Address) (types.XRPCurrencyAmount, error) {
-	return c.getAccountBalance(address, common.Validated)
+// GetXrpBalanceValidated retrieves the XRP balance of a given account address
+// from the most recently validated ledger. It returns the balance as a string
+// in XRP (not drops) and any error encountered.
+func (c *Client) GetXrpBalanceValidated(address types.Address) (string, error) {
+	balance, err := c.getXrpBalance(address, common.Validated)
+	if err != nil {
+		return "", err
+	}
+	return currency.DropsToXrp(balance.String())
 }
 
-// getAccountBalance returns the account's XRP balance in drops at the given
-// ledger specifier. A nil ledgerIndex lets rippled apply its default. It is
-// the shared account_info fetch used by GetXrpBalance (default ledger, XRP
-// string output) and FundWallet (validated ledger, drops comparison).
-func (c *Client) getAccountBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
+// getValidatedBalance returns the account balance in drops on the validated
+// ledger. FundWallet uses it to compare balances before and after the faucet
+// deposit, querying the validated ledger avoids racing against open ledger state.
+func (c *Client) getValidatedBalance(address types.Address) (types.XRPCurrencyAmount, error) {
+	return c.getXrpBalance(address, common.Validated)
+}
+
+// getXrpBalance returns the account's XRP balance in drops at the given
+// ledger specifier. A nil ledgerIndex lets rippled apply its default.
+func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
 		Account:     address,
 		LedgerIndex: ledgerIndex,

--- a/xrpl/websocket/queries.go
+++ b/xrpl/websocket/queries.go
@@ -69,34 +69,27 @@ func (c *Client) GetAccountObjects(req *account.ObjectsRequest) (*account.Object
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
-	balance, err := c.getXrpBalance(address, nil)
-	if err != nil {
-		return "", err
-	}
-	return currency.DropsToXrp(balance.String())
+	return c.getXrpBalance(address, nil)
 }
 
 // GetXrpBalanceValidated retrieves the XRP balance of a given account address
 // from the most recently validated ledger. It returns the balance as a string
 // in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalanceValidated(address types.Address) (string, error) {
-	balance, err := c.getXrpBalance(address, common.Validated)
+	return c.getXrpBalance(address, common.Validated)
+}
+
+func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (string, error) {
+	balance, err := c.getXrpDropsBalance(address, ledgerIndex)
 	if err != nil {
 		return "", err
 	}
 	return currency.DropsToXrp(balance.String())
 }
 
-// getValidatedBalance returns the account balance in drops on the validated
-// ledger. FundWallet uses it to compare balances before and after the faucet
-// deposit, querying the validated ledger avoids racing against open ledger state.
-func (c *Client) getValidatedBalance(address types.Address) (types.XRPCurrencyAmount, error) {
-	return c.getXrpBalance(address, common.Validated)
-}
-
-// getXrpBalance returns the account's XRP balance in drops at the given
+// getXrpDropsBalance returns the account's XRP balance in drops at the given
 // ledger specifier. A nil ledgerIndex lets rippled apply its default.
-func (c *Client) getXrpBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
+func (c *Client) getXrpDropsBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
 		Account:     address,
 		LedgerIndex: ledgerIndex,

--- a/xrpl/websocket/queries.go
+++ b/xrpl/websocket/queries.go
@@ -69,19 +69,33 @@ func (c *Client) GetAccountObjects(req *account.ObjectsRequest) (*account.Object
 // GetXrpBalance retrieves the XRP balance of a given account address.
 // It returns the balance as a string in XRP (not drops) and any error encountered.
 func (c *Client) GetXrpBalance(address types.Address) (string, error) {
+	balance, err := c.getAccountBalance(address, nil)
+	if err != nil {
+		return "", err
+	}
+	return currency.DropsToXrp(balance.String())
+}
+
+// getFundWalletBalance returns the account balance in drops on the validated
+// ledger. FundWallet uses it to detect confirmed faucet deposits; querying
+// the validated ledger avoids racing against open ledger state.
+func (c *Client) getFundWalletBalance(address types.Address) (types.XRPCurrencyAmount, error) {
+	return c.getAccountBalance(address, common.Validated)
+}
+
+// getAccountBalance returns the account's XRP balance in drops at the given
+// ledger specifier. A nil ledgerIndex lets rippled apply its default. It is
+// the shared account_info fetch used by GetXrpBalance (default ledger, XRP
+// string output) and FundWallet (validated ledger, drops comparison).
+func (c *Client) getAccountBalance(address types.Address, ledgerIndex common.LedgerSpecifier) (types.XRPCurrencyAmount, error) {
 	res, err := c.GetAccountInfo(&account.InfoRequest{
-		Account: address,
+		Account:     address,
+		LedgerIndex: ledgerIndex,
 	})
 	if err != nil {
-		return "", err
+		return 0, err
 	}
-
-	xrpBalance, err := currency.DropsToXrp(res.AccountData.Balance.String())
-	if err != nil {
-		return "", err
-	}
-
-	return xrpBalance, nil
+	return res.AccountData.Balance, nil
 }
 
 // GetAccountLines retrieves the lines associated with an account on the XRP Ledger.


### PR DESCRIPTION
# feat(client): poll validated ledger in FundWallet and add GetXrpBalanceValidated

## Description
This PR aims to make `FundWallet` reliable by polling the validated ledger after calling the faucet until the account balance increases, and to expose a new `GetXrpBalanceValidated` method on both the RPC and WebSocket clients.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### xrpl/rpc
- Added `GetXrpBalanceValidated` public method that retrieves the XRP balance from the most recently validated ledger
- Refactored `GetXrpBalance` to delegate to a shared private `getXrpBalance(address, ledgerIndex)` method that returns `types.XRPCurrencyAmount` (drops), keeping drops-to-XRP conversion in the public callers
- Added `getValidatedBalance` internal helper used by `FundWallet` to query the validated ledger balance in drops
- Updated `FundWallet` to capture the starting balance before calling the faucet, then poll the validated ledger up to `fundWalletMaxAttempts` (20) times at `fundWalletPollInterval` (1s) intervals, returning `ErrFundWalletBalanceNotUpdated` if the balance never increases
- Added `isFundWalletActNotFound` helper that treats `actNotFound` errors as zero-balance (new accounts) during polling
- Added `actNotFound` constant and `ErrFundWalletBalanceNotUpdated` error to `errors.go`
- Added comprehensive `TestClient_FundWallet` test table covering: new account funding, existing account balance increase, balance timeout, polling error propagation, faucet error, and missing classic address

### xrpl/websocket
- Added `GetXrpBalanceValidated` public method mirroring the RPC client
- Refactored `GetXrpBalance` with the same shared `getXrpBalance` pattern as the RPC client
- Added `getValidatedBalance` internal helper and `isFundWalletActNotFound` using the WebSocket-specific `ErrorWebsocketClientXrplResponse` error type
- Updated `FundWallet` with the same polling logic as the RPC client
- Added `actNotFound` constant and `ErrFundWalletBalanceNotUpdated` error to `errors.go`
- Added comprehensive `TestClient_FundWallet` test table with WebSocket mock server, covering the same scenarios as the RPC tests

## Notes

- The polling variables (`fundWalletMaxAttempts`, `fundWalletPollInterval`) are package-level vars rather than constants so tests can override them to avoid slow test runs.
- The `actNotFound` error is expected for brand-new accounts that haven't appeared on the ledger yet, the polling loop treats it as a zero balance and continues waiting.
