### PR TITLE
test(integration): handle mpt assetscale decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl
 
 - `fetchCounterPartySignersCount` in the RPC client now uses `"current"` ledger index instead of `"validated"` when fetching the loan broker and counterparty signer information, avoiding lookup failures before the transaction is validated.
+- `MPTokenIssuanceCreate` integration tests now handle RPC numeric fields decoded as `json.Number`.
 
 ## [v0.1.18]
 

--- a/xrpl/transaction/integration/mpt/mptoken_issuance_create_test.go
+++ b/xrpl/transaction/integration/mpt/mptoken_issuance_create_test.go
@@ -59,7 +59,7 @@ func testIntegrationMptTokenCreate(t *testing.T, client integration.Client) {
 			require.Len(t, accountObjects.AccountObjects, 1)
 			createdToken := accountObjects.AccountObjects[0]
 
-			createdAssetScale := createdToken["AssetScale"].(float64)
+			createdAssetScale := integration.TxFieldUint32(t, createdToken, "AssetScale")
 			require.Equal(t, uint8(createdAssetScale), assetScale)
 
 			createdMaximumAmount := createdToken["MaximumAmount"]


### PR DESCRIPTION
# test(integration): handle mpt assetscale decoding

## Description
This PR aims to make `MPTokenIssuanceCreate` integration tests handle RPC numeric fields decoded as `json.Number`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### xrpl

- Updated `TestMPTokenIssuanceCreate` to read the created `AssetScale` field through `integration.TxFieldUint32`, avoiding a direct `float64` assertion that panics when RPC JSON numbers are decoded as `json.Number`.
