### PR TITLE
docs(wallet): warn against logging wallet secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FundWallet` now polls the validated ledger after calling the faucet, treats `actNotFound` as an unfunded account while polling, and returns `ErrFundWalletBalanceNotUpdated` if the balance never increases.
 
+#### docs
+
+- Added wallet credential leakage warnings to the wallet docs and example comments.
+
 ### Fixed
 
 #### address-codec

--- a/docs/docs/xrpl/wallet.md
+++ b/docs/docs/xrpl/wallet.md
@@ -23,6 +23,12 @@ func FromSecret(seed string) (Wallet, error)
 func FromMnemonic(mnemonic string) (*Wallet, error)
 ```
 
+:::warning
+
+`Wallet.Seed`, `Wallet.PrivateKey`, and mnemonic values are credentials. Do not print, log, commit, or send them to telemetry. Exposing these values leaks control of the account to anyone who can read the output.
+
+:::
+
 :::info
 
 When generating a random wallet, you will need to specify the algorithm you want to use.

--- a/examples/wallet/main.go
+++ b/examples/wallet/main.go
@@ -18,6 +18,8 @@ const (
 )
 
 func main() {
+	// WARNING: Do not print or log real wallet secrets. Private keys, seeds, and
+	// mnemonics are credentials; exposing them leaks control of the account.
 	mnemonicWallet, err := wallet.FromMnemonic("monster march exile fee forget response seven push dragon oil clinic attack black miss craft surface patient stomach tank float cabbage visual image resource")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# docs(wallet): warn against logging wallet secrets

## Description
This PR aims to warn users that wallet seeds, private keys, and mnemonics are credentials that must not be printed, logged, committed, or sent to telemetry.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Added a warning comment to `examples/wallet/main.go` explaining that wallet private keys, seeds, and mnemonics are credentials and must not be printed or logged.
- Added a wallet documentation warning that `Wallet.Seed`, `Wallet.PrivateKey`, and mnemonic values must not be printed, logged, committed, or sent to telemetry.

## Notes (optional)

Verified with `gofmt -w examples/wallet/main.go` and `go test ./xrpl/wallet`.
