### PR TITLE
fix(xrpl/transaction): reject non-hex Condition and Fulfillment in EscrowFinish.Validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported `ErrRandomizerRequired` sentinel for `GenerateSeed` calls with empty entropy and a nil randomizer.
 - Exported `ErrInvalidEntropyLength` sentinel wrapping caller-supplied entropy length errors, so callers can `errors.Is` without importing `address-codec`.
 
+#### pkg/typecheck
+
+- Added `IsHexBlob` helper that reports whether a string is a hex-encoded whole-byte sequence (valid hex characters and even length). Used by the Escrow transaction validators.
+
 ### Changed
 
 #### xrpl/currency
@@ -99,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl/transaction
 
 - `EscrowFinish.Validate` now rejects `Condition` and `Fulfillment` values that are not valid hex-encoded byte sequences (non-hex characters or odd length) with the new `ErrEscrowFinishInvalidCondition` and `ErrEscrowFinishInvalidFulfillment` sentinels. Previously malformed values were forwarded to the binary codec and the fee calculator.
+- `EscrowCreate.Validate` now rejects `Condition` values that are not valid hex-encoded byte sequences with the new `ErrEscrowCreateInvalidCondition` sentinel, matching the parity check on `EscrowFinish`.
 
 #### xrpl/rpc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### xrpl/transaction
+
+- `EscrowFinish.Validate` now rejects `Condition` and `Fulfillment` values that are not valid hex-encoded byte sequences (non-hex characters or odd length) with the new `ErrEscrowFinishInvalidCondition` and `ErrEscrowFinishInvalidFulfillment` sentinels. Previously malformed values were forwarded to the binary codec and the fee calculator.
+
 #### xrpl/rpc
 
 - RPC client now caps HTTP response bodies at 64 MiB by default to prevent unbounded memory growth from oversized server responses. Use `WithMaxResponseSize(0)` to disable the limit.

--- a/pkg/typecheck/typecheck.go
+++ b/pkg/typecheck/typecheck.go
@@ -70,6 +70,12 @@ func IsHex(s string) bool {
 	return true
 }
 
+// IsHexBlob reports whether s is a hex string that encodes whole bytes
+// (valid hex characters and even length). Empty strings return false.
+func IsHexBlob(s string) bool {
+	return IsHex(s) && len(s)%2 == 0
+}
+
 // IsFloat32 checks if the given string is a valid Float32 number.
 func IsFloat32(s string) bool {
 	_, err := strconv.ParseFloat(s, 32)

--- a/pkg/typecheck/typecheck_test.go
+++ b/pkg/typecheck/typecheck_test.go
@@ -269,6 +269,63 @@ func TestIsHex(t *testing.T) {
 	}
 }
 
+func TestIsHexBlob(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{
+			name: "pass - valid even-length hex",
+			s:    "A0028000",
+			want: true,
+		},
+		{
+			name: "pass - valid even-length hex lowercase",
+			s:    "deadbeef",
+			want: true,
+		},
+		{
+			name: "fail - odd-length hex",
+			s:    "ABC",
+			want: false,
+		},
+		{
+			name: "fail - single hex digit",
+			s:    "F",
+			want: false,
+		},
+		{
+			name: "fail - even-length non-hex",
+			s:    "GG",
+			want: false,
+		},
+		{
+			name: "fail - even-length mixed hex and non-hex",
+			s:    "AB0Z",
+			want: false,
+		},
+		{
+			name: "fail - odd-length non-hex",
+			s:    "not-hex",
+			want: false,
+		},
+		{
+			name: "fail - empty string",
+			s:    "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHexBlob(tt.s); got != tt.want {
+				t.Errorf("IsHexBlob(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsInt(t *testing.T) {
 	tests := []struct {
 		name string

--- a/xrpl/transaction/errors.go
+++ b/xrpl/transaction/errors.go
@@ -252,6 +252,8 @@ var (
 	ErrEscrowCreateZeroAmount = errors.New("escrow create: amount must be non-zero")
 	// ErrEscrowCreateNoConditionOrFinishAfterSet is returned when both Condition and FinishAfter are unset.
 	ErrEscrowCreateNoConditionOrFinishAfterSet = errors.New("escrow create: either Condition or FinishAfter must be specified")
+	// ErrEscrowCreateInvalidCondition is returned when the Condition field is set but not a valid hexadecimal string.
+	ErrEscrowCreateInvalidCondition = errors.New("escrow create: Condition must be a valid hexadecimal string")
 
 	// ErrEscrowCancelMissingOwner indicates the Owner field is missing when canceling an escrow.
 	ErrEscrowCancelMissingOwner = errors.New("escrow cancel: missing owner")

--- a/xrpl/transaction/errors.go
+++ b/xrpl/transaction/errors.go
@@ -241,6 +241,10 @@ var (
 	ErrEscrowFinishMissingOwner = errors.New("escrow finish: missing owner")
 	// ErrEscrowFinishMissingOfferSequence is returned when the OfferSequence is zero in an EscrowFinish transaction.
 	ErrEscrowFinishMissingOfferSequence = errors.New("escrow finish: missing offer sequence")
+	// ErrEscrowFinishInvalidCondition is returned when the Condition field is set but not a valid hexadecimal string.
+	ErrEscrowFinishInvalidCondition = errors.New("escrow finish: Condition must be a valid hexadecimal string")
+	// ErrEscrowFinishInvalidFulfillment is returned when the Fulfillment field is set but not a valid hexadecimal string.
+	ErrEscrowFinishInvalidFulfillment = errors.New("escrow finish: Fulfillment must be a valid hexadecimal string")
 
 	// ErrEscrowCreateInvalidDestinationAddress is returned when the destination address for EscrowCreate is invalid.
 	ErrEscrowCreateInvalidDestinationAddress = errors.New("escrow create: invalid destination address")

--- a/xrpl/transaction/escrow_create.go
+++ b/xrpl/transaction/escrow_create.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
@@ -131,6 +132,11 @@ func (e *EscrowCreate) Validate() (bool, error) {
 
 	if (e.FinishAfter == 0 && e.CancelAfter == 0) || (e.Condition == "" && e.FinishAfter == 0) {
 		return false, ErrEscrowCreateNoConditionOrFinishAfterSet
+	}
+
+	// Condition is a Blob field, so the hex string must encode whole bytes (even length).
+	if e.Condition != "" && !typecheck.IsHexBlob(e.Condition) {
+		return false, ErrEscrowCreateInvalidCondition
 	}
 
 	return true, nil

--- a/xrpl/transaction/escrow_create_test.go
+++ b/xrpl/transaction/escrow_create_test.go
@@ -256,6 +256,48 @@ func TestEscrowCreate_Validate(t *testing.T) {
 			expectedErr: ErrInvalidTransactionType,
 		},
 		{
+			name: "fail - non-hex Condition (odd length)",
+			entry: &EscrowCreate{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+				CancelAfter: 533257958,
+				Condition:   "not-hex",
+			},
+			expectedErr: ErrEscrowCreateInvalidCondition,
+		},
+		{
+			name: "fail - non-hex Condition (even length)",
+			entry: &EscrowCreate{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+				CancelAfter: 533257958,
+				Condition:   "GG",
+			},
+			expectedErr: ErrEscrowCreateInvalidCondition,
+		},
+		{
+			name: "fail - odd-length Condition",
+			entry: &EscrowCreate{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowCreateTx,
+				},
+				Amount:      types.XRPCurrencyAmount(10000),
+				Destination: "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
+				CancelAfter: 533257958,
+				Condition:   "F",
+			},
+			expectedErr: ErrEscrowCreateInvalidCondition,
+		},
+		{
 			name: "pass - valid transaction - Conditional with expiration",
 			entry: &EscrowCreate{
 				BaseTx: BaseTx{

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -88,11 +88,11 @@ func (e *EscrowFinish) Validate() (bool, error) {
 	}
 
 	// Condition and Fulfillment are Blob fields, so the hex string must encode whole bytes (even length).
-	if e.Condition != "" && (!typecheck.IsHex(e.Condition) || len(e.Condition)%2 != 0) {
+	if e.Condition != "" && !typecheck.IsHexBlob(e.Condition) {
 		return false, ErrEscrowFinishInvalidCondition
 	}
 
-	if e.Fulfillment != "" && (!typecheck.IsHex(e.Fulfillment) || len(e.Fulfillment)%2 != 0) {
+	if e.Fulfillment != "" && !typecheck.IsHexBlob(e.Fulfillment) {
 		return false, ErrEscrowFinishInvalidFulfillment
 	}
 

--- a/xrpl/transaction/escrow_finish.go
+++ b/xrpl/transaction/escrow_finish.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
@@ -84,6 +85,15 @@ func (e *EscrowFinish) Validate() (bool, error) {
 
 	if e.OfferSequence == 0 {
 		return false, ErrEscrowFinishMissingOfferSequence
+	}
+
+	// Condition and Fulfillment are Blob fields, so the hex string must encode whole bytes (even length).
+	if e.Condition != "" && (!typecheck.IsHex(e.Condition) || len(e.Condition)%2 != 0) {
+		return false, ErrEscrowFinishInvalidCondition
+	}
+
+	if e.Fulfillment != "" && (!typecheck.IsHex(e.Fulfillment) || len(e.Fulfillment)%2 != 0) {
+		return false, ErrEscrowFinishInvalidFulfillment
 	}
 
 	if e.CredentialIDs != nil && !e.CredentialIDs.IsValid() {

--- a/xrpl/transaction/escrow_finish_test.go
+++ b/xrpl/transaction/escrow_finish_test.go
@@ -136,7 +136,7 @@ func TestEscrowFinish_Validate(t *testing.T) {
 			expectedErr: ErrEscrowFinishMissingOfferSequence,
 		},
 		{
-			name: "fail - non-hex Condition",
+			name: "fail - non-hex Condition (odd length)",
 			entry: &EscrowFinish{
 				BaseTx: BaseTx{
 					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
@@ -149,7 +149,20 @@ func TestEscrowFinish_Validate(t *testing.T) {
 			expectedErr: ErrEscrowFinishInvalidCondition,
 		},
 		{
-			name: "fail - non-hex Fulfillment",
+			name: "fail - non-hex Condition (even length)",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Condition:     "GG",
+			},
+			expectedErr: ErrEscrowFinishInvalidCondition,
+		},
+		{
+			name: "fail - non-hex Fulfillment (odd length)",
 			entry: &EscrowFinish{
 				BaseTx: BaseTx{
 					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
@@ -158,6 +171,19 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
 				OfferSequence: 7,
 				Fulfillment:   "not-hex",
+			},
+			expectedErr: ErrEscrowFinishInvalidFulfillment,
+		},
+		{
+			name: "fail - non-hex Fulfillment (even length)",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Fulfillment:   "AB0Z",
 			},
 			expectedErr: ErrEscrowFinishInvalidFulfillment,
 		},

--- a/xrpl/transaction/escrow_finish_test.go
+++ b/xrpl/transaction/escrow_finish_test.go
@@ -86,10 +86,9 @@ func TestEscrowFinish_Flatten(t *testing.T) {
 
 func TestEscrowFinish_Validate(t *testing.T) {
 	tests := []struct {
-		name      string
-		entry     *EscrowFinish
-		wantValid bool
-		wantErr   bool
+		name        string
+		entry       *EscrowFinish
+		expectedErr error
 	}{
 		{
 			name: "pass - valid EscrowFinish",
@@ -101,11 +100,9 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
 				OfferSequence: 7,
 			},
-			wantValid: true,
-			wantErr:   false,
 		},
 		{
-			name: "fail - invalid EscrowFinish BaseTx",
+			name: "fail - missing TransactionType",
 			entry: &EscrowFinish{
 				BaseTx: BaseTx{
 					Account: "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
@@ -113,8 +110,7 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
 				OfferSequence: 7,
 			},
-			wantValid: false,
-			wantErr:   true,
+			expectedErr: ErrInvalidTransactionType,
 		},
 		{
 			name: "fail - invalid Owner Address",
@@ -126,8 +122,7 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				Owner:         "invalidAddress",
 				OfferSequence: 7,
 			},
-			wantValid: false,
-			wantErr:   true,
+			expectedErr: ErrEscrowFinishMissingOwner,
 		},
 		{
 			name: "fail - missing OfferSequence",
@@ -138,8 +133,59 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				},
 				Owner: "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
 			},
-			wantValid: false,
-			wantErr:   true,
+			expectedErr: ErrEscrowFinishMissingOfferSequence,
+		},
+		{
+			name: "fail - non-hex Condition",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Condition:     "not-hex",
+			},
+			expectedErr: ErrEscrowFinishInvalidCondition,
+		},
+		{
+			name: "fail - non-hex Fulfillment",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Fulfillment:   "not-hex",
+			},
+			expectedErr: ErrEscrowFinishInvalidFulfillment,
+		},
+		{
+			name: "fail - odd-length Condition",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Condition:     "F",
+			},
+			expectedErr: ErrEscrowFinishInvalidCondition,
+		},
+		{
+			name: "fail - odd-length Fulfillment",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Fulfillment:   "F",
+			},
+			expectedErr: ErrEscrowFinishInvalidFulfillment,
 		},
 		{
 			name: "fail - invalid CredentialIDs",
@@ -152,21 +198,35 @@ func TestEscrowFinish_Validate(t *testing.T) {
 				OfferSequence: 7,
 				CredentialIDs: types.CredentialIDs{"invalid"},
 			},
-			wantValid: false,
-			wantErr:   true,
+			expectedErr: ErrInvalidCredentialIDs,
+		},
+		{
+			name: "pass - valid hex Condition and Fulfillment",
+			entry: &EscrowFinish{
+				BaseTx: BaseTx{
+					Account:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+					TransactionType: EscrowFinishTx,
+				},
+				Owner:         "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD",
+				OfferSequence: 7,
+				Condition:     "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
+				Fulfillment:   "A0028000",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			valid, err := tt.entry.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("escrowFinish.Validate() error = %v, wantErr %v", err, tt.wantErr)
+
+			if tt.expectedErr != nil {
+				assert.False(t, valid)
+				assert.ErrorIs(t, err, tt.expectedErr)
 				return
 			}
-			if valid != tt.wantValid {
-				t.Errorf("escrowFinish.Validate() = %v, want %v", valid, tt.wantValid)
-			}
+
+			assert.True(t, valid)
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
# fix(xrpl/transaction): reject non-hex Condition and Fulfillment in EscrowFinish.Validate

## Description
This PR aims to make `EscrowFinish.Validate` reject `Condition` and `Fulfillment` values that are not valid hex-encoded byte sequences (non-hex characters or odd length) instead of forwarding malformed values to the binary codec and fee calculator.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- `EscrowFinish.Validate` now checks that `Condition` and `Fulfillment`, when present, are valid hex strings with an even length (since they encode `Blob` fields, the hex must represent whole bytes).
- Added sentinel errors `ErrEscrowFinishInvalidCondition` and `ErrEscrowFinishInvalidFulfillment` in `xrpl/transaction/errors.go`.
- Reworked `escrow_finish_test.go` to use an `expectedErr` table pattern with `assert.ErrorIs`, and added coverage for non-hex and odd-length `Condition`/`Fulfillment`, plus a passing case with valid hex values.
