### PR TITLE
fix(xrpl): preserve DeletedNode PreviousFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.19]
+
+### Fixed
+
+#### xrpl
+
+- Preserved `DeletedNode.PreviousFields` in transaction metadata so balance changes can be decoded for deleted ledger entries.
+
 ## [v0.1.18]
 
 ### Added

--- a/docs/changelog/v0.1.x/980_v0_1_19.md
+++ b/docs/changelog/v0.1.x/980_v0_1_19.md
@@ -1,0 +1,9 @@
+---
+title: v0.1.19
+---
+
+### Fixed
+
+#### xrpl
+
+- Preserved `DeletedNode.PreviousFields` in transaction metadata so balance changes can be decoded for deleted ledger entries.

--- a/xrpl/transaction/balance_changes.go
+++ b/xrpl/transaction/balance_changes.go
@@ -68,6 +68,7 @@ func newNormalizedNode(node AffectedNode) *normalizedNode {
 			LedgerEntryType: node.DeletedNode.LedgerEntryType,
 			LedgerIndex:     node.DeletedNode.LedgerIndex,
 			FinalFields:     node.DeletedNode.FinalFields,
+			PreviousFields:  node.DeletedNode.PreviousFields,
 		}
 	default:
 		return nil

--- a/xrpl/transaction/balance_changes_test.go
+++ b/xrpl/transaction/balance_changes_test.go
@@ -14,6 +14,57 @@ func TestGetBalanceChanges(t *testing.T) {
 		expected []AccountBalanceChanges
 	}{
 		{
+			name: "pass - account delete",
+			meta: &TxObjMeta{
+				AffectedNodes: []AffectedNode{
+					{
+						ModifiedNode: &ModifiedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+								"Balance": "1039483986",
+							},
+							LedgerEntryType: ledger.AccountRootEntry,
+							PreviousFields: map[string]any{
+								"Balance": "1026818191",
+							},
+						},
+					},
+					{
+						DeletedNode: &DeletedNode{
+							FinalFields: ledger.FlatLedgerObject{
+								"Account": "rf2c74F1Z2BrvL1dV7WMHYo6Jyaw446Fre",
+								"Balance": "0",
+							},
+							LedgerEntryType: ledger.AccountRootEntry,
+							PreviousFields: map[string]any{
+								"Balance": "14665795",
+							},
+						},
+					},
+				},
+			},
+			expected: []AccountBalanceChanges{
+				{
+					Account: "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					Balances: []Balance{
+						{
+							Value:    "12.665795",
+							Currency: "XRP",
+						},
+					},
+				},
+				{
+					Account: "rf2c74F1Z2BrvL1dV7WMHYo6Jyaw446Fre",
+					Balances: []Balance{
+						{
+							Value:    "-14.665795",
+							Currency: "XRP",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "pass - USD payment to account with no USD",
 			meta: &TxObjMeta{
 				AffectedNodes: []AffectedNode{

--- a/xrpl/transaction/metadata.go
+++ b/xrpl/transaction/metadata.go
@@ -57,4 +57,5 @@ type DeletedNode struct {
 	LedgerEntryType ledger.EntryType        `json:"LedgerEntryType,omitempty"`
 	LedgerIndex     string                  `json:"LedgerIndex,omitempty"`
 	FinalFields     ledger.FlatLedgerObject `json:"FinalFields,omitempty"`
+	PreviousFields  ledger.FlatLedgerObject `json:"PreviousFields,omitempty"`
 }


### PR DESCRIPTION
# fix(xrpl): preserve deleted node previous fields

## Description
This PR aims to preserve `PreviousFields` on `DeletedNode` entries.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Preserve `PreviousFields` on `DeletedNode` entries.