### PR TITLE
fix(binary-codec): remove field id decode stdout output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### binary-codec
 
 - `Encode`, `EncodeForSigning`, and `EncodeForMultisigning` no longer remove fields from the caller's input map. Callers throughout `xrpl/` no longer need to defensively copy input maps before encoding.
+- `FieldIDCodec.Decode` no longer writes decode errors or input lengths to stdout.
 - `Amount` serialization now rejects `float64` values, preventing precision loss when encoding amounts parsed from JSON without `UseNumber`.
 - `UInt64` JSON serialization now treats input as 1 to 16 character hex strings instead of applying decimal range validation before hex encoding. Empty-string inputs are now rejected (previously silently produced 0 bytes).
 - IOU amount decoding now rejects non-canonical wire values whose mantissa or exponent fall outside the XRPL token amount ranges.

--- a/binary-codec/serdes/field_id_codec.go
+++ b/binary-codec/serdes/field_id_codec.go
@@ -3,7 +3,6 @@ package serdes
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 
 	"github.com/Peersyst/xrpl-go/binary-codec/serdes/interfaces"
 )
@@ -48,10 +47,8 @@ func (f *FieldIDCodec) Encode(fieldName string) ([]byte, error) {
 func (f *FieldIDCodec) Decode(h string) (string, error) {
 	b, err := hex.DecodeString(h)
 	if err != nil {
-		fmt.Println(err)
 		return "", err
 	}
-	fmt.Println(len(b))
 	if len(b) == 1 {
 		return f.definitions.GetFieldNameByFieldHeader(f.definitions.CreateFieldHeader(int32(b[0]>>4), int32(b[0]&byte(15))))
 	}


### PR DESCRIPTION
# fix(binary-codec): remove field id decode stdout output

## Description
This PR aims to stop `FieldIDCodec.Decode` from writing parser errors and decoded input lengths to consumer stdout. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Removed the two `fmt.Println` calls from `FieldIDCodec.Decode` so decode errors and byte lengths are returned through the API without being printed.
- Removed the now-unused `fmt` import.
