### PR TITLE
chore(deps): replace archived mapstructure dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### pkg/decodehook
+
+- Replaced the archived mapstructure dependency with `github.com/go-viper/mapstructure/v2 v2.5.0` while preserving existing decode hook behavior.
+
 #### xrpl/currency
 
 - Deprecated exported `DropsPerXrp`, it remains available for compatibility, but native amount conversion helpers use exact rational arithmetic internally instead of `float64`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FundWallet` now polls the validated ledger after calling the faucet, treats `actNotFound` as an unfunded account while polling, and returns `ErrFundWalletBalanceNotUpdated` if the balance never increases.
 - HTTP 503 retries now recreate the RPC request, close retry response bodies before retrying, and respect the configured retry delay. Each attempt also gets a fresh context, so `cfg.timeout` now bounds a single attempt rather than the full retry window.
+- Updated `response.go` to import `github.com/go-viper/mapstructure/v2` in place of the archived `github.com/mitchellh/mapstructure`.
 
 #### xrpl/websocket
 
 - `FundWallet` now polls the validated ledger after calling the faucet, treats `actNotFound` as an unfunded account while polling, and returns `ErrFundWalletBalanceNotUpdated` if the balance never increases.
+- Updated `client.go` and `response.go` to import `github.com/go-viper/mapstructure/v2` in place of the archived `github.com/mitchellh/mapstructure`.
 
 #### xrpl/transaction
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/bsv-blockchain/go-sdk v1.2.9
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.10.0
 	github.com/ugorji/go/codec v1.2.11
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/decred/dcrd/crypto/ripemd160 v1.0.2 h1:TvGTmUBHDU75OHro9ojPLK+Yv7gDl2
 github.com/decred/dcrd/crypto/ripemd160 v1.0.2/go.mod h1:uGfjDyePSpa75cSQLzNdVmWlbQMBuiJkvXw/MNKRY4M=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
+github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -22,8 +24,6 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=

--- a/pkg/decodehook/hook.go
+++ b/pkg/decodehook/hook.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 var jsonUnmarshalerType = reflect.TypeFor[json.Unmarshaler]()

--- a/pkg/decodehook/hook_test.go
+++ b/pkg/decodehook/hook_test.go
@@ -24,6 +24,16 @@ func (c *customField) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// customText is a test type that implements encoding.TextUnmarshaler.
+type customText struct {
+	Value string
+}
+
+func (c *customText) UnmarshalText(data []byte) error {
+	c.Value = "text:" + string(data)
+	return nil
+}
+
 func TestJSON(t *testing.T) {
 	type target struct {
 		Field customField `json:"field"`
@@ -78,4 +88,37 @@ func TestJSON(t *testing.T) {
 		_, err := hook(from, to)
 		require.Error(t, err)
 	})
+}
+
+// TestJSONComposedWithTextUnmarshaller mirrors the production decode chain used in
+// xrpl/rpc/response.go and xrpl/websocket/response.go, guarding against regressions
+// when the underlying mapstructure dependency changes.
+func TestJSONComposedWithTextUnmarshaller(t *testing.T) {
+	type target struct {
+		Plain     string      `json:"plain"`
+		JSONField customField `json:"json_field"`
+		TextField customText  `json:"text_field"`
+	}
+
+	input := map[string]any{
+		"plain":      "ok",
+		"json_field": json.Number("42"),
+		"text_field": "hello",
+	}
+
+	var result target
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &result,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			JSON(),
+			mapstructure.TextUnmarshallerHookFunc(),
+		),
+	})
+	require.NoError(t, err)
+	require.NoError(t, dec.Decode(input))
+
+	assert.Equal(t, "ok", result.Plain)
+	assert.Equal(t, "42", result.JSONField.Value)
+	assert.Equal(t, "text:hello", result.TextField.Value)
 }

--- a/pkg/decodehook/hook_test.go
+++ b/pkg/decodehook/hook_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/xrpl/rpc/response.go
+++ b/xrpl/rpc/response.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"github.com/Peersyst/xrpl-go/pkg/decodehook"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // Response represents a JSON-RPC response from an XRPL server.

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Peersyst/xrpl-go/xrpl/hash"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
 	transaction "github.com/Peersyst/xrpl-go/xrpl/transaction"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"

--- a/xrpl/websocket/response.go
+++ b/xrpl/websocket/response.go
@@ -2,7 +2,7 @@ package websocket
 
 import (
 	"github.com/Peersyst/xrpl-go/pkg/decodehook"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // ResponseWarning represents a warning returned in a WebSocket response.


### PR DESCRIPTION
# chore(deps): replace archived mapstructure dependency

## Description
This PR aims to replace the archived mapstructure dependency with `github.com/go-viper/mapstructure/v2 v2.5.0` while preserving existing RPC and WebSocket decode behavior. (Mark tags that apply)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Replaced `github.com/mitchellh/mapstructure v1.5.0` with `github.com/go-viper/mapstructure/v2 v2.5.0` in `go.mod` and `go.sum`.
- Updated decodehook, RPC response decoding, WebSocket response decoding, and WebSocket request formatting imports to use the v2 module.
- Preserved the existing `TagName: "json"` configuration and `decodehook.JSON()` before `mapstructure.TextUnmarshallerHookFunc()` ordering.
- Updated `pkg/decodehook` tests to compile against the replacement module.

## Notes (optional)

This preserves runtime behavior for normal RPC and WebSocket client usage.

Validated with:

```bash
GOCACHE=/tmp/xrpl-go-build-cache go test ./pkg/decodehook ./xrpl/rpc ./xrpl/websocket
GOCACHE=/tmp/xrpl-go-build-cache go test ./...
```
