### PR TITLE
fix: suppress bind address TLS warnings

### DIFF
--- a/xrpl/internal/clientconfig/insecure_scheme.go
+++ b/xrpl/internal/clientconfig/insecure_scheme.go
@@ -73,5 +73,5 @@ func isLocalHost(host string) bool {
 	}
 
 	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return ip != nil && (ip.IsLoopback() || ip.IsUnspecified())
 }

--- a/xrpl/internal/clientconfig/insecure_scheme_test.go
+++ b/xrpl/internal/clientconfig/insecure_scheme_test.go
@@ -55,8 +55,18 @@ func TestWarnIfInsecureScheme(t *testing.T) {
 			wantWarning: false,
 		},
 		{
+			name:        "unspecified ipv4 http does not warn",
+			rawURL:      "http://0.0.0.0:5005/",
+			wantWarning: false,
+		},
+		{
 			name:        "ipv6 loopback does not warn",
 			rawURL:      "http://[::1]:51234/",
+			wantWarning: false,
+		},
+		{
+			name:        "unspecified ipv6 http does not warn",
+			rawURL:      "http://[::]:5005/",
 			wantWarning: false,
 		},
 		{


### PR DESCRIPTION
# fix: suppress bind address TLS warnings

## Description
This PR aims to stop insecure-scheme warnings for local unspecified bind addresses while preserving warnings for remote non-TLS endpoints.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Treat unspecified IP addresses such as `0.0.0.0` and `[::]` as local endpoints in `clientconfig.WarnIfInsecureScheme`.
- Add regression coverage for IPv4 and IPv6 unspecified-address endpoints so local bind URLs do not emit insecure-scheme warnings.

## Notes (optional)

Remote `http` and `ws` endpoints still emit the production TLS warning.
