### PR TITLE
ci: declare least-privilege GITHUB_TOKEN permissions on workflows

### DIFF
--- a/.github/workflows/xrpl-go-ci-coverage.yml
+++ b/.github/workflows/xrpl-go-ci-coverage.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+permissions:
+  contents: read
 jobs:
   build:
     name: Test Coverage

--- a/.github/workflows/xrpl-go-ci-lint-test.yml
+++ b/.github/workflows/xrpl-go-ci-lint-test.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+permissions:
+  contents: read
 jobs:
   build:
     name: Lint and Test

--- a/.github/workflows/xrpl-go-docs-deploy.yml
+++ b/.github/workflows/xrpl-go-docs-deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Docusaurus

--- a/.github/workflows/xrpl-go-docs-test-deploy.yml
+++ b/.github/workflows/xrpl-go-docs-test-deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
# ci: declare least-privilege GITHUB_TOKEN permissions on workflows

## Description
This PR aims to harden GitHub Actions workflows by declaring explicit least-privilege `GITHUB_TOKEN` permissions at the workflow level.

## Type of change
- [x] CI

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] My changes generate no new warnings

## Changes

- Add top-level `permissions: contents: read` to `.github/workflows/xrpl-go-ci-coverage.yml` to restrict the workflow's `GITHUB_TOKEN` to read-only repository access.
- Add top-level `permissions: contents: read` to `.github/workflows/xrpl-go-ci-lint-test.yml` for the lint and test workflow.
- Add top-level `permissions: contents: read` to `.github/workflows/xrpl-go-docs-deploy.yml` for the docs deployment workflow.
- Add top-level `permissions: contents: read` to `.github/workflows/xrpl-go-docs-test-deploy.yml` for the docs test deployment workflow.


