### PR TITLE
fix(binary-codec): correct variable-length prefix encoding at 12480 boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fetchCounterPartySignersCount` in the RPC client now uses `"current"` ledger index instead of `"validated"` when fetching the loan broker and counterparty signer information, avoiding lookup failures before the transaction is validated.
 
+#### binary-codec
+
+- Fixed off-by-one in the variable-length prefix encoder (`serdes.encodeVariableLength`) at the 2-byte/3-byte boundary. Length 12480 was routed to the 3-byte branch and underflowed to bytes `[0xF0, 0xFF, 0xFF]`, corrupting the next field on decode. The 2-byte branch now correctly covers lengths 193..12480 inclusive per the XRPL serialization spec.
+
 ## [v0.1.18]
 
 ### Added

--- a/binary-codec/serdes/binary_serializer.go
+++ b/binary-codec/serdes/binary_serializer.go
@@ -62,7 +62,7 @@ func encodeVariableLength(length int) ([]byte, error) {
 	if length <= 192 {
 		return []byte{byte(length)}, nil
 	}
-	if length < 12480 {
+	if length <= 12480 {
 		length -= 193
 		b1 := byte((length >> 8) + 193)
 		b2 := byte((length & 0xFF))

--- a/binary-codec/serdes/binary_serializer_test.go
+++ b/binary-codec/serdes/binary_serializer_test.go
@@ -34,7 +34,7 @@ func TestBinarySerializer_EncodeVariableLength(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name:        "length more than 12841 ad less than 918744",
+			name:        "length more than 12841 and less than 918744",
 			len:         20000,
 			expected:    []byte{0xF1, 0x1D, 0x5F},
 			expectedErr: nil,
@@ -74,6 +74,12 @@ func TestBinarySerializer_EncodeVariableLength(t *testing.T) {
 			len:         918744,
 			expected:    []byte{0xFE, 0xD4, 0x17},
 			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 918745 (one past max)",
+			len:         918745,
+			expected:    nil,
+			expectedErr: ErrLengthPrefixTooLong,
 		},
 		{
 			name:        "length more than 918744",

--- a/binary-codec/serdes/binary_serializer_test.go
+++ b/binary-codec/serdes/binary_serializer_test.go
@@ -3,6 +3,7 @@ package serdes
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -39,6 +40,42 @@ func TestBinarySerializer_EncodeVariableLength(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "boundary - length 0",
+			len:         0,
+			expected:    []byte{0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 192 (max 1-byte)",
+			len:         192,
+			expected:    []byte{0xC0},
+			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 193 (min 2-byte)",
+			len:         193,
+			expected:    []byte{0xC1, 0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 12480 (max 2-byte)",
+			len:         12480,
+			expected:    []byte{0xF0, 0xFF},
+			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 12481 (min 3-byte)",
+			len:         12481,
+			expected:    []byte{0xF1, 0x00, 0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "boundary - length 918744 (max 3-byte)",
+			len:         918744,
+			expected:    []byte{0xFE, 0xD4, 0x17},
+			expectedErr: nil,
+		},
+		{
 			name:        "length more than 918744",
 			len:         1000000,
 			expected:    nil,
@@ -59,6 +96,22 @@ func TestBinarySerializer_EncodeVariableLength(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)
 			}
+		})
+	}
+}
+
+func TestBinarySerializer_VariableLength_RoundTrip(t *testing.T) {
+	lengths := []int{0, 192, 193, 12480, 12481, 918744}
+	for _, length := range lengths {
+		t.Run(fmt.Sprintf("length %d", length), func(t *testing.T) {
+			prefix, err := encodeVariableLength(length)
+			require.NoError(t, err)
+
+			parser := NewBinaryParser(prefix, definitions.Get())
+			decoded, err := parser.ReadVariableLength()
+			require.NoError(t, err)
+			require.Equal(t, length, decoded)
+			require.False(t, parser.HasMore(), "no extra bytes after prefix")
 		})
 	}
 }


### PR DESCRIPTION
# fix(binary-codec): correct variable-length prefix encoding at 12480 boundary

## Description
This PR aims to fix an off-by-one bug in the variable-length prefix encoder at the 2-byte/3-byte boundary, which caused length 12480 to be incorrectly routed to the 3-byte branch and produce a corrupted prefix.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### binary-codec

- Fixed off-by-one in `serdes.encodeVariableLength` at the 2-byte/3-byte boundary. Length 12480 was previously routed to the 3-byte branch and underflowed to bytes `[0xF0, 0xFF, 0xFF]`, corrupting the next field on decode. The 2-byte branch now correctly covers lengths 193..12480 inclusive per the XRPL serialization spec (`length < 12480` -> `length <= 12480`).
- Added boundary test cases in `binary_serializer_test.go` covering lengths 0, 192 (max 1-byte), 193 (min 2-byte), 12480 (max 2-byte), 12481 (min 3-byte), and 918744 (max 3-byte).
- Added `TestBinarySerializer_VariableLength_RoundTrip` to verify encode/decode symmetry across all boundary lengths and assert no extra bytes remain in the parser.