### PR TITLE
fix(crypto): validate ed25519 key lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### pkg/crypto
 
 - Ed25519 signing and validation now reject malformed key lengths before slicing decoded key bytes, preventing panics on malformed ED-prefixed keys.
+- Ed25519 signing and validation now reject decoded keys whose first byte is not the ED prefix before stripping the prefix.
 
 #### xrpl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added wallet credential leakage warnings to the wallet docs and example comments.
 
+#### pkg/crypto
+
+- Ed25519 and SECP256K1 `Sign` now wrap the underlying `hex.DecodeString` error with `ErrInvalidPrivateKey`. `errors.Is(err, ErrInvalidPrivateKey)` still matches, and the hex offset / invalid-byte detail is now reachable via `errors.As` and `errors.Unwrap`.
+
 ### Fixed
 
 #### xrpl/transaction
@@ -109,8 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### pkg/crypto
 
-- Ed25519 signing and validation now reject malformed key lengths before slicing decoded key bytes, preventing panics on malformed ED-prefixed keys.
-- Ed25519 signing and validation now reject decoded keys whose first byte is not the ED prefix before stripping the prefix.
+- Ed25519 signing and validation now reject malformed keys and signatures by length and ED prefix before slicing decoded bytes or verifying, preventing panics on malformed inputs.
 
 #### xrpl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native XRP amount serialization now validates drops with exact integer bounds instead of float comparisons.
 - Fixed off-by-one in the variable-length prefix encoder (`serdes.encodeVariableLength`) at the 2-byte/3-byte boundary. Length 12480 was routed to the 3-byte branch and underflowed to bytes `[0xF0, 0xFF, 0xFF]`, corrupting the next field on decode. The 2-byte branch now correctly covers lengths 193..12480 inclusive per the XRPL serialization spec.
 
+#### pkg/crypto
+
+- Ed25519 signing and validation now reject malformed key lengths before slicing decoded key bytes, preventing panics on malformed ED-prefixed keys.
+
 #### xrpl
 
 - `Multisign`, `CombineLoanSetCounterpartySigners`, and `CombineBatchSigners` now propagate signer sort errors and use canonical account ID byte ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native XRP amount serialization now validates drops with exact integer bounds instead of float comparisons.
 - Fixed off-by-one in the variable-length prefix encoder (`serdes.encodeVariableLength`) at the 2-byte/3-byte boundary. Length 12480 was routed to the 3-byte branch and underflowed to bytes `[0xF0, 0xFF, 0xFF]`, corrupting the next field on decode. The 2-byte branch now correctly covers lengths 193..12480 inclusive per the XRPL serialization spec.
 
+#### keypairs
+
+- Keypair signing and validation now reject keys shorter than the crypto prefix before slicing, preventing panics on empty or one-character keys.
+
 #### pkg/crypto
 
 - Ed25519 signing and validation now reject malformed key lengths before slicing decoded key bytes, preventing panics on malformed ED-prefixed keys.

--- a/keypairs/crypto.go
+++ b/keypairs/crypto.go
@@ -12,6 +12,10 @@ import (
 // It returns nil if the key does not match any crypto implementation.
 // Currently, only ED25519 and SECP256K1 are supported.
 func getCryptoImplementationFromKey(k string) interfaces.KeypairCryptoAlg {
+	if len(k) < 2 {
+		return nil
+	}
+
 	prefix, err := hex.DecodeString(k[:2])
 	if err != nil {
 		return nil

--- a/keypairs/crypto_test.go
+++ b/keypairs/crypto_test.go
@@ -15,6 +15,16 @@ func TestGetCryptoImplementationFromKey(t *testing.T) {
 		expected interfaces.KeypairCryptoAlg
 	}{
 		{
+			name:     "fail - empty key",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "fail - short key",
+			input:    "E",
+			expected: nil,
+		},
+		{
 			name:     "fail - invalid key",
 			input:    "invalid",
 			expected: nil,

--- a/keypairs/keypairs_test.go
+++ b/keypairs/keypairs_test.go
@@ -314,6 +314,11 @@ func TestDeriveNodeAddress(t *testing.T) {
 		expectedErr error
 	}{
 		{
+			name:        "fail - derive node address - input too short to base58check-decode",
+			inputPubKey: "x",
+			expectedErr: addresscodec.ErrInvalidFormat,
+		},
+		{
 			name:        "fail - derive node address - node prefix mismatch",
 			inputPubKey: "rfZG9pC1cKF7q96TNZR264H9ykzKCxMyk44ZK8hFL8cNv1G3c8J",
 			expectedErr: addresscodec.ErrB58PrefixMismatch,

--- a/keypairs/keypairs_test.go
+++ b/keypairs/keypairs_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestGenerateEncodeSeed(t *testing.T) {
 	defaultEntropy := "fakeRandomString"
+	errGenerateBytes := errors.New("generate bytes error")
 
 	tt := []struct {
 		name        string
@@ -27,10 +28,10 @@ func TestGenerateEncodeSeed(t *testing.T) {
 			name: "fail - generate bytes error",
 			malleate: func() interfaces.Randomizer {
 				rand := testutil.NewMockRandomizer(gomock.NewController(t))
-				rand.EXPECT().GenerateBytes(gomock.Any()).AnyTimes().Return(nil, errors.New("error"))
+				rand.EXPECT().GenerateBytes(gomock.Any()).AnyTimes().Return(nil, errGenerateBytes)
 				return rand
 			},
-			expectedErr: errors.New("error"),
+			expectedErr: errGenerateBytes,
 			algorithm:   crypto.ED25519(),
 		},
 		{
@@ -90,7 +91,7 @@ func TestGenerateEncodeSeed(t *testing.T) {
 
 			if tc.expectedErr != nil {
 				require.Empty(t, a)
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, a)
@@ -187,7 +188,7 @@ func TestDeriveClassicAddress(t *testing.T) {
 			actual, err := DeriveClassicAddress(tc.input)
 			if tc.expectedErr != nil {
 				require.Empty(t, actual)
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)
@@ -296,7 +297,7 @@ func TestValidate(t *testing.T) {
 			actual, err := Validate(tc.inputMsg, tc.inputPubKey, tc.inputSig)
 			if tc.expectedErr != nil {
 				require.Zero(t, actual)
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)
@@ -313,9 +314,9 @@ func TestDeriveNodeAddress(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "fail - derive node address - node prefix not found",
-			inputPubKey: "x9KHn8NfbBsZV5q8bLfS72XyGqwFt5mgoPbcTV4c6qKiuPTAtXYk",
-			expectedErr: &addresscodec.EncodeLengthError{Instance: "NodePublicKey", Expected: addresscodec.NodePublicKeyLength, Input: 3},
+			name:        "fail - derive node address - node prefix mismatch",
+			inputPubKey: "rfZG9pC1cKF7q96TNZR264H9ykzKCxMyk44ZK8hFL8cNv1G3c8J",
+			expectedErr: addresscodec.ErrB58PrefixMismatch,
 		},
 		{
 			name:        "pass - derive correct node address from public key",
@@ -329,7 +330,7 @@ func TestDeriveNodeAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := DeriveNodeAddress(tc.inputPubKey, crypto.SECP256K1())
 			if tc.expectedErr != nil {
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)

--- a/keypairs/keypairs_test.go
+++ b/keypairs/keypairs_test.go
@@ -205,6 +205,18 @@ func TestSign(t *testing.T) {
 		expectedErr  error
 	}{
 		{
+			name:         "fail - empty private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "",
+			expectedErr:  ErrInvalidCryptoImplementation,
+		},
+		{
+			name:         "fail - short private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "E",
+			expectedErr:  ErrInvalidCryptoImplementation,
+		},
+		{
 			name:         "fail - invalid private key",
 			inputMsg:     "hello world",
 			inputPrivKey: "invalid",
@@ -248,6 +260,20 @@ func TestValidate(t *testing.T) {
 		expected    bool
 		expectedErr error
 	}{
+		{
+			name:        "fail - empty public key",
+			inputMsg:    "test message",
+			inputPubKey: "",
+			inputSig:    "invalid",
+			expectedErr: ErrInvalidCryptoImplementation,
+		},
+		{
+			name:        "fail - short public key",
+			inputMsg:    "test message",
+			inputPubKey: "E",
+			inputSig:    "invalid",
+			expectedErr: ErrInvalidCryptoImplementation,
+		},
 		{
 			name:        "fail - invalid public key",
 			inputMsg:    "test message",

--- a/keypairs/keypairs_test.go
+++ b/keypairs/keypairs_test.go
@@ -211,6 +211,12 @@ func TestSign(t *testing.T) {
 			expectedErr:  ErrInvalidCryptoImplementation,
 		},
 		{
+			name:         "fail - malformed ED25519 private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "ED",
+			expectedErr:  crypto.ErrInvalidPrivateKey,
+		},
+		{
 			name:         "pass - sign a message with a ED25519 key",
 			inputMsg:     "hello world",
 			inputPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
@@ -224,7 +230,7 @@ func TestSign(t *testing.T) {
 			actual, err := Sign(tc.inputMsg, tc.inputPrivKey)
 			if tc.expectedErr != nil {
 				require.Empty(t, actual)
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/Peersyst/xrpl-go/pkg/hexutil"
 )
@@ -66,7 +67,7 @@ func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool
 func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	b, err := hex.DecodeString(privKey)
 	if err != nil {
-		return "", ErrInvalidPrivateKey
+		return "", fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
 	}
 	// The private key is sliced below to remove the ED prefix, so reject malformed keys first.
 	if len(b) != ed25519PrivateKeyLength || b[0] != ed25519Prefix {

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -13,6 +13,9 @@ import (
 const (
 	// ed25519 prefix - value is 237
 	ed25519Prefix byte = 0xED
+	// XRPL Ed25519 keys are encoded as the ED prefix byte followed by the seed or public key bytes.
+	ed25519PrivateKeyLength = 1 + ed25519.SeedSize
+	ed25519PublicKeyLength  = 1 + ed25519.PublicKeySize
 )
 
 var (
@@ -63,7 +66,11 @@ func (c ED25519CryptoAlgorithm) DeriveKeypair(decodedSeed []byte, validator bool
 func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	b, err := hex.DecodeString(privKey)
 	if err != nil {
-		return "", err
+		return "", ErrInvalidPrivateKey
+	}
+	// The private key is sliced below to remove the ED prefix, so reject malformed lengths first.
+	if len(b) != ed25519PrivateKeyLength {
+		return "", ErrInvalidPrivateKey
 	}
 	rawPriv := ed25519.NewKeyFromSeed(b[1:])
 	signedMsg := ed25519.Sign(rawPriv, []byte(msg))
@@ -79,6 +86,10 @@ func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 
 	bs, err := hex.DecodeString(sig)
 	if err != nil {
+		return false
+	}
+	// Validate lengths before removing the ED prefix or passing malformed signatures to ed25519.Verify.
+	if len(bp) != ed25519PublicKeyLength || len(bs) != ed25519.SignatureSize {
 		return false
 	}
 

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -68,8 +68,8 @@ func (c ED25519CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	if err != nil {
 		return "", ErrInvalidPrivateKey
 	}
-	// The private key is sliced below to remove the ED prefix, so reject malformed lengths first.
-	if len(b) != ed25519PrivateKeyLength {
+	// The private key is sliced below to remove the ED prefix, so reject malformed keys first.
+	if len(b) != ed25519PrivateKeyLength || b[0] != ed25519Prefix {
 		return "", ErrInvalidPrivateKey
 	}
 	rawPriv := ed25519.NewKeyFromSeed(b[1:])
@@ -88,8 +88,8 @@ func (c ED25519CryptoAlgorithm) Validate(msg, pubkey, sig string) bool {
 	if err != nil {
 		return false
 	}
-	// Validate lengths before removing the ED prefix or passing malformed signatures to ed25519.Verify.
-	if len(bp) != ed25519PublicKeyLength || len(bs) != ed25519.SignatureSize {
+	// Validate the ED prefix and lengths before stripping the prefix or verifying the signature.
+	if len(bp) != ed25519PublicKeyLength || bp[0] != ed25519Prefix || len(bs) != ed25519.SignatureSize {
 		return false
 	}
 

--- a/pkg/crypto/ed25519_test.go
+++ b/pkg/crypto/ed25519_test.go
@@ -100,6 +100,13 @@ func TestED25519Sign(t *testing.T) {
 			expectedErr:  ErrInvalidPrivateKey,
 		},
 		{
+			name:         "fail - private key with invalid ED prefix",
+			inputMsg:     "hello world",
+			inputPrivKey: "00BB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
 			name:         "pass - sign a valid message",
 			inputMsg:     "hello world",
 			inputPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
@@ -199,6 +206,13 @@ func TestED25519Validate(t *testing.T) {
 			inputMsg:    "test message",
 			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
 			inputSig:    "C001",
+			expected:    false,
+		},
+		{
+			name:        "fail - public key with invalid ED prefix",
+			inputMsg:    "test message",
+			inputPubKey: "004924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
 			expected:    false,
 		},
 		{

--- a/pkg/crypto/ed25519_test.go
+++ b/pkg/crypto/ed25519_test.go
@@ -72,6 +72,34 @@ func TestED25519Sign(t *testing.T) {
 			expectedErr:  ErrInvalidPrivateKey,
 		},
 		{
+			name:         "fail - empty private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
+			name:         "fail - prefix-only private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "ED",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
+			name:         "fail - short private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "EDBB3ECA",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
+			name:         "fail - oversized private key",
+			inputMsg:     "hello world",
+			inputPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA1400",
+			expected:     "",
+			expectedErr:  ErrInvalidPrivateKey,
+		},
+		{
 			name:         "pass - sign a valid message",
 			inputMsg:     "hello world",
 			inputPrivKey: "EDBB3ECA8985E1484FA6A28C4B30FB0042A2CC5DF3EC8DC37B5F3D126DDFD3CA14",
@@ -100,7 +128,7 @@ func TestED25519Sign(t *testing.T) {
 
 			if tc.expectedErr != nil {
 				require.Empty(t, actual)
-				require.Error(t, err, tc.expectedErr.Error())
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)
@@ -136,6 +164,41 @@ func TestED25519Validate(t *testing.T) {
 			inputMsg:    "test message",
 			inputPubKey: "invalid_key",
 			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "fail - empty public key",
+			inputMsg:    "test message",
+			inputPubKey: "",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "fail - prefix-only public key",
+			inputMsg:    "test message",
+			inputPubKey: "ED",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "fail - short public key",
+			inputMsg:    "test message",
+			inputPubKey: "ED4924A9",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "fail - oversized public key",
+			inputMsg:    "test message",
+			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA600",
+			inputSig:    "C001CB8A9883497518917DD16391930F4FEE39CEA76C846CFF4330BA44ED19DC4730056C2C6D7452873DE8120A5023C6807135C6329A89A13BA1D476FE8E7100",
+			expected:    false,
+		},
+		{
+			name:        "fail - invalid signature length",
+			inputMsg:    "test message",
+			inputPubKey: "ED4924A9045FE5ED8B22BAA7B6229A72A287CCF3EA287AADD3A032A24C0F008FA6",
+			inputSig:    "C001",
 			expected:    false,
 		},
 		{

--- a/pkg/crypto/secp256k1.go
+++ b/pkg/crypto/secp256k1.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha512"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"math"
 
 	"github.com/Peersyst/xrpl-go/pkg/hexutil"
@@ -120,7 +121,7 @@ func (c SECP256K1CryptoAlgorithm) Sign(msg, privKey string) (string, error) {
 	}
 	key, err := hex.DecodeString(privKey)
 	if err != nil {
-		return "", ErrInvalidPrivateKey
+		return "", fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
 	}
 
 	secpPrivKey := secp256k1.PrivKeyFromBytes(key)


### PR DESCRIPTION
# fix(crypto): validate ed25519 key lengths

## Description
This PR rejects malformed ED25519-prefixed key material before signing or signature validation, preventing panics from short or oversized decoded key bytes. It also hardens the `keypairs` dispatcher so empty or one-character keys cannot panic before crypto algorithm selection. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

#### pkg/crypto

- Added explicit decoded length checks for ED25519 private and public keys before stripping the XRPL `ED` prefix byte.
- Changed ED25519 signing to return `crypto.ErrInvalidPrivateKey` for invalid hex input, matching the existing invalid-private-key contract.
- Rejected malformed ED25519 signatures by length before verification.
- Added regression coverage for empty, prefix-only, short, and oversized ED25519 private/public keys.

#### keypairs

- Guarded `keypairs.getCryptoImplementationFromKey` against keys shorter than the two-character crypto prefix, so `keypairs.Sign` and `keypairs.Validate` return `ErrInvalidCryptoImplementation` instead of panicking on empty or one-character keys.
- Added dispatcher regression coverage for malformed ED25519-prefixed private keys and too-short keys through `keypairs.Sign` / `keypairs.Validate`.

## Notes (optional)

Verified locally with `go test ./pkg/crypto ./keypairs -count=1`.
