### PR TITLE
fix(xrpl): nftoken accept offer zero value check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SignerListSet.Validate` now rejects duplicate signer accounts including classic/X-address equivalents, signer entries that reference the transaction account, zero signer weights, and correctly handles signer weight sums above `uint16`.
 - `AccountSet.Validate` now rejects invalid `TransferRate`, `ClearFlag`, and reserved `SetFlag` values before submission.
 - `AccountSet.Validate` now rejects `SetFlag == ClearFlag` (non-zero) locally, matching rippled's `temINVALID` and xrpl.js's `validateAccountSet`. Returned via the new `ErrAccountSetMutuallyExclusiveFlags` sentinel.
+- `NFTokenAcceptOffer.Validate` now rejects zero issued-currency `NFTokenBrokerFee` via canonical numeric comparison (`IssuedCurrencyAmount.IsZero`), so non-canonical zero representations like `"0.0"`, `"00"`, `"0e0"`, and `"-0"` are no longer accepted past the validator.
 
 
 #### xrpl/currency

--- a/xrpl/transaction/nftoken_accept_offer.go
+++ b/xrpl/transaction/nftoken_accept_offer.go
@@ -89,7 +89,7 @@ func (n *NFTokenAcceptOffer) Validate() (bool, error) {
 			return false, ErrNFTokenBrokerFeeZero
 		}
 	} else if issuedAmount, ok := n.NFTokenBrokerFee.(types.IssuedCurrencyAmount); ok {
-		if issuedAmount.Value == "0" {
+		if issuedAmount.IsZero() {
 			return false, ErrNFTokenBrokerFeeZero
 		}
 	}

--- a/xrpl/transaction/nftoken_accept_offer_test.go
+++ b/xrpl/transaction/nftoken_accept_offer_test.go
@@ -148,6 +148,23 @@ func TestNFTokenAcceptOffer_Validate(t *testing.T) {
 			errMessage: ErrNFTokenBrokerFeeZero,
 		},
 		{
+			name: "fail - NFTokenBrokerFee issued amount zero with non-canonical representation",
+			tx: &NFTokenAcceptOffer{
+				BaseTx: BaseTx{
+					Account:         "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+					TransactionType: NFTokenAcceptOfferTx,
+				},
+				NFTokenBrokerFee: types.IssuedCurrencyAmount{
+					Issuer:   "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+					Currency: "USD",
+					Value:    "0.00",
+				},
+			},
+			wantValid:  false,
+			wantErr:    true,
+			errMessage: ErrNFTokenBrokerFeeZero,
+		},
+		{
 			name: "pass - Valid with Sell Offer",
 			tx: &NFTokenAcceptOffer{
 				BaseTx: BaseTx{


### PR DESCRIPTION
# fix(xrpl): nftoken accept offer zero value check

## Description
This PR aims to reject issued-currency NFToken broker fees whose value is zero after canonical numeric comparison. (Mark tags that apply)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Validate issued-currency `NFTokenBrokerFee` values with `IssuedCurrencyAmount.IsZero()` so non-canonical zero values are rejected consistently.
- Add regression coverage for an issued-currency broker fee with a non-canonical zero representation.

## Notes (optional)

None.
