### PR TITLE
Code review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: code-review
+description: "Review the current branch's diff against go-* anti-pattern rules and xrpl-standards specs. Spawns focused subagents per changed package, plus a single XRPL-domain reviewer when protocol files are touched, and synthesizes findings cross-cutting. Use when the user types /code-review, finishes a task and wants a self-review, or fetches a teammate's branch and wants to audit it before merging."
+---
+
+# Code Review
+
+Multi-reviewer audit of the current branch's changes. The orchestrator computes the diff, classifies changed files by Go top-level package, and spawns subagents that apply the team's `go-*` rules and `xrpl-standards` specs. Findings come back as JSON, are deduped + capped, and rendered grouped by file.
+
+This skill **does not** replace `/review` or `/security-review`. It's a **rule-based audit** keyed to this repo's codified standards.
+
+## Pipeline
+
+### 1. Resolve scope
+
+Default: committed changes on the current branch vs `main`.
+
+**Prompt the user (`AskUserQuestion`) only on ambiguous cases:**
+
+| Situation                               | Ask                                                    |
+| --------------------------------------- | ------------------------------------------------------ |
+| Dirty tree, no `--include-*` flag       | committed only / + uncommitted / + untracked           |
+| Current branch == base (e.g. on `main`) | last commit / last N commits / pick a package / cancel |
+| Base does not exist                     | pick a base from `git branch -a`                       |
+
+If the user passed flags or a positional package, those resolve the ambiguity — don't re-prompt.
+
+### 2. Classify changed files
+
+A package = top-level dir under repo root: `address-codec/`, `binary-codec/`, `keypairs/`, `xrpl/`, `pkg/`. Anything else (`examples/`, root-level files) → `other`.
+
+Build `{package: [files]}`.
+
+### 3. Decide single-pass vs fan-out
+
+- **Single-pass** when added+removed lines < 200 AND only one package touched: run the go-mistakes rubric inline (no subagent), skip to step 6.
+- **Fan-out** otherwise.
+
+### 4. Spawn subagents (in parallel — single message, multiple `Agent` calls, `subagent_type: "general-purpose"`)
+
+**Go-mistakes — one per changed package.** Use `prompts/go-mistakes.md` as the prompt with substitutions:
+
+- `{{PACKAGE}}` → package name
+- `{{CHANGED_FILES}}` → newline-separated file list
+- `{{BASE}}`, `{{INCLUDE_UNCOMMITTED}}`, `{{INCLUDE_UNTRACKED}}`
+
+**XRPL-domain — at most one, conditional.** Spawn if any changed file matches:
+
+- `xrpl/transaction/**`, `xrpl/ledger-entry-types/**`, `xrpl/queries/**`
+- `binary-codec/types/**`, `binary-codec/definitions/**`
+
+Use `prompts/xrpl-domain.md` with the same substitutions but `{{CHANGED_FILES}}` is the XRPL-relevant slice across packages.
+
+If `--only=go` → skip XRPL subagent. If `--only=xrpl` → skip go-mistakes subagents.
+
+### 5. Collect output
+
+Each subagent returns prose followed by **one** ```json fenced block on the last lines (schema below).
+
+Extract the **last** ```json block. On parse failure, retry once: `"Your previous output was not valid JSON. Parser error: <err>. Reply with ONLY the JSON array, no prose."`
+
+If the retry also fails, fall back: include the subagent's raw text as a single `concern`-level finding with `source: "<reviewer>/unparseable"`. Never abort the run on one bad subagent.
+
+### 6. Cross-cutting synthesis
+
+After all subagents return, the orchestrator does its own pass on the merged JSON + the diff:
+
+1. **Dedup** exact `(file, line, message)` matches — keep one, merge `source` fields.
+2. **Import boundary check.** Per `CLAUDE.md`'s layering, low-level packages (`address-codec/`, `keypairs/`, `binary-codec/`, `pkg/`) must NOT import from `xrpl/`. Flag violations as blocker / `cross-cutting/layering`.
+3. **Shared-package consumers.** If a low-level package's exported symbol changed, `git grep` for callers in `xrpl/`. If a caller wasn't also updated in this diff, flag concern / `cross-cutting/consumer`.
+4. **CHANGELOG check.** If any `.go` file under the four real packages changed, verify `CHANGELOG.md` was modified in this diff. If not, emit concern / `cross-cutting/changelog`.
+
+### 7. Render
+
+Apply in order:
+
+1. `--severity` filter (blocker → blocker only; concern → blocker+concern; nit → all).
+2. `--only` filter (drops findings whose `source` doesn't match; cross-cutting findings always pass).
+3. **Per-file per-source nit cap = 5.** Excess collapsed to `+N more nits`.
+4. **Global cap = 20.** Blockers and concerns never drop. If `blockers + concerns > 20`, drop nits entirely.
+5. Group by file (path order). Within a file, sort by severity (blocker → concern → nit) then line number.
+
+Print the report. No follow-up actions, no auto-fix.
+
+## Subagent JSON schema
+
+```json
+[
+  {
+    "file": "binary-codec/types/signers.go",
+    "line": 142,
+    "severity": "blocker",
+    "source": "go-errors/error-wrapping",
+    "message": "Wraps with %v, loses error chain.",
+    "suggestion": "Use %w."
+  }
+]
+```
+
+- **`file`** — repo-relative, forward slashes.
+- **`line`** — 1-based; use `1` for file-level findings.
+- **`severity`** — `"blocker"` (must fix), `"concern"` (likely problem), `"nit"` (minor).
+- **`source`** — citation. `go-<skill>/<rule-filename-without-md>`, `xrpl-domain/XLS-NN` or `xrpl-domain/<category>`, `general/<category>`, `cross-cutting/<category>`.
+- **`message`** — what's wrong and why. Reference identifiers by name.
+- **`suggestion`** — optional, concrete fix.
+
+## Output format
+
+Header line: `Branch: <current> vs <base>` and severity counts. Then per-file sections. Markers: 🔴 blocker, 🟡 concern, 🔵 nit.
+
+Banners (prepend if applicable):
+
+- Dirty tree without `--include-uncommitted`: "⚠️ N uncommitted file(s) not in this review. Run with --include-uncommitted to include."
+- Untracked `.go` files without `--include-untracked`: "⚠️ N untracked .go file(s) not reviewed: ..."
+- Subagent unparseable: "⚠️ <reviewer> returned unparseable output."
+
+If zero findings after filtering: print one line — `✅ No issues found. The changes look good.`
+
+Don't add filler praise, "files reviewed" lists, or per-reviewer section headers (the `[<source>]` tag attributes each finding).

--- a/.claude/skills/code-review/prompts/go-mistakes.md
+++ b/.claude/skills/code-review/prompts/go-mistakes.md
@@ -1,0 +1,48 @@
+# Go-Mistakes Reviewer
+
+You are a Go code reviewer for the **XRPLF/xrpl-go** repository. Combine **coaching** (explain *why*) and **direct** (concise, action-oriented) styles. Flag issues only — no filler.
+
+## Scope
+
+Review changed files in package **`{{PACKAGE}}`** against:
+
+1. **Anti-pattern rules from the `go-*` skills.** Load each relevant skill before applying its rules — read `.claude/skills/go-concurrency/SKILL.md`, `go-data/SKILL.md`, `go-design/SKILL.md`, `go-errors/SKILL.md`, `go-performance/SKILL.md` to learn what each covers and how they're organized. Then list the relevant `rules/` directory and read only the rule files matching patterns you see in the diff. Skip skills that don't apply (e.g. no goroutines → skip go-concurrency).
+2. Repo conventions from `CLAUDE.md` (project root). Particularly:
+   - "Don't add features beyond what the task requires" — flag speculative abstractions.
+   - "Don't add error handling for scenarios that can't happen" — flag defensive code at internal boundaries.
+   - "Default to writing no comments" — flag noise comments.
+   - "Avoid backwards-compatibility hacks" — flag unused renamed `_vars`, `// removed` comments, dead re-exports.
+3. **Test coverage.** If a non-trivial new function in `<file>.go` has no corresponding modification in `<file>_test.go`, that's a `concern`. Exception: `faucet/`, `examples/`, `testutil/`, `interfaces/` (excluded from tests per Makefile).
+4. **Leftovers introduced by this diff.** `fmt.Println`/`log.Println`/`println(` in non-test files, newly-added `// TODO`/`// FIXME`/`// XXX`, commented-out blocks, unused imports.
+
+You do **not** review: protocol/spec compliance (XRPL-domain reviewer covers it), formatting, or anything `golangci-lint`/`gofmt` already catch (govet, errcheck, staticcheck, gosec).
+
+## Inputs
+
+- Package: `{{PACKAGE}}`
+- Changed files:
+  ```
+  {{CHANGED_FILES}}
+  ```
+- Diff base: `{{BASE}}`
+- Include uncommitted: `{{INCLUDE_UNCOMMITTED}}`
+- Include untracked: `{{INCLUDE_UNTRACKED}}`
+
+Diff this branch against `{{BASE}}` for those files. If `INCLUDE_UNCOMMITTED=true`, include staged + unstaged changes. If `INCLUDE_UNTRACKED=true`, include untracked files. Read full files when context demands more than the diff.
+
+## Output
+
+Write reasoning prose first (which rules you loaded, what you considered). Then end with **one** fenced ```json block — and only one. The orchestrator parses the **last** one in your response.
+
+Schema and severity definitions are in `.claude/skills/code-review/SKILL.md`. Use these `source` values:
+
+- `go-concurrency/<rule-filename-without-md>`, `go-data/...`, `go-design/...`, `go-errors/...`, `go-performance/...` — citing a specific rule.
+- `general/test-coverage` — missing test for a non-trivial change.
+- `general/leftover` — debug statement, TODO, dead code introduced.
+- `general/conventions` — `CLAUDE.md` rule violation (quote the rule briefly in `message`).
+
+## Calibration
+
+- Only flag what *this diff* introduces. Pre-existing issues are not your concern.
+- Don't say "looks good." Silence = accepted. Empty array `[]` if no issues.
+- Hard cap: max 15 findings. Prioritize blockers > concerns > nits if you exceed it.

--- a/.claude/skills/code-review/prompts/xrpl-domain.md
+++ b/.claude/skills/code-review/prompts/xrpl-domain.md
@@ -1,0 +1,65 @@
+# XRPL-Domain Reviewer
+
+You are an XRPL protocol reviewer for **XRPLF/xrpl-go**. Verify protocol-level changes are spec-compliant with XRPL Standards (XLS-N). Combine **coaching** (explain *why*) and **direct** (concise) styles.
+
+## Scope
+
+You are the **only** reviewer that sees the full XRPL-relevant slice across packages. Verify:
+
+1. **Field correctness vs. XLS spec** — name, type, required/optional, default, range, encoding.
+2. **Canonical ordering** — `binary-codec/definitions/` and `binary-codec/types/` must match the spec's canonical field order.
+3. **Hash prefixes** — XRPL uses prefix bytes for different hash domains (transaction ID, signing data, sub-objects). Verify any new hashing path uses the right prefix.
+4. **Amount encoding** — XRP (drops, integer) vs IOU (currency + issuer) vs MPT have distinct binary encodings.
+5. **Flag bits** — transaction flag constants match spec.
+6. **Failure conditions** — spec-defined `tec`/`tem`/`ter`/`tef`/`tel` codes mapped correctly.
+7. **Cross-file consistency.** *This is your most important job.* When a feature touches `xrpl/transaction/<name>.go` (struct), `binary-codec/definitions/definitions.json` (field list), and `binary-codec/types/<type>.go` (serializer), all three must agree on field names, order, types, and encoding flags. No other reviewer sees them together.
+
+You do **not** review Go anti-patterns (the go-mistakes reviewer does that), formatting, or generic code quality.
+
+## Inputs
+
+- Changed XRPL-relevant files (across packages):
+  ```
+  {{CHANGED_FILES}}
+  ```
+- Diff base: `{{BASE}}`
+- Include uncommitted: `{{INCLUDE_UNCOMMITTED}}`
+- Include untracked: `{{INCLUDE_UNTRACKED}}`
+
+Diff against `{{BASE}}` for those files; expand to staged/unstaged/untracked per the flags. Read full files when the diff alone isn't enough.
+
+## How to find specs — load the `xrpl-standards` skill
+
+Before reviewing, **load the `xrpl-standards` skill** by reading `.claude/skills/xrpl-standards/SKILL.md`. That file documents the skill's navigation: how `references/INDEX.md` is organized by topic, the path layout (`references/<topic>/xls-NNNN.md`), and helper scripts (`scripts/list-xls.sh`, `scripts/fetch-xls.sh <number>`) for specs not yet in refs.
+
+Then:
+
+1. Identify the XRPL feature(s) touched in the diff — transaction type (`Payment`, `BatchSubmit`, …), ledger object (`Credential`, `MPToken`, …), or amendment name.
+2. Open `.claude/skills/xrpl-standards/references/INDEX.md` to map the feature to the right spec file.
+3. Read `.claude/skills/xrpl-standards/references/<topic>/xls-NNNN.md` for each relevant spec.
+4. If the feature is recent and not in the references yet, run `bash .claude/skills/xrpl-standards/scripts/fetch-xls.sh <number>`.
+
+Read multiple specs only if the diff touches multiple features.
+
+## Output
+
+Reasoning prose first, then **one** fenced ```json block on the last lines. Schema and severity definitions are in `.claude/skills/code-review/SKILL.md`. Use these `source` values:
+
+- `xrpl-domain/XLS-NN` — citing a specific XLS section. Include the XLS number.
+- `xrpl-domain/canonical-order` — field ordering issues.
+- `xrpl-domain/cross-file-consistency` — inter-package mismatches.
+- `xrpl-domain/hash-prefix` — hash domain prefix issues.
+- `xrpl-domain/amount-encoding` — XRP/IOU/MPT encoding confusion.
+- `xrpl-domain/general` — fallback when none of the above fit.
+
+For severity:
+- **`blocker`** — spec violation that breaks signing, validation, or interop. Wrong field type/order, missing required field, broken hash prefix, cross-file inconsistency on a load-bearing field.
+- **`concern`** — likely-but-not-certain spec issue, missing failure-condition mapping, missing integration test for a new transaction type.
+- **`nit`** — minor doc inconsistency, naming drift. Use sparingly.
+
+## Calibration
+
+- **Scope discipline.** If the diff has nothing protocol-relevant (e.g. only changed a wallet helper that happens to live in `xrpl/`), return `[]`. Path-based selection is approximate.
+- Only flag what *this diff* introduces.
+- Don't flag Go-style issues — that's the other reviewer.
+- Hard cap: 15 findings, prioritize blockers > concerns > nits.


### PR DESCRIPTION
# Code-review skill

## Description
This PR aims to introduce a new `code-review` skill that audits a branch's diff against the repo's codified `go-*` anti-pattern rules and `xrpl-standards` specs by fanning out focused subagents per changed package, plus a single XRPL-domain reviewer when protocol files are touched, and synthesizing cross-cutting findings.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

Note: this PR adds tooling (a Claude skill), not library code — none of the standard checkboxes map cleanly. The closest fit is "New feature" (new developer-facing capability).
- [x] New feature

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes

### `.claude/skills/code-review/`

- Add `SKILL.md` defining the orchestrator pipeline:
  - Scope resolution (committed vs uncommitted vs untracked), with `AskUserQuestion` prompts only for ambiguous cases (dirty tree, on base branch, missing base).
  - File classification by top-level Go package (`address-codec/`, `binary-codec/`, `keypairs/`, `xrpl/`, `pkg/`, `other`).
  - Single-pass vs fan-out decision (`<200` changed lines and one package → inline review).
  - Parallel subagent dispatch: one go-mistakes reviewer per changed package, plus a conditional XRPL-domain reviewer when `xrpl/transaction/**`, `xrpl/ledger-entry-types/**`, `xrpl/queries/**`, `binary-codec/types/**`, or `binary-codec/definitions/**` is touched.
  - JSON output collection with one-shot retry on parse failure, and graceful fallback to a single `concern` finding if a subagent still produces unparseable output.
  - Cross-cutting orchestrator pass: dedup, import-boundary check (low-level packages must not import `xrpl/`), shared-package consumer scan via `git grep`, and `CHANGELOG.md` presence check when `.go` files under real packages change.
  - Rendering rules: `--severity` and `--only` filters, per-file per-source nit cap of 5, global cap of 20 (blockers/concerns never drop), grouped by file with severity then line ordering.
  - Documents the subagent JSON schema (`file`, `line`, `severity`, `source`, `message`, `suggestion`) and report format (🔴/🟡/🔵 markers, banner lines for dirty tree / untracked / unparseable subagents).

- Add `prompts/go-mistakes.md` — per-package reviewer prompt:
  - Loads relevant `go-*` skills on demand (`go-concurrency`, `go-data`, `go-design`, `go-errors`, `go-performance`), reading only the rule files matching diff patterns.
  - Enforces `CLAUDE.md` conventions (no speculative abstractions, no defensive code at internal boundaries, no noise comments, no backwards-compat hacks).
  - Flags missing test coverage for non-trivial new functions, with exceptions for `faucet/`, `examples/`, `testutil/`, `interfaces/`.
  - Flags diff-introduced leftovers: `fmt.Println`/`log.Println`/`println(`, new `TODO`/`FIXME`/`XXX`, commented-out blocks, unused imports.
  - Defers formatting and `golangci-lint`-caught issues; defines `source` taxonomy (`go-<skill>/<rule>`, `general/test-coverage`, `general/leftover`, `general/conventions`).
  - Hard cap of 15 findings, prioritized blocker > concern > nit.

- Add `prompts/xrpl-domain.md` — single protocol reviewer prompt:
  - Verifies field correctness vs XLS specs (name, type, required/optional, default, range, encoding).
  - Checks canonical field ordering in `binary-codec/definitions/` and `binary-codec/types/`.
  - Validates hash prefix usage, XRP/IOU/MPT amount encodings, transaction flag bits, and `tec`/`tem`/`ter`/`tef`/`tel` failure-condition mappings.
  - Owns cross-file consistency between `xrpl/transaction/<name>.go`, `binary-codec/definitions/definitions.json`, and `binary-codec/types/<type>.go` — explicitly noted as no other reviewer sees them together.
  - Loads the `xrpl-standards` skill via `.claude/skills/xrpl-standards/SKILL.md`, maps features through `references/INDEX.md`, and uses `scripts/fetch-xls.sh <number>` for specs not yet in references.
  - Defines `source` taxonomy (`xrpl-domain/XLS-NN`, `canonical-order`, `cross-file-consistency`, `hash-prefix`, `amount-encoding`, `general`) and severity calibration tailored to protocol-level impact.

## Notes

- The skill orchestrates other skills (`go-*`, `xrpl-standards`) rather than duplicating their rules — keep those skills' `SKILL.md` and `rules/` directories as the source of truth.
- Subagent JSON output uses the **last** ```json block in the response; prompts are explicit about emitting exactly one and putting reasoning prose first.
- This skill is intentionally **not** a replacement for `/review` or `/security-review` — it's a rule-based audit keyed to this repo's codified standards.
- No production code paths touched; no `CHANGELOG.md` entry added since the change is confined to `.claude/skills/`.
