### PR TITLE
fix(xrpl): avoid mutating signed transaction maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### xrpl
 
+- `Wallet.Sign` and `Wallet.Multisign` no longer mutate caller-provided transaction maps while adding signing fields.
 - `Multisign`, `CombineLoanSetCounterpartySigners`, and `CombineBatchSigners` now propagate signer sort errors and use canonical account ID byte ordering.
 - `fetchCounterPartySignersCount` in the RPC client now uses `"current"` ledger index instead of `"validated"` when fetching the loan broker and counterparty signer information, avoiding lookup failures before the transaction is validated.
 - `Multisign` now validates that all input blobs represent the same transaction (ignoring `Signers`) and returns `ErrMultisignTxNotEqual` otherwise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WebSocket client now caps inbound messages at 16 MiB by default to prevent unbounded memory growth from oversized server messages. Use `WithMaxResponseSize(0)` to disable the limit.
 
+#### xrpl/wallet
+
+- `Sign` and `Multisign` now return `ErrNilTransaction` for nil transaction maps instead of panicking.
+
 #### keypairs
 
 - `GenerateSeed` now rejects non-empty entropy whose length is not exactly 16 bytes, removing silent truncation of longer inputs and the panic on shorter inputs.

--- a/xrpl/README.md
+++ b/xrpl/README.md
@@ -42,8 +42,8 @@ type Tx interface {
 | `Fee` | Cost in drops (must be set before signing) |
 | `Sequence` | Account sequence number (0 if using a Ticket) |
 | `LastLedgerSequence` | Expiry ledger — always set to avoid stuck transactions |
-| `SigningPubKey` | Public key of the signer (set by `wallet.Sign`) |
-| `TxnSignature` | Signature (set by `wallet.Sign`) |
+| `SigningPubKey` | Public key of the signer, included in the signed blob produced by `wallet.Sign` |
+| `TxnSignature` | Signature, included in the signed blob produced by `wallet.Sign` |
 | `Signers` | Multi-signature entries |
 | `Memos` | Arbitrary attached data |
 | `Flags` | Bitmask of transaction-specific flags |
@@ -84,10 +84,10 @@ w, err := wallet.FromMnemonic("word1 word2 ...")
 ### Signing
 
 ```go
-// Single signature — sets SigningPubKey and TxnSignature on the tx map
+// Single signature — returns the signed blob and its hash; flatTx is not mutated
 txBlob, txHash, err := w.Sign(flatTx)
 
-// Multi-signature — sets SigningPubKey = "" and appends a Signer entry
+// Multi-signature — returns the signed blob and its hash; flatTx is not mutated
 txBlob, txHash, err := w.Multisign(flatTx)
 ```
 

--- a/xrpl/wallet/errors.go
+++ b/xrpl/wallet/errors.go
@@ -3,6 +3,11 @@ package wallet
 import "errors"
 
 var (
+	// signing
+
+	// ErrNilTransaction is returned when a nil transaction map is provided.
+	ErrNilTransaction = errors.New("transaction cannot be nil")
+
 	// address
 
 	// ErrAddressTagNotZero is returned when the address tag is not zero.

--- a/xrpl/wallet/wallet.go
+++ b/xrpl/wallet/wallet.go
@@ -5,6 +5,7 @@ package wallet
 import (
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"strings"
 
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
@@ -138,9 +139,10 @@ func FromMnemonic(mnemonic string) (*Wallet, error) {
 // Sign signs a transaction offline, returning the transaction blob and its signature.
 // TODO: Refactor to accept a `Transaction` object instead of a map.
 func (w *Wallet) Sign(tx map[string]any) (string, string, error) {
-	tx["SigningPubKey"] = w.PublicKey
+	signTx := cloneTransactionMap(tx)
+	signTx["SigningPubKey"] = w.PublicKey
 
-	encodedTx, err := binarycodec.EncodeForSigning(tx)
+	encodedTx, err := binarycodec.EncodeForSigning(signTx)
 	if err != nil {
 		return "", "", err
 	}
@@ -150,9 +152,9 @@ func (w *Wallet) Sign(tx map[string]any) (string, string, error) {
 		return "", "", err
 	}
 
-	tx["TxnSignature"] = txHash
+	signTx["TxnSignature"] = txHash
 
-	txBlob, err := binarycodec.Encode(tx)
+	txBlob, err := binarycodec.Encode(signTx)
 	if err != nil {
 		return "", "", err
 	}
@@ -171,11 +173,12 @@ func (w *Wallet) GetAddress() types.Address {
 }
 
 // Multisign signs a multisigned transaction offline, returning the signed transaction blob and its transaction hash.
-// Note: this method sets tx["SigningPubKey"] = "" directly on the provided map (XRPL protocol requirement).
+// The transaction is signed using an internal copy and the provided map is not mutated.
 func (w *Wallet) Multisign(tx map[string]any) (string, string, error) {
+	signTx := cloneTransactionMap(tx)
 	// For regular multisigning, SigningPubKey must be empty per XRPL protocol.
-	tx["SigningPubKey"] = ""
-	encodedTx, err := binarycodec.EncodeForMultisigning(tx, w.ClassicAddress.String())
+	signTx["SigningPubKey"] = ""
+	encodedTx, err := binarycodec.EncodeForMultisigning(signTx, w.ClassicAddress.String())
 	if err != nil {
 		return "", "", err
 	}
@@ -193,8 +196,8 @@ func (w *Wallet) Multisign(tx map[string]any) (string, string, error) {
 		},
 	}
 
-	tx["Signers"] = []any{signer.Flatten()}
-	blob, err := binarycodec.Encode(tx)
+	signTx["Signers"] = []any{signer.Flatten()}
+	blob, err := binarycodec.Encode(signTx)
 	if err != nil {
 		return "", "", err
 	}
@@ -259,3 +262,9 @@ func ensureClassicAddress(account string) (types.Address, error) {
 // func (w *Wallet) GetXAddress() (string, error) {
 // 	return "", errors.New("not implemented")
 // }
+
+func cloneTransactionMap(tx map[string]any) map[string]any {
+	txCopy := make(map[string]any, len(tx))
+	maps.Copy(txCopy, tx)
+	return txCopy
+}

--- a/xrpl/wallet/wallet.go
+++ b/xrpl/wallet/wallet.go
@@ -137,9 +137,14 @@ func FromMnemonic(mnemonic string) (*Wallet, error) {
 }
 
 // Sign signs a transaction offline, returning the transaction blob and its signature.
+// The transaction is signed using an internal copy and the provided map is not mutated.
 // TODO: Refactor to accept a `Transaction` object instead of a map.
 func (w *Wallet) Sign(tx map[string]any) (string, string, error) {
-	signTx := cloneTransactionMap(tx)
+	if tx == nil {
+		return "", "", ErrNilTransaction
+	}
+
+	signTx := maps.Clone(tx)
 	signTx["SigningPubKey"] = w.PublicKey
 
 	encodedTx, err := binarycodec.EncodeForSigning(signTx)
@@ -175,7 +180,11 @@ func (w *Wallet) GetAddress() types.Address {
 // Multisign signs a multisigned transaction offline, returning the signed transaction blob and its transaction hash.
 // The transaction is signed using an internal copy and the provided map is not mutated.
 func (w *Wallet) Multisign(tx map[string]any) (string, string, error) {
-	signTx := cloneTransactionMap(tx)
+	if tx == nil {
+		return "", "", ErrNilTransaction
+	}
+
+	signTx := maps.Clone(tx)
 	// For regular multisigning, SigningPubKey must be empty per XRPL protocol.
 	signTx["SigningPubKey"] = ""
 	encodedTx, err := binarycodec.EncodeForMultisigning(signTx, w.ClassicAddress.String())
@@ -262,9 +271,3 @@ func ensureClassicAddress(account string) (types.Address, error) {
 // func (w *Wallet) GetXAddress() (string, error) {
 // 	return "", errors.New("not implemented")
 // }
-
-func cloneTransactionMap(tx map[string]any) map[string]any {
-	txCopy := make(map[string]any, len(tx))
-	maps.Copy(txCopy, tx)
-	return txCopy
-}

--- a/xrpl/wallet/wallet_test.go
+++ b/xrpl/wallet/wallet_test.go
@@ -1,9 +1,12 @@
 package wallet
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewWalletFromSeed(t *testing.T) {
@@ -212,18 +215,43 @@ func TestSign(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			original := maps.Clone(tc.tx)
+
 			txBlob, hash, err := tc.wallet.Sign(tc.tx)
-			if err != nil {
-				t.Fatalf("Error signing transaction: %v", err)
-			}
+			require.NoError(t, err)
 
-			if txBlob == "" {
-				t.Error("Expected non-empty txBlob, got empty string")
-			}
-
-			if hash == "" {
-				t.Error("Expected non-empty hash, got empty string")
-			}
+			assert.Equal(t, tc.expectedTxBlob, txBlob)
+			assert.Equal(t, tc.expectedHash, hash)
+			assert.Equal(t, original, tc.tx, "Sign must not mutate the input transaction map")
+			assert.NotContains(t, tc.tx, "TxnSignature", "Sign must not add TxnSignature to the input map")
 		})
 	}
+}
+
+func TestMultisignDoesNotMutateInput(t *testing.T) {
+	wallet := &Wallet{
+		PublicKey:      "EDE5638D8055CCD45EBF7F5FFD59FC1703D6BC00800BBA19F158119DAA1A52A8D5",
+		PrivateKey:     "ED0A961B472E78B89F1AE6A7CC4FB55FD083B36661D3D124E1BA29998346AE1AA1",
+		ClassicAddress: "raJB6EHNSJa3jV7FqWNrAhcL6FEDE3PGc5",
+	}
+	tx := map[string]any{
+		"Account":         "raJB6EHNSJa3jV7FqWNrAhcL6FEDE3PGc5",
+		"TransactionType": "Payment",
+		"Amount":          "15",
+		"Destination":     "rDwvihpE48E48F8rvNrqTb2UGWv62xqYTg",
+		"Flags":           uint32(0),
+		"Fee":             "12",
+		"Sequence":        uint32(1798962),
+		"SigningPubKey":   "028E831F16FD85ABEDA7577B6F4F26500FAB80AEA54B8A89EEC6FA44BCC7AF5678",
+	}
+	original := maps.Clone(tx)
+
+	blob, hash, err := wallet.Multisign(tx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, blob)
+	assert.NotEmpty(t, hash)
+
+	assert.Equal(t, original, tx, "Multisign must not mutate the input transaction map")
+	assert.NotContains(t, tx, "Signers", "Multisign must not add Signers to the input map")
+	assert.Equal(t, "028E831F16FD85ABEDA7577B6F4F26500FAB80AEA54B8A89EEC6FA44BCC7AF5678", tx["SigningPubKey"], "Multisign must not overwrite SigningPubKey on the input map")
 }

--- a/xrpl/wallet/wallet_test.go
+++ b/xrpl/wallet/wallet_test.go
@@ -228,6 +228,16 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestSignRejectsNilTransaction(t *testing.T) {
+	wallet := &Wallet{}
+
+	blob, hash, err := wallet.Sign(nil)
+
+	require.ErrorIs(t, err, ErrNilTransaction)
+	assert.Empty(t, blob)
+	assert.Empty(t, hash)
+}
+
 func TestMultisignDoesNotMutateInput(t *testing.T) {
 	wallet := &Wallet{
 		PublicKey:      "EDE5638D8055CCD45EBF7F5FFD59FC1703D6BC00800BBA19F158119DAA1A52A8D5",
@@ -246,12 +256,84 @@ func TestMultisignDoesNotMutateInput(t *testing.T) {
 	}
 	original := maps.Clone(tx)
 
+	const expectedBlob = "120000220000000024001B733261400000000000000F68400000000000000C730081143A18A088CF12B2D3E51F47A75D2A9859EF61ECA78314858233827B488ECB8D0EB940E7AC85CE41E343CFF3E0107321EDE5638D8055CCD45EBF7F5FFD59FC1703D6BC00800BBA19F158119DAA1A52A8D57440F5F19EE8DEDC11F40DE59A9F18F6EF4FED39AD222A4A65271FDC2F9A7CFF70D185EA5F49536EDA24EE4D9B73FC376AFD01758C9F7CEB54F6EADC7E10DD23C60C81143A18A088CF12B2D3E51F47A75D2A9859EF61ECA7E1F1"
+	const expectedHash = "6AC79CD0EF2855667E8C77445CCA052515AC7F570E0CC20C142A4131D7BC1852"
+
 	blob, hash, err := wallet.Multisign(tx)
 	require.NoError(t, err)
-	assert.NotEmpty(t, blob)
-	assert.NotEmpty(t, hash)
+	assert.Equal(t, expectedBlob, blob)
+	assert.Equal(t, expectedHash, hash)
 
 	assert.Equal(t, original, tx, "Multisign must not mutate the input transaction map")
 	assert.NotContains(t, tx, "Signers", "Multisign must not add Signers to the input map")
 	assert.Equal(t, "028E831F16FD85ABEDA7577B6F4F26500FAB80AEA54B8A89EEC6FA44BCC7AF5678", tx["SigningPubKey"], "Multisign must not overwrite SigningPubKey on the input map")
+}
+
+func TestMultisignRejectsNilTransaction(t *testing.T) {
+	wallet := &Wallet{}
+
+	blob, hash, err := wallet.Multisign(nil)
+
+	require.ErrorIs(t, err, ErrNilTransaction)
+	assert.Empty(t, blob)
+	assert.Empty(t, hash)
+}
+
+// TestSignAndMultisignPreserveNestedSliceIdentity pins the shallow-copy contract:
+// nested slices in the input transaction are not deep-cloned, and after Sign or
+// Multisign the input map's nested values still reference the same underlying
+// arrays as before the call.
+func TestSignAndMultisignPreserveNestedSliceIdentity(t *testing.T) {
+	w := &Wallet{
+		PublicKey:      "EDE5638D8055CCD45EBF7F5FFD59FC1703D6BC00800BBA19F158119DAA1A52A8D5",
+		PrivateKey:     "ED0A961B472E78B89F1AE6A7CC4FB55FD083B36661D3D124E1BA29998346AE1AA1",
+		ClassicAddress: "raJB6EHNSJa3jV7FqWNrAhcL6FEDE3PGc5",
+	}
+	buildTx := func() (map[string]any, []any) {
+		memos := []any{
+			map[string]any{
+				"Memo": map[string]any{
+					"MemoType": "657363726F77",
+					"MemoData": "457363726F77206372656174656420666F72207061796D656E74",
+				},
+			},
+		}
+		return map[string]any{
+			"Account":         "raJB6EHNSJa3jV7FqWNrAhcL6FEDE3PGc5",
+			"TransactionType": "Payment",
+			"Amount":          "15",
+			"Destination":     "rDwvihpE48E48F8rvNrqTb2UGWv62xqYTg",
+			"Flags":           uint32(0),
+			"Fee":             "12",
+			"Sequence":        uint32(1798962),
+			"SigningPubKey":   "028E831F16FD85ABEDA7577B6F4F26500FAB80AEA54B8A89EEC6FA44BCC7AF5678",
+			"Memos":           memos,
+		}, memos
+	}
+
+	t.Run("Sign", func(t *testing.T) {
+		tx, memosBefore := buildTx()
+		contentsBefore := []any{maps.Clone(memosBefore[0].(map[string]any))}
+
+		_, _, err := w.Sign(tx)
+		require.NoError(t, err)
+
+		memosAfter, ok := tx["Memos"].([]any)
+		require.True(t, ok, "Memos must still be []any in the input map")
+		assert.Same(t, &memosBefore[0], &memosAfter[0], "Sign must preserve nested slice identity (shallow copy)")
+		assert.Equal(t, contentsBefore, memosAfter, "Sign must not mutate nested slice contents")
+	})
+
+	t.Run("Multisign", func(t *testing.T) {
+		tx, memosBefore := buildTx()
+		contentsBefore := []any{maps.Clone(memosBefore[0].(map[string]any))}
+
+		_, _, err := w.Multisign(tx)
+		require.NoError(t, err)
+
+		memosAfter, ok := tx["Memos"].([]any)
+		require.True(t, ok, "Memos must still be []any in the input map")
+		assert.Same(t, &memosBefore[0], &memosAfter[0], "Multisign must preserve nested slice identity (shallow copy)")
+		assert.Equal(t, contentsBefore, memosAfter, "Multisign must not mutate nested slice contents")
+	})
 }


### PR DESCRIPTION
# fix(xrpl): avoid mutating signed transaction maps

## Description
This PR aims to prevent wallet signing helpers from mutating caller-provided transaction maps while preserving signed transaction output. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Updated `Wallet.Sign` to sign an internal shallow copy of the provided transaction map before setting `SigningPubKey` and `TxnSignature`.
- Updated `Wallet.Multisign` to sign an internal shallow copy before applying the XRPL multisign `SigningPubKey` value and adding `Signers`.
- Added wallet regression tests proving `Sign` and `Multisign` leave caller-provided maps unchanged.
- Strengthened existing `TestSign` coverage to assert the exact expected signed blob and transaction hash.

## Notes (optional)

The copy is intentionally shallow because the wallet methods only add or replace top-level signing fields.
