### PR TITLE
docs: warn against production example seeds

### DIFF
--- a/docs/docs/xrpl/wallet.md
+++ b/docs/docs/xrpl/wallet.md
@@ -94,7 +94,7 @@ import (
 )
 
 func main() {
-	// Create a wallet from a seed
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	wallet, err := wallet.FromSeed("snGHNrPbHrdUcszeuDEigMdC1Lyyd", "")
 	if err != nil {
 		log.Fatal(err)

--- a/examples/autofill/rpc/main.go
+++ b/examples/autofill/rpc/main.go
@@ -22,12 +22,14 @@ func main() {
 
 	client := rpc.NewClient(cfg)
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w, err := wallet.FromSeed("sEdSMVV4dJ1JbdBxmakRR4Puu3XVZz2", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	receiverWallet, err := wallet.FromSeed("sEd7d8Ci9nevdLCeUMctF3uGXp9WQqJ", "")
 	if err != nil {
 		fmt.Println(err)

--- a/examples/autofill/ws/main.go
+++ b/examples/autofill/ws/main.go
@@ -30,12 +30,14 @@ func main() {
 
 	fmt.Println("Connection: ", wsClient.IsConnected())
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w, err := wallet.FromSeed("sEdSMVV4dJ1JbdBxmakRR4Puu3XVZz2", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	receiverWallet, err := wallet.FromSeed("sEd7d8Ci9nevdLCeUMctF3uGXp9WQqJ", "")
 	if err != nil {
 		fmt.Println(err)

--- a/examples/multisigning/rpc/main.go
+++ b/examples/multisigning/rpc/main.go
@@ -25,18 +25,21 @@ func main() {
 
 	client := rpc.NewClient(cfg)
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w1, err := wallet.FromSeed("sEdTtvLmJmrb7GaivhWoXRkvU4NDjVf", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w2, err := wallet.FromSeed("sEdSFiKMQp7RvYLgH7t7FEpwNRWv2Gr", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	master, err := wallet.FromSeed("sEdTMm2yv8c8Rg8YHFHQA9TxVMFy1ze", "")
 	if err != nil {
 		fmt.Println(err)

--- a/examples/multisigning/ws/main.go
+++ b/examples/multisigning/ws/main.go
@@ -41,18 +41,21 @@ func main() {
 	fmt.Println("✅ Connected to testnet")
 	fmt.Println()
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w1, err := wallet.FromSeed("sEdTtvLmJmrb7GaivhWoXRkvU4NDjVf", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w2, err := wallet.FromSeed("sEdSFiKMQp7RvYLgH7t7FEpwNRWv2Gr", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	master, err := wallet.FromSeed("sEdTMm2yv8c8Rg8YHFHQA9TxVMFy1ze", "")
 	if err != nil {
 		fmt.Println(err)

--- a/examples/send-payment/rpc/main.go
+++ b/examples/send-payment/rpc/main.go
@@ -14,12 +14,14 @@ import (
 )
 
 func main() {
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	w, err := wallet.FromSeed("sEdSMVV4dJ1JbdBxmakRR4Puu3XVZz2", "")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	receiverWallet, err := wallet.FromSeed("sEd7d8Ci9nevdLCeUMctF3uGXp9WQqJ", "")
 	if err != nil {
 		fmt.Println(err)

--- a/examples/use-tickets/rpc/main.go
+++ b/examples/use-tickets/rpc/main.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	walletSeed = "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 )
 

--- a/examples/use-tickets/ws/main.go
+++ b/examples/use-tickets/ws/main.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	// Example-only seed for testnet demos. Do not commit real seeds or use this in production.
 	walletSeed = "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 )
 


### PR DESCRIPTION
# docs(examples): warn against production example seeds

## Description
This PR aims to make hardcoded seed values in examples and wallet docs clearly marked as example-only material that must not be used in production.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### examples

- Added explicit example-only warnings next to hardcoded seeds in autofill, multisigning, send-payment, and use-tickets examples.
- Clarified that the demo seeds are for testnet examples and must not be committed as real seeds or used in production.

### docs

- Updated the wallet payment channel example to warn against production use of the hardcoded seed.
