### PR TITLE
ci: harden GitHub Actions workflows with pinned SHAs and least-privilege permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/xrpl-go-ci-coverage.yml
+++ b/.github/workflows/xrpl-go-ci-coverage.yml
@@ -4,19 +4,21 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+permissions:
+  contents: read
 jobs:
   build:
     name: Test Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
       - name: Generate unit test coverage
         run: make coverage-unit
 
       - name: Check unit test coverage
-        uses: vladopajic/go-test-coverage@v2
+        uses: vladopajic/go-test-coverage@8cfd056d3bc5cc2bc64a840ded0c907aaae3dc46 # v2.18.7
         with:
           # Configure action using config file (option 1)
           config: ./.testcoverage.yml

--- a/.github/workflows/xrpl-go-ci-lint-test.yml
+++ b/.github/workflows/xrpl-go-ci-lint-test.yml
@@ -4,15 +4,17 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+permissions:
+  contents: read
 jobs:
   build:
     name: Lint and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Install golangci-lint

--- a/.github/workflows/xrpl-go-docs-deploy.yml
+++ b/.github/workflows/xrpl-go-docs-deploy.yml
@@ -7,15 +7,18 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -25,7 +28,7 @@ jobs:
         run: cd docs && yarn build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/build
 
@@ -47,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/xrpl-go-docs-test-deploy.yml
+++ b/.github/workflows/xrpl-go-docs-test-deploy.yml
@@ -7,15 +7,18 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: yarn

--- a/.github/workflows/xrpl-go-release.yml
+++ b/.github/workflows/xrpl-go-release.yml
@@ -12,21 +12,25 @@ on:
         description: Is this a pre-release?
         type: boolean
         required: true
+permissions:
+  contents: read
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
+    permissions:
+      contents: write # to create the git tag and publish the GitHub release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.commit_branch }}
           fetch-depth: 0
           fetch-tags: true
       - name: Publish the Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag }}
-          prerelease: github.event.inputs.is_pre_release
+          prerelease: ${{ github.event.inputs.is_pre_release }}
           target_commitish: ${{ github.event.inputs.commit_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# ci: harden GitHub Actions workflows with pinned SHAs and least-privilege permissions

## Description
This PR aims to harden the repository's GitHub Actions workflows by pinning every third-party action to a full commit SHA, declaring least-privilege `GITHUB_TOKEN` permissions, fixing a couple of pre-existing workflow bugs, and enabling Dependabot to keep the pinned actions up to date.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI / build hardening (bug fix + chore)
- [x] Bug fix (workflow correctness)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Changes

### Action pinning
- Replaced floating tag references with full commit SHAs (with version comments) across all workflows so future action releases cannot silently change CI behavior:
  - `actions/checkout@v3` / `@v4` -> `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - `actions/setup-go@v3` / `@v4` -> `@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0`
  - `actions/setup-node@v4` -> `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`
  - `actions/upload-pages-artifact@v3` -> `@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0`
  - `actions/deploy-pages@v4` -> `@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0`
  - `vladopajic/go-test-coverage@v2` -> `@8cfd056d3bc5cc2bc64a840ded0c907aaae3dc46 # v2.18.7`
  - `softprops/action-gh-release@v1` -> `@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0`

### Workflow permissions
- Added top-level `permissions: { contents: read }` to enforce least privilege on:
  - `xrpl-go-ci-coverage.yml`
  - `xrpl-go-ci-lint-test.yml`
  - `xrpl-go-docs-deploy.yml` (job-scoped `pages: write` / `id-token: write` retained on the `deploy` job only)
  - `xrpl-go-docs-test-deploy.yml`

### Bug fixes
- `xrpl-go-ci-lint-test.yml`: bumped `setup-go` from `1.24` to `1.25` to match the version used elsewhere and unbreak the lint job.
- `xrpl-go-release.yml`: wrapped `prerelease: github.event.inputs.is_pre_release` in `${{ ... }}` so the input is actually evaluated instead of being treated as a literal string.
- `xrpl-go-docs-test-deploy.yml`: fixed missing trailing newline at end of file.

### Dependabot
- Added a `github-actions` ecosystem entry to `.github/dependabot.yml` (weekly schedule, 10 PR limit) so the newly pinned action SHAs receive automated update PRs.