### PR TITLE
fix(address-codec): validate Base58Check checksum and prefix length in Decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### address-codec
+
+- `Decode` now validates Base58Check checksums and prefix lengths before slicing, preventing panics on malformed public key input.
+
 #### xrpl
 
 - `fetchCounterPartySignersCount` in the RPC client now uses `"current"` ledger index instead of `"validated"` when fetching the loan broker and counterparty signer information, avoiding lookup failures before the transaction is validated.

--- a/address-codec/codec.go
+++ b/address-codec/codec.go
@@ -49,14 +49,16 @@ func Encode(b []byte, typePrefix []byte, expectedLength int) (string, error) {
 func Decode(b58string string, typePrefix []byte) ([]byte, error) {
 	prefixLength := len(typePrefix)
 
-	if !bytes.Equal(DecodeBase58(b58string)[:prefixLength], typePrefix) {
-		return nil, errors.New("b58string prefix and typeprefix not equal")
+	result, err := Base58CheckDecode(b58string)
+	if err != nil {
+		return nil, err
 	}
 
-	result, err := Base58CheckDecode(b58string)
-	result = result[prefixLength:]
+	if len(result) < prefixLength || !bytes.Equal(result[:prefixLength], typePrefix) {
+		return nil, ErrB58PrefixMismatch
+	}
 
-	return result, err
+	return result[prefixLength:], nil
 }
 
 // EncodeClassicAddressFromPublicKeyHex returns the classic address from a public key hex string.

--- a/address-codec/codec_test.go
+++ b/address-codec/codec_test.go
@@ -91,7 +91,7 @@ func TestDecode(t *testing.T) {
 			res, err := Decode(tc.input, tc.inputPrefix)
 
 			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOutput, res)
@@ -478,7 +478,7 @@ func TestDecodeNodePublicKey(t *testing.T) {
 			res, err := DecodeNodePublicKey(tc.input)
 
 			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOutput, res)
@@ -548,7 +548,7 @@ func TestDecodeAccountPublicKey(t *testing.T) {
 			res, err := DecodeAccountPublicKey(tc.input)
 
 			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.output, res)

--- a/address-codec/codec_test.go
+++ b/address-codec/codec_test.go
@@ -63,12 +63,39 @@ func TestDecode(t *testing.T) {
 			expectedOutput: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 			expectedErr:    nil,
 		},
+		{
+			name:           "fail - invalid base58 character",
+			input:          "0",
+			inputPrefix:    []byte{AccountAddressPrefix},
+			expectedOutput: nil,
+			expectedErr:    ErrInvalidFormat,
+		},
+		{
+			name:           "fail - invalid checksum",
+			input:          "rrrrrrrrrrrrrrrrrp9U13c",
+			inputPrefix:    []byte{AccountAddressPrefix},
+			expectedOutput: nil,
+			expectedErr:    ErrChecksum,
+		},
+		{
+			name:           "fail - decoded payload shorter than prefix",
+			input:          Base58CheckEncode(nil, AccountAddressPrefix),
+			inputPrefix:    []byte{AccountAddressPrefix, AccountPublicKeyPrefix},
+			expectedOutput: nil,
+			expectedErr:    ErrB58PrefixMismatch,
+		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, _ := Decode(tc.input, tc.inputPrefix)
-			require.Equal(t, tc.expectedOutput, res)
+			res, err := Decode(tc.input, tc.inputPrefix)
+
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOutput, res)
+			}
 		})
 	}
 }
@@ -442,7 +469,7 @@ func TestDecodeNodePublicKey(t *testing.T) {
 			name:           "fail - length error",
 			input:          "rfZG9pC1cKF7q96TNZR264H9ykzKCxMyk44ZK8hFL8cNv1G3c8J",
 			expectedOutput: nil,
-			expectedErr:    errors.New("b58string prefix and typeprefix not equal"),
+			expectedErr:    ErrB58PrefixMismatch,
 		},
 	}
 
@@ -512,7 +539,7 @@ func TestDecodeAccountPublicKey(t *testing.T) {
 			name:        "fail - length error",
 			input:       "nHU75pVH2Tak7adBWNP3H2CU3wcUtSgf45sKrd1uGyFyRcTozXNm",
 			output:      nil,
-			expectedErr: errors.New("b58string prefix and typeprefix not equal"),
+			expectedErr: ErrB58PrefixMismatch,
 		},
 	}
 

--- a/address-codec/errors.go
+++ b/address-codec/errors.go
@@ -30,6 +30,8 @@ var (
 	ErrChecksum = errors.New("checksum error")
 	// ErrInvalidFormat indicates that the check-encoded string has an invalid format.
 	ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes missing")
+	// ErrB58PrefixMismatch indicates that the decoded base58 payload prefix does not match the expected type prefix.
+	ErrB58PrefixMismatch = errors.New("b58string prefix and typeprefix not equal")
 )
 
 // Dynamic errors


### PR DESCRIPTION
# fix(address-codec): validate Base58Check checksum and prefix length in Decode

## Description
This PR aims to harden `addresscodec.Decode` against malformed input by validating the Base58Check checksum and ensuring the decoded payload is long enough to contain the expected type prefix before slicing.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### address-codec
- Rewrote `Decode` in `address-codec/codec.go` to call `Base58CheckDecode` first, propagate its error, and verify `len(result) >= prefixLength` before comparing the prefix, eliminating panics on short or invalid Base58Check input.
- Replaced the inline `errors.New("b58string prefix and typeprefix not equal")` with a new exported sentinel `ErrB58PrefixMismatch` declared in `address-codec/errors.go` so callers can match against it with `errors.Is`.
- Extended `TestDecode` in `address-codec/codec_test.go` with three new failure cases: invalid base58 character (`ErrInvalidFormat`), invalid checksum (`ErrChecksum`), and decoded payload shorter than the requested prefix (`ErrB58PrefixMismatch`); switched the assertion style to `require.EqualError` so the error path is checked explicitly.
- Updated existing `errors.New(...)` test expectations in the X-address and node-public-key decode tables to use the new `ErrB58PrefixMismatch` sentinel.