### PR TITLE
fix(binary-codec): validate issued-currency values as XRPL String Numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### binary-codec
 
-- Exported `VerifyIOUValue` for issued-currency value validation and `IsZeroIOUValue` for XRPL String Number zero checks covering `"0"`, `"0.0"`, `"-0"`, and `"0e5"`.
+- Exported `VerifyIOUValue(value) (isZero bool, err error)` for issued-currency value validation. The `isZero` return distinguishes canonical zero forms (`"0"`, `"0.0"`, `"-0"`, `"0e5"`, etc.) so callers don't need to repeat grammar checks to handle signed zero.
+- Exported `ErrInvalidStringNumber` (sentinel error) for inputs whose characters are all legal but whose structure violates the XRPL String Number grammar (e.g. `"00.1"`, `".5"`, `"1."`, `"1e"`, `""`, `"-"`, `"+1"`). Distinct from `bigdecimal.ErrInvalidCharacter`, which signals an out-of-set character.
 
 ### Fixed
 
 #### binary-codec
 
-- `VerifyIOUValue` and `SerializeIssuedCurrencyValue` now validate issued-currency values as XRPL String Numbers, rejecting malformed float-like inputs while accepting zero token values. `SerializeIssuedCurrencyValue` emits the XRPL zero amount encoding (`0x8000000000000000`) for those zero values.
+- `VerifyIOUValue` and `SerializeIssuedCurrencyValue` now validate issued-currency values as XRPL String Numbers, rejecting malformed float-like inputs (`NaN`, `Inf`, `+Inf`, `-Inf`, hex-floats like `0x1p10`, prefixed or suffixed strings, leading-zero mantissas such as `-000.2345` or `00.5`, incomplete exponents like `1e`/`1e+`/`1e-`, and out-of-range exponents such as `1e1000`) while accepting zero token values. `SerializeIssuedCurrencyValue` emits the XRPL zero amount encoding (`0x8000000000000000`) for those zero values.
 
 #### xrpl/transaction
 
-- `IsIssuedCurrency` now validates token values as XRPL String Numbers (the same gate the binary codec applies at encode time) instead of `strconv.ParseFloat`. Inputs that previously passed `Validate` (`NaN`, `Inf`, hex-floats like `0x1p10`, prefixed or suffixed strings, leading-zero values, and out-of-range exponents such as `1e1000`) are now rejected. Zero is accepted as a valid token amount; negative amounts are still rejected.
+- `IsIssuedCurrency` now validates token values as XRPL String Numbers (the same gate the binary codec applies at encode time) instead of `strconv.ParseFloat`. Inputs that previously passed `Validate` (`NaN`, `Inf`, hex-floats like `0x1p10`, prefixed or suffixed strings, leading-zero values, and out-of-range exponents such as `1e1000`) are now rejected. Zero is accepted as a valid token amount; negative amounts are still rejected. The returned error now wraps both `ErrInvalidTokenValue` and the underlying binary-codec cause via `errors.Is`, preserving diagnostic context for callers.
 
 ## [v0.2.0-rc1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### binary-codec
+
+- Exported `VerifyIOUValue` for issued-currency value validation and `IsZeroIOUValue` for XRPL String Number zero checks covering `"0"`, `"0.0"`, `"-0"`, and `"0e5"`.
+
+### Fixed
+
+#### binary-codec
+
+- `VerifyIOUValue` and `SerializeIssuedCurrencyValue` now validate issued-currency values as XRPL String Numbers, rejecting malformed float-like inputs while accepting zero token values. `SerializeIssuedCurrencyValue` emits the XRPL zero amount encoding (`0x8000000000000000`) for those zero values.
+
+#### xrpl/transaction
+
+- `IsIssuedCurrency` now validates token values as XRPL String Numbers (the same gate the binary codec applies at encode time) instead of `strconv.ParseFloat`. Inputs that previously passed `Validate` (`NaN`, `Inf`, hex-floats like `0x1p10`, prefixed or suffixed strings, leading-zero values, and out-of-range exponents such as `1e1000`) are now rejected. Zero is accepted as a valid token amount; negative amounts are still rejected.
+
 ## [v0.2.0-rc1]
 
 ### BREAKING CHANGES

--- a/binary-codec/types/amount.go
+++ b/binary-codec/types/amount.go
@@ -265,7 +265,7 @@ func deserializeValue(data []byte) (string, error) {
 		return "", err
 	}
 	val := d.GetScaledValue()
-	err = verifyIOUValue(val)
+	err = VerifyIOUValue(val)
 	if err != nil {
 		return "", err
 	}
@@ -369,33 +369,6 @@ func verifyXrpValue(value string) error {
 	return nil
 }
 
-// verifyIOUValue validates the format of an issued currency amount value.
-func verifyIOUValue(value string) error {
-	bigDecimal, err := bigdecimal.NewBigDecimal(value)
-	if err != nil {
-		return err
-	}
-
-	if bigDecimal.UnscaledValue == "" {
-		return nil
-	}
-
-	if bigDecimal.Precision > MaxIOUPrecision {
-		return &OutOfRangeError{Type: "Precision"}
-	}
-
-	adjustedExp := bigDecimal.Scale + bigDecimal.Precision - 16
-
-	if adjustedExp < MinIOUExponent {
-		return &OutOfRangeError{Type: "Exponent"}
-	}
-	if adjustedExp > MaxIOUExponent {
-		return &OutOfRangeError{Type: "Exponent"}
-	}
-
-	return nil
-}
-
 // verifyMPTValue validates the format of an MPT amount value.
 // MPT values must be integers (no decimal point) and must not have the high bit set.
 func verifyMPTValue(value string) error {
@@ -456,19 +429,15 @@ func serializeXrpAmount(value string) ([]byte, error) {
 
 // SerializeIssuedCurrencyValue serializes the value field of an issued currency amount to its bytes representation.
 func SerializeIssuedCurrencyValue(value string) ([]byte, error) {
-	if err := verifyIOUValue(value); err != nil {
-		return nil, err
-	}
-
-	bigDecimal, err := bigdecimal.NewBigDecimal(value)
+	bigDecimal, isZero, err := parseIOUValue(value)
 	if err != nil {
 		return nil, err
 	}
 
-	if bigDecimal.UnscaledValue == "" {
+	if isZero {
 		zeroAmount := make([]byte, 8)
 		binary.BigEndian.PutUint64(zeroAmount, uint64(ZeroCurrencyAmountHex))
-		return zeroAmount, nil // if the value is zero, then return the zero currency amount hex
+		return zeroAmount, nil
 	}
 
 	mantissa, err := strconv.ParseUint(bigDecimal.UnscaledValue, 10, 64) // convert the unscaled value to an unsigned integer
@@ -576,15 +545,7 @@ func serializeIssuedCurrencyCodeChars(currency string) ([]byte, error) {
 // The currency code can be 3 allowed string characters, or 20 bytes of hex in standard currency format (e.g. with "00" prefix)
 // or non-standard currency format (e.g. without "00" prefix)
 func serializeIssuedCurrencyAmount(value, currency, issuer string) ([]byte, error) {
-	var valBytes []byte
-	var err error
-	if value == "0" {
-		valBytes = make([]byte, 8)
-		binary.BigEndian.PutUint64(valBytes, uint64(ZeroCurrencyAmountHex))
-	} else {
-		valBytes, err = SerializeIssuedCurrencyValue(value) // serialize the value
-	}
-
+	valBytes, err := SerializeIssuedCurrencyValue(value) // serialize the value
 	if err != nil {
 		return nil, err
 	}

--- a/binary-codec/types/amount.go
+++ b/binary-codec/types/amount.go
@@ -265,8 +265,7 @@ func deserializeValue(data []byte) (string, error) {
 		return "", err
 	}
 	val := d.GetScaledValue()
-	err = VerifyIOUValue(val)
-	if err != nil {
+	if _, err = VerifyIOUValue(val); err != nil {
 		return "", err
 	}
 	return val, nil

--- a/binary-codec/types/amount_test.go
+++ b/binary-codec/types/amount_test.go
@@ -72,29 +72,67 @@ func TestVerifyXrpValue(t *testing.T) {
 
 func TestVerifyIOUValue(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		expErr error
+		name      string
+		input     string
+		expIsZero bool
+		expErr    error
 	}{
 		{
-			name:   "pass - valid iou value with decimal",
-			input:  "3.6",
-			expErr: nil,
+			name:  "pass - valid iou value with decimal",
+			input: "3.6",
 		},
 		{
-			name:   "pass - valid iou value - leading zero after decimal",
-			input:  "345.023857",
-			expErr: nil,
+			name:  "pass - valid iou value - leading zero after decimal",
+			input: "345.023857",
 		},
 		{
-			name:   "pass - valid iou value - negative value",
-			input:  "-0.2345",
-			expErr: nil,
+			name:  "pass - valid iou value - negative value",
+			input: "-0.2345",
+		},
+		{
+			name:      "pass - canonical zero",
+			input:     "0",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - zero in decimal form",
+			input:     "0.0",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - signed zero",
+			input:     "-0",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - signed zero in decimal form",
+			input:     "-0.0",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - zero with exponent",
+			input:     "0e5",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - signed zero with exponent",
+			input:     "-0e5",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - signed zero with fractional zeros",
+			input:     "-0.00",
+			expIsZero: true,
+		},
+		{
+			name:      "pass - zero with many fractional zeros",
+			input:     "0.00000000000000000000000",
+			expIsZero: true,
 		},
 		{
 			name:   "fail - invalid iou value - leading zeros before decimal",
 			input:  "-000.2345",
-			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+			expErr: ErrInvalidStringNumber,
 		},
 		{
 			name:   "fail - invalid iou value - leading space",
@@ -117,6 +155,81 @@ func TestVerifyIOUValue(t *testing.T) {
 			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
 		},
 		{
+			name:   "fail - NaN literal",
+			input:  "NaN",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - Inf literal",
+			input:  "Inf",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - +Inf literal",
+			input:  "+Inf",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - -Inf literal",
+			input:  "-Inf",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - hex float",
+			input:  "0x1p10",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - empty value",
+			input:  "",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - bare minus sign",
+			input:  "-",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - leading plus sign",
+			input:  "+1",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - trailing decimal point",
+			input:  "1.",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - leading decimal point",
+			input:  ".5",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - missing exponent digits",
+			input:  "1e",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - missing exponent digits with plus sign",
+			input:  "1e+",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - missing exponent digits with minus sign",
+			input:  "1e-",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - missing mantissa with exponent",
+			input:  "-e5",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
+			name:   "fail - bare signed decimal point",
+			input:  "-.",
+			expErr: ErrInvalidStringNumber,
+		},
+		{
 			name:   "fail - invalid iou value - out of range precision",
 			input:  "0.000000000000000000007265675687436598345739475",
 			expErr: &OutOfRangeError{Type: "Precision"},
@@ -135,15 +248,22 @@ func TestVerifyIOUValue(t *testing.T) {
 			input:  "1e-113",
 			expErr: &OutOfRangeError{Type: "Exponent"},
 		},
+		{
+			name:   "fail - exponent far out of range",
+			input:  "1e1000",
+			expErr: &OutOfRangeError{Type: "Exponent"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := VerifyIOUValue(tt.input)
+			isZero, err := VerifyIOUValue(tt.input)
 			if tt.expErr != nil {
 				require.Error(t, err)
 				require.EqualError(t, tt.expErr, err.Error())
+				require.False(t, isZero)
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, tt.expIsZero, isZero)
 			}
 		})
 	}
@@ -358,6 +478,12 @@ func TestSerializeIssuedCurrencyValue(t *testing.T) {
 			input:       "9999999999999999e80",
 			expected:    []byte{0xec, 0x63, 0x86, 0xf2, 0x6f, 0xc0, 0xff, 0xff},
 			expectedErr: nil,
+		},
+		{
+			name:        "fail - non-canonical leading-zero mantissa",
+			input:       "00.5",
+			expected:    nil,
+			expectedErr: ErrInvalidStringNumber,
 		},
 	}
 	for _, tt := range tests {

--- a/binary-codec/types/amount_test.go
+++ b/binary-codec/types/amount_test.go
@@ -87,9 +87,34 @@ func TestVerifyIOUValue(t *testing.T) {
 			expErr: nil,
 		},
 		{
-			name:   "pass - valid iou value - negative value & multiple leading zeros before decimal",
-			input:  "-000.2345",
+			name:   "pass - valid iou value - negative value",
+			input:  "-0.2345",
 			expErr: nil,
+		},
+		{
+			name:   "fail - invalid iou value - leading zeros before decimal",
+			input:  "-000.2345",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - invalid iou value - leading space",
+			input:  " 1",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - invalid iou value - trailing characters",
+			input:  "1abc",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - invalid iou value - prefixed characters",
+			input:  "abc1",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
+		},
+		{
+			name:   "fail - invalid iou value - comma",
+			input:  "1,2",
+			expErr: bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters},
 		},
 		{
 			name:   "fail - invalid iou value - out of range precision",
@@ -113,8 +138,9 @@ func TestVerifyIOUValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := verifyIOUValue(tt.input)
+			err := VerifyIOUValue(tt.input)
 			if tt.expErr != nil {
+				require.Error(t, err)
 				require.EqualError(t, tt.expErr, err.Error())
 			} else {
 				require.NoError(t, err)
@@ -262,10 +288,28 @@ func TestSerializeIssuedCurrencyValue(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "fail - invalid zero value",
+			name:        "pass - canonical zero value",
 			input:       "0",
-			expected:    nil,
-			expectedErr: bigdecimal.ErrInvalidZeroValue,
+			expected:    []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - canonical zero value - decimal form",
+			input:       "0.0",
+			expected:    []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - canonical zero value - signed",
+			input:       "-0",
+			expected:    []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedErr: nil,
+		},
+		{
+			name:        "pass - canonical zero value - exponent form",
+			input:       "0e5",
+			expected:    []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expectedErr: nil,
 		},
 		{
 			name:        "pass - valid value - 2",

--- a/binary-codec/types/errors.go
+++ b/binary-codec/types/errors.go
@@ -20,4 +20,8 @@ var (
 	ErrUInt32OutOfRange = errors.New("value out of uint32 range (0-4294967295)")
 	// ErrInt32OutOfRange is returned when a value is outside the int32 range (-2147483648 to 2147483647).
 	ErrInt32OutOfRange = errors.New("value out of int32 range (-2147483648 to 2147483647)")
+	// ErrInvalidStringNumber is returned when a value contains only legal XRPL String Number characters
+	// but does not match the grammar (e.g. "00.1", ".5", "1.", "1e", "", "-", "+1"). Distinct from
+	// bigdecimal.ErrInvalidCharacter, which signals an out-of-set character.
+	ErrInvalidStringNumber = errors.New("value is not a valid XRPL String Number")
 )

--- a/binary-codec/types/iou_value.go
+++ b/binary-codec/types/iou_value.go
@@ -1,0 +1,143 @@
+package types
+
+import (
+	"strings"
+
+	bigdecimal "github.com/Peersyst/xrpl-go/pkg/big-decimal"
+)
+
+// XRPL token (IOU) amounts are decimal strings encoded as a sign plus
+// mantissa * 10^exponent. Non-zero values must fit in 16 significant digits
+// once normalized, with a canonical exponent between -96 and 80. Zero is
+// encoded separately as ZeroCurrencyAmountHex (0x8000000000000000).
+// Reference: https://xrpl.org/docs/references/protocol/binary-format#token-amount-format
+
+// IsZeroIOUValue reports whether value is a valid XRPL String Number whose
+// numeric value is zero.
+func IsZeroIOUValue(value string) bool {
+	return isXRPLStringNumber(value) && isZeroMantissa(value)
+}
+
+// VerifyIOUValue validates that value is an XRPL String Number within the IOU
+// precision and exponent bounds. A numeric zero (for example "0", "0.0",
+// "-0", or "0e5") is valid per the XRPL protocol.
+func VerifyIOUValue(value string) error {
+	_, _, err := parseIOUValue(value)
+	return err
+}
+
+// parseIOUValue validates value once and returns its decoded form. For a
+// numeric zero it returns (nil, true, nil); the caller must check isZero
+// before dereferencing bigDecimal. It is the single parse shared by
+// VerifyIOUValue and SerializeIssuedCurrencyValue.
+func parseIOUValue(value string) (bigDecimal *bigdecimal.BigDecimal, isZero bool, err error) {
+	if !isXRPLStringNumber(value) {
+		return nil, false, bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters}
+	}
+	if isZeroMantissa(value) {
+		return nil, true, nil
+	}
+
+	bigDecimal, err = bigdecimal.NewBigDecimal(value)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if bigDecimal.Precision > MaxIOUPrecision {
+		return nil, false, &OutOfRangeError{Type: "Precision"}
+	}
+
+	// XRPL stores a token amount as a mantissa normalized to exactly
+	// MaxIOUPrecision (16) significant digits times 10^exponent. BigDecimal
+	// holds the value as UnscaledValue (Precision digits) * 10^Scale, so
+	// renormalizing to a 16-digit mantissa shifts the exponent to
+	// Scale + Precision - MaxIOUPrecision. That canonical exponent must fall
+	// within the protocol's [MinIOUExponent, MaxIOUExponent] range.
+	canonicalExp := bigDecimal.Scale + bigDecimal.Precision - MaxIOUPrecision
+
+	if canonicalExp < MinIOUExponent || canonicalExp > MaxIOUExponent {
+		return nil, false, &OutOfRangeError{Type: "Exponent"}
+	}
+
+	return bigDecimal, false, nil
+}
+
+// isZeroMantissa reports whether value's mantissa is all zeros. It assumes
+// value has already passed isXRPLStringNumber, so the mantissa is non-empty.
+func isZeroMantissa(value string) bool {
+	mantissa, _, _ := splitXRPLStringNumber(value)
+	for _, r := range mantissa {
+		if r != '.' && r != '0' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isXRPLStringNumber reports whether value matches the XRPL String Number
+// grammar: an optional leading '-', a non-zero-prefaced decimal mantissa
+// (e.g. "0.1" ok, "00.1" not), and an optional "e"/"E" integer exponent.
+func isXRPLStringNumber(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	mantissa, exponent, hasExponent := splitXRPLStringNumber(value)
+	if !isValidXRPLMantissa(mantissa) {
+		return false
+	}
+
+	return !hasExponent || isValidXRPLExponent(exponent)
+}
+
+func splitXRPLStringNumber(value string) (mantissa, exponent string, hasExponent bool) {
+	value = strings.TrimPrefix(value, "-")
+	if value == "" {
+		return "", "", false
+	}
+
+	expIndex := strings.IndexAny(value, "eE")
+	if expIndex == -1 {
+		return value, "", false
+	}
+
+	return value[:expIndex], value[expIndex+1:], true
+}
+
+func isValidXRPLMantissa(mantissa string) bool {
+	whole, fraction, hasDecimal := strings.Cut(mantissa, ".")
+
+	if whole == "" || !isAllDecimalDigits(whole) {
+		return false
+	}
+
+	// XRPL String Numbers are non-zero-prefaced: "0.1" is valid, "00.1" is not.
+	if len(whole) > 1 && whole[0] == '0' {
+		return false
+	}
+
+	if hasDecimal {
+		return fraction != "" && isAllDecimalDigits(fraction)
+	}
+
+	return true
+}
+
+func isValidXRPLExponent(exponent string) bool {
+	if len(exponent) > 0 && (exponent[0] == '+' || exponent[0] == '-') {
+		exponent = exponent[1:]
+	}
+
+	return exponent != "" && isAllDecimalDigits(exponent)
+}
+
+func isAllDecimalDigits(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/binary-codec/types/iou_value.go
+++ b/binary-codec/types/iou_value.go
@@ -12,18 +12,20 @@ import (
 // encoded separately as ZeroCurrencyAmountHex (0x8000000000000000).
 // Reference: https://xrpl.org/docs/references/protocol/binary-format#token-amount-format
 
-// IsZeroIOUValue reports whether value is a valid XRPL String Number whose
-// numeric value is zero.
-func IsZeroIOUValue(value string) bool {
-	return isXRPLStringNumber(value) && isZeroMantissa(value)
-}
+// xrplStringNumberAllowedChars is the full set of characters that can legally
+// appear anywhere in an XRPL String Number. '+' is only meaningful as an
+// exponent sign, but is included here so the character-set check only fires
+// for inputs that contain truly out-of-set characters.
+const xrplStringNumberAllowedChars = "0123456789.-+eE"
 
 // VerifyIOUValue validates that value is an XRPL String Number within the IOU
 // precision and exponent bounds. A numeric zero (for example "0", "0.0",
-// "-0", or "0e5") is valid per the XRPL protocol.
-func VerifyIOUValue(value string) error {
-	_, _, err := parseIOUValue(value)
-	return err
+// "-0", or "0e5") is valid per the XRPL protocol. The first return reports
+// whether the validated value is numerically zero, so callers do not need to
+// repeat the grammar check to distinguish signed zero from negative non-zero.
+func VerifyIOUValue(value string) (bool, error) {
+	_, isZero, err := parseIOUValue(value)
+	return isZero, err
 }
 
 // parseIOUValue validates value once and returns its decoded form. For a
@@ -32,7 +34,10 @@ func VerifyIOUValue(value string) error {
 // VerifyIOUValue and SerializeIssuedCurrencyValue.
 func parseIOUValue(value string) (bigDecimal *bigdecimal.BigDecimal, isZero bool, err error) {
 	if !isXRPLStringNumber(value) {
-		return nil, false, bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters}
+		if !hasOnlyXRPLStringNumberChars(value) {
+			return nil, false, bigdecimal.ErrInvalidCharacter{Allowed: bigdecimal.AllowedCharacters}
+		}
+		return nil, false, ErrInvalidStringNumber
 	}
 	if isZeroMantissa(value) {
 		return nil, true, nil
@@ -135,6 +140,16 @@ func isValidXRPLExponent(exponent string) bool {
 func isAllDecimalDigits(value string) bool {
 	for _, r := range value {
 		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hasOnlyXRPLStringNumberChars(value string) bool {
+	for _, r := range value {
+		if !strings.ContainsRune(xrplStringNumberAllowedChars, r) {
 			return false
 		}
 	}

--- a/xrpl/transaction/payment_test.go
+++ b/xrpl/transaction/payment_test.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -473,8 +474,8 @@ func TestPayment_Validate(t *testing.T) {
 			if valid != tt.wantValid {
 				t.Errorf("expected valid to be %v, got %v", tt.wantValid, valid)
 			}
-			if (err != nil) && err.Error() != tt.expectedErr.Error() {
-				t.Errorf("Validate() got error message: %v, want error message: %v", err, tt.expectedErr)
+			if err != nil && !errors.Is(err, tt.expectedErr) {
+				t.Errorf("Validate() got error: %v, want error wrapping: %v", err, tt.expectedErr)
 				return
 			}
 			if (err != nil) != tt.wantErr {

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -139,11 +140,12 @@ func IsIssuedCurrency(input types.CurrencyAmount) (bool, error) {
 
 	// Check that the value is an XRPL String Number (same gate the binary codec
 	// applies at encode time), then reject negative amounts.
-	// Zero is a valid token amount, "-0" is zero, so it is not negative.
-	if err := bctypes.VerifyIOUValue(issuedAmount.Value); err != nil {
-		return false, ErrInvalidTokenValue
+	// Zero is a valid token amount; "-0" parses as zero and is not treated as negative.
+	isZero, err := bctypes.VerifyIOUValue(issuedAmount.Value)
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", ErrInvalidTokenValue, err)
 	}
-	if strings.HasPrefix(issuedAmount.Value, "-") && !bctypes.IsZeroIOUValue(issuedAmount.Value) {
+	if strings.HasPrefix(issuedAmount.Value, "-") && !isZero {
 		return false, ErrInvalidTokenValue
 	}
 

--- a/xrpl/transaction/validations_xrpl_objects.go
+++ b/xrpl/transaction/validations_xrpl_objects.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	addresscodec "github.com/Peersyst/xrpl-go/address-codec"
+	bctypes "github.com/Peersyst/xrpl-go/binary-codec/types"
 	maputils "github.com/Peersyst/xrpl-go/pkg/map_utils"
 	"github.com/Peersyst/xrpl-go/pkg/typecheck"
 	"github.com/Peersyst/xrpl-go/xrpl/currency"
@@ -136,9 +137,13 @@ func IsIssuedCurrency(input types.CurrencyAmount) (bool, error) {
 		return false, ErrInvalidIssuer
 	}
 
-	// Check if the value is a valid positive number
-	value, err := strconv.ParseFloat(issuedAmount.Value, 64)
-	if err != nil || value < 0 {
+	// Check that the value is an XRPL String Number (same gate the binary codec
+	// applies at encode time), then reject negative amounts.
+	// Zero is a valid token amount, "-0" is zero, so it is not negative.
+	if err := bctypes.VerifyIOUValue(issuedAmount.Value); err != nil {
+		return false, ErrInvalidTokenValue
+	}
+	if strings.HasPrefix(issuedAmount.Value, "-") && !bctypes.IsZeroIOUValue(issuedAmount.Value) {
 		return false, ErrInvalidTokenValue
 	}
 

--- a/xrpl/transaction/validations_xrpl_objects_test.go
+++ b/xrpl/transaction/validations_xrpl_objects_test.go
@@ -189,6 +189,15 @@ func TestIsIssuedCurrency(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "pass - valid IssuedCurrency object with signed zero value",
+			input: types.IssuedCurrencyAmount{
+				Value:    "-0",
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+			},
+			expected: true,
+		},
+		{
 			name:     "fail - invalid IssuedCurrency object",
 			input:    types.XRPCurrencyAmount(100), // should be non XRP
 			expected: false,
@@ -247,6 +256,15 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Issuer:   "invalid",
 				Currency: "USD",
 				Value:    "100",
+			},
+			expected: false,
+		},
+		{
+			name: "fail - issuedCurrency object with leading-space negative value",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    " -1",
 			},
 			expected: false,
 		},

--- a/xrpl/transaction/validations_xrpl_objects_test.go
+++ b/xrpl/transaction/validations_xrpl_objects_test.go
@@ -3,8 +3,10 @@ package transaction
 import (
 	"testing"
 
+	bctypes "github.com/Peersyst/xrpl-go/binary-codec/types"
 	ledger "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsSigner(t *testing.T) {
@@ -174,10 +176,13 @@ func TestIsAmount(t *testing.T) {
 }
 
 func TestIsIssuedCurrency(t *testing.T) {
+	// IsIssuedCurrency returns (true, nil) on success and (false, err) on every
+	// failure, so a non-nil expectedErr both selects the failure path and locks
+	// in which sentinel must appear in the error chain.
 	tests := []struct {
-		name     string
-		input    types.CurrencyAmount
-		expected bool
+		name        string
+		input       types.CurrencyAmount
+		expectedErr error
 	}{
 		{
 			name: "pass - valid IssuedCurrency object",
@@ -186,7 +191,6 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
 				Currency: "USD",
 			},
-			expected: true,
 		},
 		{
 			name: "pass - valid IssuedCurrency object with signed zero value",
@@ -195,33 +199,56 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
 				Currency: "USD",
 			},
-			expected: true,
 		},
 		{
-			name:     "fail - invalid IssuedCurrency object",
-			input:    types.XRPCurrencyAmount(100), // should be non XRP
-			expected: false,
+			name: "pass - valid IssuedCurrency object with zero value 0.0",
+			input: types.IssuedCurrencyAmount{
+				Value:    "0.0",
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+			},
+		},
+		{
+			name: "pass - valid IssuedCurrency object with signed zero value -0.0",
+			input: types.IssuedCurrencyAmount{
+				Value:    "-0.0",
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+			},
+		},
+		{
+			name: "pass - valid IssuedCurrency object with zero scientific value 0e5",
+			input: types.IssuedCurrencyAmount{
+				Value:    "0e5",
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+			},
+		},
+		{
+			name:        "fail - invalid IssuedCurrency object",
+			input:       types.XRPCurrencyAmount(100), // should be non XRP
+			expectedErr: ErrInvalidTokenType,
 		},
 		{
 			name: "fail - issuedCurrency object with missing currency and issuer fields",
 			input: types.IssuedCurrencyAmount{
 				Value: "100",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenFields,
 		},
 		{
 			name: "fail - issuedCurrency object with missing issuer and value fields",
 			input: types.IssuedCurrencyAmount{
 				Currency: "USD",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenFields,
 		},
 		{
 			name: "fail - issuedCurrency object with missing currency and value fields",
 			input: types.IssuedCurrencyAmount{
 				Issuer: "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenFields,
 		},
 		{
 			name: "fail - issuedCurrency object with empty currency",
@@ -230,7 +257,7 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Currency: "   ",
 				Value:    "100",
 			},
-			expected: false,
+			expectedErr: ErrMissingTokenCurrency,
 		},
 		{
 			name: "fail - issuedCurrency object with XRP currency",
@@ -239,7 +266,7 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Currency: "XRp", // will be uppercased during validation
 				Value:    "100",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenCurrency,
 		},
 		{
 			name: "fail - issuedCurrency object with empty value",
@@ -248,7 +275,7 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Currency: "USD",
 				Value:    "  ",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenValue,
 		},
 		{
 			name: "fail - issuedCurrency object with invalid issuer",
@@ -257,7 +284,7 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Currency: "USD",
 				Value:    "100",
 			},
-			expected: false,
+			expectedErr: ErrInvalidIssuer,
 		},
 		{
 			name: "fail - issuedCurrency object with leading-space negative value",
@@ -266,20 +293,106 @@ func TestIsIssuedCurrency(t *testing.T) {
 				Currency: "USD",
 				Value:    " -1",
 			},
-			expected: false,
+			expectedErr: ErrInvalidTokenValue,
 		},
 		{
-			name:     "fail - empty object",
-			input:    types.IssuedCurrencyAmount{},
-			expected: false,
+			name: "fail - issuedCurrency object with negative integer value",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "-1",
+			},
+			expectedErr: ErrInvalidTokenValue,
+		},
+		{
+			name: "fail - issuedCurrency object with negative decimal value",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "-0.5",
+			},
+			expectedErr: ErrInvalidTokenValue,
+		},
+		{
+			name: "fail - issuedCurrency object with negative scientific value",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "-1e2",
+			},
+			expectedErr: ErrInvalidTokenValue,
+		},
+		{
+			name: "fail - issuedCurrency object with leading-plus sign",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "+1",
+			},
+			expectedErr: bctypes.ErrInvalidStringNumber,
+		},
+		{
+			name: "fail - issuedCurrency object with leading-zero mantissa",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "00.1",
+			},
+			expectedErr: bctypes.ErrInvalidStringNumber,
+		},
+		{
+			name: "fail - issuedCurrency object with multiple decimal points",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "1.2.3",
+			},
+			expectedErr: bctypes.ErrInvalidStringNumber,
+		},
+		{
+			name: "fail - issuedCurrency object with bare decimal point",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    ".",
+			},
+			expectedErr: bctypes.ErrInvalidStringNumber,
+		},
+		{
+			name: "fail - issuedCurrency object with exponent out of range",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "1e500",
+			},
+			expectedErr: ErrInvalidTokenValue,
+		},
+		{
+			name: "fail - issuedCurrency object with precision overflow (17 digits)",
+			input: types.IssuedCurrencyAmount{
+				Issuer:   "r4ES5Mmnz4HGbu2asdicuECBaBWo4knhXW",
+				Currency: "USD",
+				Value:    "12345678901234567",
+			},
+			expectedErr: ErrInvalidTokenValue,
+		},
+		{
+			name:        "fail - empty object",
+			input:       types.IssuedCurrencyAmount{},
+			expectedErr: ErrInvalidTokenFields,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if ok, err := IsIssuedCurrency(tt.input); ok != tt.expected {
-				t.Errorf("Expected IsIssuedCurrency to return %v, but got %v with error: %v", tt.expected, ok, err)
+			ok, err := IsIssuedCurrency(tt.input)
+			if err != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.False(t, ok)
+				return
 			}
+			require.NoError(t, tt.expectedErr)
+			require.True(t, ok)
 		})
 	}
 }


### PR DESCRIPTION
# fix(binary-codec): validate issued-currency values as XRPL String Numbers

## Description
This PR aims to validate issued-currency amount values with XRPL String Number rules in binary-codec serialization and transaction object validation.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Export `VerifyIOUValue` and add `IsZeroIOUValue` so issued-currency value validation is shared between encoding and transaction validation.
- Validate IOU values as XRPL String Numbers before binary serialization, rejecting malformed float-like inputs, leading-zero mantissas, invalid characters, and out-of-range precision or exponent values.
- Preserve valid token zero handling by accepting zero forms such as `0`, `0.0`, `-0`, and `0e5`, then encoding them as the XRPL zero amount value.
- Use the binary-codec IOU validation path from `IsIssuedCurrency`, while still rejecting negative non-zero token values.
- Add binary-codec and transaction validation coverage for malformed values, signed zero, and canonical zero serialization.

## Notes (optional)

Transaction validation now rejects malformed issued-currency values that could previously pass through `strconv.ParseFloat`, such as `NaN`, `Inf`, hex-float syntax, prefixed or suffixed strings, leading-zero values, and out-of-range exponents.
