### PR TITLE
fix(binary-codec): prevent PathSet and XChainBridge input panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IOU amount decoding now rejects non-canonical wire values whose mantissa or exponent fall outside the XRPL token amount ranges.
 - Native XRP amount serialization now validates drops with exact integer bounds instead of float comparisons.
 - Fixed off-by-one in the variable-length prefix encoder (`serdes.encodeVariableLength`) at the 2-byte/3-byte boundary. Length 12480 was routed to the 3-byte branch and underflowed to bytes `[0xF0, 0xFF, 0xFF]`, corrupting the next field on decode. The 2-byte branch now correctly covers lengths 193..12480 inclusive per the XRPL serialization spec.
+- `PathSet.FromJSON` now returns errors for malformed inputs (non-`[]any` paths, empty paths, non-map steps, non-string `account`/`currency`/`issuer` values) instead of panicking, and propagates account, currency, and issuer decode errors that were previously swallowed and produced malformed signed paths.
+- `XChainBridge.FromJSON` now returns errors for non-string `LockingChainDoor`, `LockingChainIssue`, `IssuingChainDoor`, and `IssuingChainIssue` values instead of panicking on the type assertions.
+- `XChainBridge.ToJSON` now returns an error when the read byte buffer is not 80 bytes instead of panicking on out-of-range slice access.
 
 #### xrpl
 

--- a/binary-codec/codec_test.go
+++ b/binary-codec/codec_test.go
@@ -1,6 +1,7 @@
 package binarycodec
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/binary-codec/types"
@@ -330,7 +331,10 @@ func TestEncode(t *testing.T) {
 			got, err := Encode(tc.input)
 
 			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.Error(t, err)
+				if !errors.Is(err, tc.expectedErr) {
+					require.EqualError(t, err, tc.expectedErr.Error())
+				}
 				require.Empty(t, got)
 			} else {
 				require.NoError(t, err)

--- a/binary-codec/types/pathset.go
+++ b/binary-codec/types/pathset.go
@@ -30,32 +30,42 @@ func serializePathCurrency(currency string) ([]byte, error) {
 type PathSet struct{}
 
 // ErrInvalidPathSet is an error that's thrown when an invalid path set is provided.
-var ErrInvalidPathSet = errors.New("invalid type to construct PathSet from. Expected non-empty []any of non-empty []any path steps")
+var ErrInvalidPathSet = errors.New("invalid path set")
 
 // FromJSON attempts to serialize a path set from a JSON representation of a slice of paths to a byte array.
 // It returns the byte array representation of the path set, or an error if the provided json does not represent a valid path set.
 func (p PathSet) FromJSON(json any) ([]byte, error) {
-	paths, ok := json.([]any)
-	if !ok || len(paths) == 0 {
-		return nil, ErrInvalidPathSet
+	rawPaths, ok := json.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: input is not a []any", ErrInvalidPathSet)
+	}
+	if len(rawPaths) == 0 {
+		return nil, fmt.Errorf("%w: empty path set", ErrInvalidPathSet)
 	}
 
-	for _, rawPath := range paths {
-		path, ok := rawPath.([]any)
-		if !ok || len(path) == 0 {
-			return nil, ErrInvalidPathSet
+	paths := make([][]map[string]any, 0, len(rawPaths))
+	for _, rawPath := range rawPaths {
+		rawSteps, ok := rawPath.([]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: path is not a []any", ErrInvalidPathSet)
+		}
+		if len(rawSteps) == 0 {
+			return nil, fmt.Errorf("%w: empty path", ErrInvalidPathSet)
 		}
 
-		for _, rawStep := range path {
+		steps := make([]map[string]any, 0, len(rawSteps))
+		for _, rawStep := range rawSteps {
 			step, ok := rawStep.(map[string]any)
 			if !ok {
-				return nil, ErrInvalidPathSet
+				return nil, fmt.Errorf("%w: path step is not a map[string]any", ErrInvalidPathSet)
 			}
 
 			if !isPathStep(step) {
-				return nil, ErrInvalidPathSet
+				return nil, fmt.Errorf("%w: path step has no account/currency/issuer", ErrInvalidPathSet)
 			}
+			steps = append(steps, step)
 		}
+		paths = append(paths, steps)
 	}
 
 	return newPathSet(paths)
@@ -67,14 +77,13 @@ func isPathStep(v map[string]any) bool {
 	return v["account"] != nil || v["currency"] != nil || v["issuer"] != nil
 }
 
-// newPathSet constructs a path set from a validated non-empty slice of paths.
-// Each element of v must be a []any path.
+// newPathSet constructs a path set from a non-empty slice of paths.
 // It generates a byte array representation of the path set, encoding each path and adding path separators as appropriate.
-func newPathSet(v []any) ([]byte, error) {
+func newPathSet(v [][]map[string]any) ([]byte, error) {
 	b := make([]byte, 0)
 
 	for _, path := range v { // for each path in the path set (slice of paths)
-		p, err := newPath(path.([]any))
+		p, err := newPath(path)
 		if err != nil {
 			return nil, err
 		}
@@ -87,14 +96,13 @@ func newPathSet(v []any) ([]byte, error) {
 	return b, nil
 }
 
-// newPath constructs a path from a validated non-empty slice of path steps.
-// Each element of v must be a map[string]any path step.
+// newPath constructs a path from a non-empty slice of path steps.
 // It generates a byte array representation of the path, encoding each path step in turn.
-func newPath(v []any) ([]byte, error) {
+func newPath(v []map[string]any) ([]byte, error) {
 	b := make([]byte, 0)
 
 	for _, step := range v { // for each step in the path (slice of path steps)
-		s, err := newPathStep(step.(map[string]any))
+		s, err := newPathStep(step)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +120,7 @@ func newPathStep(v map[string]any) ([]byte, error) {
 	if v["account"] != nil {
 		accStr, ok := v["account"].(string)
 		if !ok {
-			return nil, ErrInvalidPathSet
+			return nil, fmt.Errorf("%w: account is not a string", ErrInvalidPathSet)
 		}
 		_, account, err := addresscodec.DecodeClassicAddressToAccountID(accStr)
 		if err != nil {
@@ -124,7 +132,7 @@ func newPathStep(v map[string]any) ([]byte, error) {
 	if v["currency"] != nil {
 		curStr, ok := v["currency"].(string)
 		if !ok {
-			return nil, ErrInvalidPathSet
+			return nil, fmt.Errorf("%w: currency is not a string", ErrInvalidPathSet)
 		}
 		currency, err := serializePathCurrency(curStr)
 		if err != nil {
@@ -136,7 +144,7 @@ func newPathStep(v map[string]any) ([]byte, error) {
 	if v["issuer"] != nil {
 		issStr, ok := v["issuer"].(string)
 		if !ok {
-			return nil, ErrInvalidPathSet
+			return nil, fmt.Errorf("%w: issuer is not a string", ErrInvalidPathSet)
 		}
 		_, issuer, err := addresscodec.DecodeClassicAddressToAccountID(issStr)
 		if err != nil {

--- a/binary-codec/types/pathset.go
+++ b/binary-codec/types/pathset.go
@@ -30,20 +30,123 @@ func serializePathCurrency(currency string) ([]byte, error) {
 type PathSet struct{}
 
 // ErrInvalidPathSet is an error that's thrown when an invalid path set is provided.
-var ErrInvalidPathSet = errors.New("invalid type to construct PathSet from. Expected []any of []any")
+var ErrInvalidPathSet = errors.New("invalid type to construct PathSet from. Expected non-empty []any of non-empty []any path steps")
 
 // FromJSON attempts to serialize a path set from a JSON representation of a slice of paths to a byte array.
 // It returns the byte array representation of the path set, or an error if the provided json does not represent a valid path set.
 func (p PathSet) FromJSON(json any) ([]byte, error) {
-	if _, ok := json.([]any)[0].([]any); !ok {
+	paths, ok := json.([]any)
+	if !ok || len(paths) == 0 {
 		return nil, ErrInvalidPathSet
 	}
 
-	if !isPathSet(json.([]any)) {
-		return nil, ErrInvalidPathSet
+	for _, rawPath := range paths {
+		path, ok := rawPath.([]any)
+		if !ok || len(path) == 0 {
+			return nil, ErrInvalidPathSet
+		}
+
+		for _, rawStep := range path {
+			step, ok := rawStep.(map[string]any)
+			if !ok {
+				return nil, ErrInvalidPathSet
+			}
+
+			if !isPathStep(step) {
+				return nil, ErrInvalidPathSet
+			}
+		}
 	}
 
-	return newPathSet(json.([]any)), nil
+	return newPathSet(paths)
+}
+
+// isPathStep determines if a map represents a valid path step.
+// It checks if any of the keys "account", "currency" or "issuer" are present in the map.
+func isPathStep(v map[string]any) bool {
+	return v["account"] != nil || v["currency"] != nil || v["issuer"] != nil
+}
+
+// newPathSet constructs a path set from a validated non-empty slice of paths.
+// Each element of v must be a []any path.
+// It generates a byte array representation of the path set, encoding each path and adding path separators as appropriate.
+func newPathSet(v []any) ([]byte, error) {
+	b := make([]byte, 0)
+
+	for _, path := range v { // for each path in the path set (slice of paths)
+		p, err := newPath(path.([]any))
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, p...)              // append the path to the byte array
+		b = append(b, pathSeparatorByte) // between each path, append a path separator byte
+	}
+
+	b[len(b)-1] = pathsetEndByte // replace last path separator with path set end byte
+
+	return b, nil
+}
+
+// newPath constructs a path from a validated non-empty slice of path steps.
+// Each element of v must be a map[string]any path step.
+// It generates a byte array representation of the path, encoding each path step in turn.
+func newPath(v []any) ([]byte, error) {
+	b := make([]byte, 0)
+
+	for _, step := range v { // for each step in the path (slice of path steps)
+		s, err := newPathStep(step.(map[string]any))
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, s...) // append the path step to the byte array
+	}
+	return b, nil
+}
+
+// newPathStep creates a path step from a map representation.
+// It generates a byte array representation of the path step, encoding account, currency, and issuer information as appropriate.
+func newPathStep(v map[string]any) ([]byte, error) {
+	dataType := 0x00
+	b := make([]byte, 0)
+
+	if v["account"] != nil {
+		accStr, ok := v["account"].(string)
+		if !ok {
+			return nil, ErrInvalidPathSet
+		}
+		_, account, err := addresscodec.DecodeClassicAddressToAccountID(accStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid account path step: %w", ErrInvalidPathSet, err)
+		}
+		b = append(b, account...)
+		dataType |= typeAccount
+	}
+	if v["currency"] != nil {
+		curStr, ok := v["currency"].(string)
+		if !ok {
+			return nil, ErrInvalidPathSet
+		}
+		currency, err := serializePathCurrency(curStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid currency path step: %w", ErrInvalidPathSet, err)
+		}
+		b = append(b, currency...)
+		dataType |= typeCurrency
+	}
+	if v["issuer"] != nil {
+		issStr, ok := v["issuer"].(string)
+		if !ok {
+			return nil, ErrInvalidPathSet
+		}
+		_, issuer, err := addresscodec.DecodeClassicAddressToAccountID(issStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid issuer path step: %w", ErrInvalidPathSet, err)
+		}
+		b = append(b, issuer...)
+		dataType |= typeIssuer
+	}
+
+	return append([]byte{byte(dataType)}, b...), nil
 }
 
 // ToJSON decodes a path set from a binary representation using a provided binary parser, then translates it to a JSON representation.
@@ -98,67 +201,37 @@ func (p PathSet) ToJSON(parser interfaces.BinaryParser, _ ...int) (any, error) {
 	return pathSet, nil
 }
 
-// isPathSet determines if an array represents a valid path set.
-// It checks if the array is either empty or if its first element is a valid path step.
-func isPathSet(v []any) bool {
-	return len(v) == 0 || len(v[0].([]any)) == 0 || isPathStep(v[0].([]any)[0].(map[string]any))
-}
+// parsePath decodes a path from a binary representation using a provided binary parser.
+// It returns a slice representing the path, or an error if the path could not be decoded.
+func parsePath(parser interfaces.BinaryParser) ([]any, error) {
+	var path []any
 
-// isPathStep determines if a map represents a valid path step.
-// It checks if any of the keys "account", "currency" or "issuer" are present in the map.
-func isPathStep(v map[string]any) bool {
-	return v["account"] != nil || v["currency"] != nil || v["issuer"] != nil
-}
+	for parser.HasMore() {
+		peek, err := parser.Peek()
+		if err != nil {
+			return nil, err
+		}
 
-// newPathStep creates a path step from a map representation.
-// It generates a byte array representation of the path step, encoding account, currency, and issuer information as appropriate.
-func newPathStep(v map[string]any) []byte {
-	dataType := 0x00
-	b := make([]byte, 0)
+		if peek == pathsetEndByte {
+			break
+		}
 
-	if v["account"] != nil {
-		_, account, _ := addresscodec.DecodeClassicAddressToAccountID(v["account"].(string))
-		b = append(b, account...)
-		dataType |= typeAccount
-	}
-	if v["currency"] != nil {
-		currency, _ := serializePathCurrency(v["currency"].(string))
-		b = append(b, currency...)
-		dataType |= typeCurrency
-	}
-	if v["issuer"] != nil {
-		_, issuer, _ := addresscodec.DecodeClassicAddressToAccountID(v["issuer"].(string))
-		b = append(b, issuer...)
-		dataType |= typeIssuer
+		if peek == pathSeparatorByte {
+			_, err := parser.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+
+		step, err := parsePathStep(parser)
+		if err != nil {
+			return nil, err
+		}
+		path = append(path, step)
 	}
 
-	return append([]byte{byte(dataType)}, b...)
-}
-
-// newPath constructs a path from a slice of path steps.
-// It generates a byte array representation of the path, encoding each path step in turn.
-func newPath(v []any) []byte {
-	b := make([]byte, 0)
-
-	for _, step := range v { // for each step in the path (slice of path steps)
-		b = append(b, newPathStep(step.(map[string]any))...) // append the path step to the byte array
-	}
-	return b
-}
-
-// newPathSet constructs a path set from a slice of paths.
-// It generates a byte array representation of the path set, encoding each path and adding path separators as appropriate.
-func newPathSet(v []any) []byte {
-	b := make([]byte, 0)
-
-	for _, path := range v { // for each path in the path set (slice of paths)
-		b = append(b, newPath(path.([]any))...) // append the path to the byte array
-		b = append(b, pathSeparatorByte)        // between each path, append a path separator byte
-	}
-
-	b[len(b)-1] = pathsetEndByte // replace last path separator with path set end byte
-
-	return b
+	return path, nil
 }
 
 // parsePathStep decodes a path step from a binary representation using a provided binary parser.
@@ -204,37 +277,4 @@ func parsePathStep(parser interfaces.BinaryParser) (map[string]any, error) {
 	}
 
 	return step, nil
-}
-
-// parsePath decodes a path from a binary representation using a provided binary parser.
-// It returns a slice representing the path, or an error if the path could not be decoded.
-func parsePath(parser interfaces.BinaryParser) ([]any, error) {
-	var path []any
-
-	for parser.HasMore() {
-		peek, err := parser.Peek()
-		if err != nil {
-			return nil, err
-		}
-
-		if peek == pathsetEndByte {
-			break
-		}
-
-		if peek == pathSeparatorByte {
-			_, err := parser.ReadByte()
-			if err != nil {
-				return nil, err
-			}
-			break
-		}
-
-		step, err := parsePathStep(parser)
-		if err != nil {
-			return nil, err
-		}
-		path = append(path, step)
-	}
-
-	return path, nil
 }

--- a/binary-codec/types/pathset_test.go
+++ b/binary-codec/types/pathset_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
 	"github.com/Peersyst/xrpl-go/binary-codec/definitions"
 	"github.com/Peersyst/xrpl-go/binary-codec/serdes"
 	"github.com/Peersyst/xrpl-go/binary-codec/types/interfaces"
@@ -14,10 +15,11 @@ import (
 
 func TestPathSet_FromJson(t *testing.T) {
 	testcases := []struct {
-		name   string
-		input  any
-		output []byte
-		err    error
+		name       string
+		input      any
+		output     []byte
+		err        error
+		innerCheck func(t *testing.T, err error)
 	}{
 		{
 			name:  "fail - input is not []any",
@@ -94,6 +96,9 @@ func TestPathSet_FromJson(t *testing.T) {
 				},
 			},
 			err: ErrInvalidPathSet,
+			innerCheck: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, addresscodec.ErrInvalidClassicAddress)
+			},
 		},
 		{
 			name: "fail - invalid currency decode",
@@ -103,6 +108,10 @@ func TestPathSet_FromJson(t *testing.T) {
 				},
 			},
 			err: ErrInvalidPathSet,
+			innerCheck: func(t *testing.T, err error) {
+				var codeErr *InvalidCodeError
+				require.ErrorAs(t, err, &codeErr)
+			},
 		},
 		{
 			name: "fail - invalid issuer decode",
@@ -112,6 +121,9 @@ func TestPathSet_FromJson(t *testing.T) {
 				},
 			},
 			err: ErrInvalidPathSet,
+			innerCheck: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, addresscodec.ErrInvalidClassicAddress)
+			},
 		},
 		{
 			name: "pass - valid path set",
@@ -135,6 +147,9 @@ func TestPathSet_FromJson(t *testing.T) {
 			act, err := pathset.FromJSON(tc.input)
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
+				if tc.innerCheck != nil {
+					tc.innerCheck(t, err)
+				}
 				return
 			}
 			require.NoError(t, err)
@@ -206,6 +221,60 @@ func TestPathSet_ToJson(t *testing.T) {
 	}
 }
 
+func TestPathSet_FromJsonToJsonRoundTrip(t *testing.T) {
+	pathset := PathSet{}
+	input := []any{
+		[]any{
+			map[string]any{
+				"account":  "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"currency": "USD",
+				"issuer":   "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
+			},
+			map[string]any{
+				"currency": "EUR",
+				"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
+			},
+		},
+		[]any{
+			map[string]any{
+				"account": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+		},
+	}
+
+	encoded, err := pathset.FromJSON(input)
+	require.NoError(t, err)
+
+	decoded, err := pathset.ToJSON(serdes.NewBinaryParser(encoded, definitions.Get()))
+	require.NoError(t, err)
+
+	expected := []any{
+		[]any{
+			map[string]any{
+				"account":  "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"currency": "USD",
+				"issuer":   "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
+				"type":     49, // typeAccount | typeCurrency | typeIssuer
+				"type_hex": "0000000000000031",
+			},
+			map[string]any{
+				"currency": "EUR",
+				"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
+				"type":     48, // typeCurrency | typeIssuer
+				"type_hex": "0000000000000030",
+			},
+		},
+		[]any{
+			map[string]any{
+				"account":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"type":     1, // typeAccount
+				"type_hex": "0000000000000001",
+			},
+		},
+	}
+	require.Equal(t, expected, decoded)
+}
+
 func TestIsPathStep(t *testing.T) {
 	tt := []struct {
 		description string
@@ -272,18 +341,18 @@ func TestNewPathStep(t *testing.T) {
 func TestNewPath(t *testing.T) {
 	tt := []struct {
 		description string
-		input       []any
+		input       []map[string]any
 		expected    []byte
 	}{
 		{
 			description: "created valid path",
-			input: []any{
-				map[string]any{
+			input: []map[string]any{
+				{
 					"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 					"currency": "USD",
 					"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
 				},
-				map[string]any{
+				{
 					"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 					"currency": "USD",
 					"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
@@ -305,43 +374,43 @@ func TestNewPath(t *testing.T) {
 func TestNewPathSet(t *testing.T) {
 	tt := []struct {
 		description string
-		input       []any
+		input       [][]map[string]any
 		expected    []byte
 	}{
 		{
 			description: "created valid path set with multiple paths",
-			input: []any{
-				[]any{
-					map[string]any{
+			input: [][]map[string]any{
+				{
+					{
 						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 						"currency": "USD",
 						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
 					},
-					map[string]any{
-						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
-						"currency": "USD",
-						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
-					},
-				},
-				[]any{
-					map[string]any{
-						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
-						"currency": "USD",
-						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
-					},
-					map[string]any{
+					{
 						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 						"currency": "USD",
 						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
 					},
 				},
-				[]any{
-					map[string]any{
+				{
+					{
 						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 						"currency": "USD",
 						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
 					},
-					map[string]any{
+					{
+						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
+						"currency": "USD",
+						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
+					},
+				},
+				{
+					{
+						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
+						"currency": "USD",
+						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",
+					},
+					{
 						"account":  "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
 						"currency": "USD",
 						"issuer":   "r3Y6vCE8XqfZmYBRngy22uFYkmz3y9eCRA",

--- a/binary-codec/types/pathset_test.go
+++ b/binary-codec/types/pathset_test.go
@@ -20,17 +20,95 @@ func TestPathSet_FromJson(t *testing.T) {
 		err    error
 	}{
 		{
-			name: "fail - empty path set",
+			name:  "fail - input is not []any",
+			input: "not a path set",
+			err:   ErrInvalidPathSet,
+		},
+		{
+			name:  "fail - empty paths",
+			input: []any{},
+			err:   ErrInvalidPathSet,
+		},
+		{
+			name: "fail - path is not []any",
 			input: []any{
 				map[string]any{},
 			},
 			err: ErrInvalidPathSet,
 		},
 		{
-			name: "fail - invalid path set",
+			name: "fail - empty path",
+			input: []any{
+				[]any{},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - step is not a map",
+			input: []any{
+				[]any{"not a map"},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - step has no account/currency/issuer keys",
 			input: []any{
 				[]any{
 					map[string]any{},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - account is not a string",
+			input: []any{
+				[]any{
+					map[string]any{"account": 123},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - currency is not a string",
+			input: []any{
+				[]any{
+					map[string]any{"currency": 123},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - issuer is not a string",
+			input: []any{
+				[]any{
+					map[string]any{"issuer": 123},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - invalid account decode",
+			input: []any{
+				[]any{
+					map[string]any{"account": "not-a-valid-address"},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - invalid currency decode",
+			input: []any{
+				[]any{
+					map[string]any{"currency": "ZZ"},
+				},
+			},
+			err: ErrInvalidPathSet,
+		},
+		{
+			name: "fail - invalid issuer decode",
+			input: []any{
+				[]any{
+					map[string]any{"issuer": "not-a-valid-issuer"},
 				},
 			},
 			err: ErrInvalidPathSet,
@@ -56,8 +134,7 @@ func TestPathSet_FromJson(t *testing.T) {
 			pathset := PathSet{}
 			act, err := pathset.FromJSON(tc.input)
 			if tc.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tc.err, err)
+				require.ErrorIs(t, err, tc.err)
 				return
 			}
 			require.NoError(t, err)
@@ -185,7 +262,9 @@ func TestNewPathStep(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPathStep(tc.input))
+			actual, err := newPathStep(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -216,7 +295,9 @@ func TestNewPath(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPath(tc.input))
+			actual, err := newPath(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -273,7 +354,9 @@ func TestNewPathSet(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
-			require.Equal(t, tc.expected, newPathSet(tc.input))
+			actual, err := newPathSet(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/binary-codec/types/xchain_bridge.go
+++ b/binary-codec/types/xchain_bridge.go
@@ -13,6 +13,8 @@ var (
 	errNotValidXChainBridge = errors.New("not a valid xchain bridge")
 )
 
+const xChainBridgeLength = 80
+
 // XChainBridge is a struct that represents an xchain bridge.
 type XChainBridge struct{}
 
@@ -24,26 +26,42 @@ func (x *XChainBridge) FromJSON(json any) ([]byte, error) {
 		return nil, errNotValidJSON
 	}
 
-	if v["LockingChainDoor"] == nil || v["LockingChainIssue"] == nil || v["IssuingChainDoor"] == nil || v["IssuingChainIssue"] == nil {
+	lockingChainDoorStr, ok := v["LockingChainDoor"].(string)
+	if !ok {
 		return nil, errNotValidXChainBridge
 	}
 
-	_, lockingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainDoor"].(string))
+	lockingChainIssueStr, ok := v["LockingChainIssue"].(string)
+	if !ok {
+		return nil, errNotValidXChainBridge
+	}
+
+	issuingChainDoorStr, ok := v["IssuingChainDoor"].(string)
+	if !ok {
+		return nil, errNotValidXChainBridge
+	}
+
+	issuingChainIssueStr, ok := v["IssuingChainIssue"].(string)
+	if !ok {
+		return nil, errNotValidXChainBridge
+	}
+
+	_, lockingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(lockingChainDoorStr)
 	if err != nil {
 		return nil, errDecodeClassicAddress
 	}
 
-	_, lockingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["LockingChainIssue"].(string))
+	_, lockingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(lockingChainIssueStr)
 	if err != nil {
 		return nil, errDecodeClassicAddress
 	}
 
-	_, issuingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainDoor"].(string))
+	_, issuingChainDoor, err := addresscodec.DecodeClassicAddressToAccountID(issuingChainDoorStr)
 	if err != nil {
 		return nil, errDecodeClassicAddress
 	}
 
-	_, issuingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(v["IssuingChainIssue"].(string))
+	_, issuingChainIssue, err := addresscodec.DecodeClassicAddressToAccountID(issuingChainIssueStr)
 	if err != nil {
 		return nil, errDecodeClassicAddress
 	}
@@ -61,13 +79,17 @@ func (x *XChainBridge) FromJSON(json any) ([]byte, error) {
 // ToJSON converts a byte slice representation of an XChainBridge object to its json representation.
 // It returns an error if the bytes are not valid or if the classic addresses are not valid.
 func (x *XChainBridge) ToJSON(p interfaces.BinaryParser, opts ...int) (any, error) {
-	if opts == nil {
+	if len(opts) == 0 {
 		return nil, ErrNoLengthPrefix
 	}
 
 	bytes, err := p.ReadBytes(opts[0])
 	if err != nil {
 		return nil, errReadBytes
+	}
+
+	if len(bytes) != xChainBridgeLength {
+		return nil, errNotValidXChainBridge
 	}
 
 	json := make(map[string]string)

--- a/binary-codec/types/xchain_bridge_test.go
+++ b/binary-codec/types/xchain_bridge_test.go
@@ -88,6 +88,50 @@ func TestXChainBridge_FromJson(t *testing.T) {
 			want: nil,
 			err:  errNotValidXChainBridge,
 		},
+		{
+			name: "LockingChainDoor is not a string",
+			json: map[string]any{
+				"LockingChainDoor":  123,
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  errNotValidXChainBridge,
+		},
+		{
+			name: "LockingChainIssue is not a string",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": 123,
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  errNotValidXChainBridge,
+		},
+		{
+			name: "IssuingChainDoor is not a string",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  123,
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			want: nil,
+			err:  errNotValidXChainBridge,
+		},
+		{
+			name: "IssuingChainIssue is not a string",
+			json: map[string]any{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": 123,
+			},
+			want: nil,
+			err:  errNotValidXChainBridge,
+		},
 	}
 
 	for _, tc := range tt {
@@ -151,6 +195,32 @@ func TestXChainBridge_ToJson(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mock := testutil.NewMockBinaryParser(ctrl)
 				mock.EXPECT().ReadBytes(80).Return([]byte{}, errors.New("errReadBytes"))
+				return &XChainBridge{}, mock
+			},
+		},
+		{
+			name:  "Short bytes",
+			input: nil,
+			opts:  []int{80},
+			want:  nil,
+			err:   errNotValidXChainBridge,
+			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+				ctrl := gomock.NewController(t)
+				mock := testutil.NewMockBinaryParser(ctrl)
+				mock.EXPECT().ReadBytes(80).Return(make([]byte, 60), nil)
+				return &XChainBridge{}, mock
+			},
+		},
+		{
+			name:  "Nil bytes",
+			input: nil,
+			opts:  []int{80},
+			want:  nil,
+			err:   errNotValidXChainBridge,
+			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+				ctrl := gomock.NewController(t)
+				mock := testutil.NewMockBinaryParser(ctrl)
+				mock.EXPECT().ReadBytes(80).Return(nil, nil)
 				return &XChainBridge{}, mock
 			},
 		},

--- a/binary-codec/types/xchain_bridge_test.go
+++ b/binary-codec/types/xchain_bridge_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Peersyst/xrpl-go/binary-codec/definitions"
+	"github.com/Peersyst/xrpl-go/binary-codec/serdes"
+	"github.com/Peersyst/xrpl-go/binary-codec/types/interfaces"
 	"github.com/Peersyst/xrpl-go/binary-codec/types/testutil"
 	"github.com/golang/mock/gomock"
 )
@@ -155,7 +158,7 @@ func TestXChainBridge_ToJson(t *testing.T) {
 		opts  []int
 		want  map[string]string
 		err   error
-		setup func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser)
+		setup func(t *testing.T) (*XChainBridge, interfaces.BinaryParser)
 	}{
 		{
 			name:  "Valid xchain bridge",
@@ -168,11 +171,27 @@ func TestXChainBridge_ToJson(t *testing.T) {
 				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
 			},
 			err: nil,
-			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
 				ctrl := gomock.NewController(t)
 				mock := testutil.NewMockBinaryParser(ctrl)
 				mock.EXPECT().ReadBytes(80).Return([]byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18}, nil)
 				return &XChainBridge{}, mock
+			},
+		},
+		{
+			name:  "Valid xchain bridge - real parser",
+			input: []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18},
+			opts:  []int{80},
+			want: map[string]string{
+				"LockingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"LockingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainDoor":  "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+				"IssuingChainIssue": "r3e7qTG44Mg8pHXgxPtyRx286Re5Urtx2p",
+			},
+			err: nil,
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
+				payload := []byte{83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18, 83, 223, 129, 195, 127, 70, 21, 146, 66, 247, 202, 145, 99, 224, 159, 4, 64, 41, 204, 18}
+				return &XChainBridge{}, serdes.NewBinaryParser(payload, definitions.Get())
 			},
 		},
 		{
@@ -181,7 +200,7 @@ func TestXChainBridge_ToJson(t *testing.T) {
 			opts:  nil,
 			want:  nil,
 			err:   ErrNoLengthPrefix,
-			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
 				return &XChainBridge{}, nil
 			},
 		},
@@ -191,7 +210,7 @@ func TestXChainBridge_ToJson(t *testing.T) {
 			opts:  []int{80},
 			want:  nil,
 			err:   errReadBytes,
-			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
 				ctrl := gomock.NewController(t)
 				mock := testutil.NewMockBinaryParser(ctrl)
 				mock.EXPECT().ReadBytes(80).Return([]byte{}, errors.New("errReadBytes"))
@@ -204,7 +223,7 @@ func TestXChainBridge_ToJson(t *testing.T) {
 			opts:  []int{80},
 			want:  nil,
 			err:   errNotValidXChainBridge,
-			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
 				ctrl := gomock.NewController(t)
 				mock := testutil.NewMockBinaryParser(ctrl)
 				mock.EXPECT().ReadBytes(80).Return(make([]byte, 60), nil)
@@ -217,7 +236,7 @@ func TestXChainBridge_ToJson(t *testing.T) {
 			opts:  []int{80},
 			want:  nil,
 			err:   errNotValidXChainBridge,
-			setup: func(t *testing.T) (*XChainBridge, *testutil.MockBinaryParser) {
+			setup: func(t *testing.T) (*XChainBridge, interfaces.BinaryParser) {
 				ctrl := gomock.NewController(t)
 				mock := testutil.NewMockBinaryParser(ctrl)
 				mock.EXPECT().ReadBytes(80).Return(nil, nil)
@@ -228,8 +247,8 @@ func TestXChainBridge_ToJson(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			xcb, mock := tc.setup(t)
-			got, err := xcb.ToJSON(mock, tc.opts...)
+			xcb, parser := tc.setup(t)
+			got, err := xcb.ToJSON(parser, tc.opts...)
 			if !errors.Is(err, tc.err) {
 				t.Errorf("ToJson() error = %v, want %v", err.Error(), tc.err.Error())
 			} else if tc.err == nil && !reflect.DeepEqual(got, tc.want) {


### PR DESCRIPTION
# fix(binary-codec): prevent PathSet and XChainBridge input panics

## Description
This PR aims to make PathSet and XChainBridge decoding return validation errors for malformed inputs instead of panicking or silently accepting invalid path data. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Hardened `PathSet.FromJSON` validation so malformed path sets, empty paths, non-map steps, and non-string `account`, `currency`, or `issuer` values return `ErrInvalidPathSet`.
- Updated PathSet construction helpers to return errors and propagate account, currency, and issuer serialization failures instead of ignoring decode errors.
- Hardened `XChainBridge.FromJSON` so non-string bridge fields return `errNotValidXChainBridge` before address decoding.
- Added an 80-byte length check to `XChainBridge.ToJSON` so short or nil parser output returns `errNotValidXChainBridge` instead of panicking during slicing.
- Added unit coverage for malformed PathSet JSON inputs, invalid PathSet component decoding, non-string XChainBridge fields, and short/nil XChainBridge byte buffers.

## Notes (optional)

Focused test run: `go test ./binary-codec/types`.
