### PR TITLE
ci: pin govuln 1.3.0 SHA

### DIFF
--- a/.github/workflows/ci-govulncheck.yml
+++ b/.github/workflows/ci-govulncheck.yml
@@ -31,6 +31,6 @@ jobs:
         with:
           go-version: "1.26"
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@0782b76014f15f24e22a438f30f308df42899ba1 # v1.3.0
       - name: Run govulncheck
         run: govulncheck ./...


### PR DESCRIPTION
# ci: pin govuln 1.3.0 SHA

## Description
This PR aims to pin the Govulncheck workflow install step to the commit SHA for govulncheck v1.3.0.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Pin the `golang.org/x/vuln/cmd/govulncheck` install command to commit `0782b76014f15f24e22a438f30f308df42899ba1`.
- Keep a `# v1.3.0` comment beside the pinned SHA for reviewer readability.
