### PR TITLE
fix(binary-codec): align confidential MPT wire fields

### DIFF
--- a/binary-codec/codec_test.go
+++ b/binary-codec/codec_test.go
@@ -488,6 +488,7 @@ func TestMPTUInt64FieldsUseDecimalJSON(t *testing.T) {
 		{field: "OutstandingAmount", header: "3019"},
 		{field: "MPTAmount", header: "301A"},
 		{field: "LockedAmount", header: "301D"},
+		{field: "ConfidentialOutstandingAmount", header: "3020"},
 	}
 
 	for _, tt := range tests {
@@ -499,6 +500,52 @@ func TestMPTUInt64FieldsUseDecimalJSON(t *testing.T) {
 			decoded, err := Decode(encoded)
 			require.NoError(t, err)
 			require.Equal(t, "10000", decoded[tt.field])
+		})
+	}
+}
+
+func TestConfidentialMPTWireFields(t *testing.T) {
+	const (
+		blindingFactor    = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
+		amountCommitment  = "021111111111111111111111111111111111111111111111111111111111111111"
+		balanceCommitment = "032222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	tests := []struct {
+		name     string
+		field    string
+		value    string
+		expected string
+	}{
+		{
+			name:     "BlindingFactor is a fixed Hash256 field 40",
+			field:    "BlindingFactor",
+			value:    blindingFactor,
+			expected: "5028" + blindingFactor,
+		},
+		{
+			name:     "AmountCommitment is a variable-length Blob field 45",
+			field:    "AmountCommitment",
+			value:    amountCommitment,
+			expected: "702D21" + amountCommitment,
+		},
+		{
+			name:     "BalanceCommitment is a variable-length Blob field 46",
+			field:    "BalanceCommitment",
+			value:    balanceCommitment,
+			expected: "702E21" + balanceCommitment,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := Encode(map[string]any{tt.field: tt.value})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, encoded)
+
+			decoded, err := Decode(encoded)
+			require.NoError(t, err)
+			require.Equal(t, tt.value, decoded[tt.field])
 		})
 	}
 }

--- a/binary-codec/definitions/definitions.json
+++ b/binary-codec/definitions/definitions.json
@@ -2283,9 +2283,9 @@
       {
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": true,
-        "nth": 45,
-        "type": "Blob"
+        "isVLEncoded": false,
+        "nth": 40,
+        "type": "Hash256"
       }
     ],
     [
@@ -2294,7 +2294,7 @@
         "isSerialized": true,
         "isSigningField": true,
         "isVLEncoded": true,
-        "nth": 46,
+        "nth": 45,
         "type": "Blob"
       }
     ],
@@ -2304,7 +2304,7 @@
         "isSerialized": true,
         "isSigningField": true,
         "isVLEncoded": true,
-        "nth": 47,
+        "nth": 46,
         "type": "Blob"
       }
     ],
@@ -6890,6 +6890,5 @@
     "Validation": 10003,
     "Vector256": 19,
     "XChainBridge": 25
-  },
-  "hash": "0F2AE080CAED01060B32CCFA9B8BEA653176490D9FB3513FD3CB6CD475BE09C8"
+  }
 }

--- a/binary-codec/definitions/definitions.json
+++ b/binary-codec/definitions/definitions.json
@@ -4481,6 +4481,30 @@
         "optionality": 1
       },
       {
+        "name": "ConfidentialBalanceInbox",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialBalanceSpending",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialBalanceVersion",
+        "optionality": 2
+      },
+      {
+        "name": "IssuerEncryptedBalance",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptedBalance",
+        "optionality": 1
+      },
+      {
+        "name": "HolderEncryptionKey",
+        "optionality": 1
+      },
+      {
         "name": "OwnerNode",
         "optionality": 0
       },
@@ -4549,6 +4573,18 @@
       {
         "name": "ReferenceHolding",
         "optionality": 1
+      },
+      {
+        "name": "IssuerEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialOutstandingAmount",
+        "optionality": 2
       }
     ],
     "NFTokenOffer": [
@@ -5463,6 +5499,144 @@
         "optionality": 1
       }
     ],
+    "ConfidentialMPTClawback": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTConvert": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "HolderEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "HolderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "BlindingFactor",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 1
+      }
+    ],
+    "ConfidentialMPTConvertBack": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "HolderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "BlindingFactor",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      },
+      {
+        "name": "BalanceCommitment",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTMergeInbox": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTSend": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "SenderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      },
+      {
+        "name": "AmountCommitment",
+        "optionality": 0
+      },
+      {
+        "name": "BalanceCommitment",
+        "optionality": 0
+      },
+      {
+        "name": "CredentialIDs",
+        "optionality": 1
+      }
+    ],
     "CredentialAccept": [
       {
         "name": "Issuer",
@@ -5861,6 +6035,14 @@
       },
       {
         "name": "ImmutableFlags",
+        "optionality": 1
+      },
+      {
+        "name": "IssuerEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptionKey",
         "optionality": 1
       }
     ],

--- a/binary-codec/definitions/definitions_test.go
+++ b/binary-codec/definitions/definitions_test.go
@@ -63,6 +63,24 @@ func TestLoadDefinitions(t *testing.T) {
 			header:  &FieldHeader{TypeCode: 21, FieldCode: 4},
 			ordinal: 1376260,
 		},
+		{
+			name:    "BlindingFactor",
+			info:    &FieldInfo{Nth: 40, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "Hash256"},
+			header:  &FieldHeader{TypeCode: 5, FieldCode: 40},
+			ordinal: 327720,
+		},
+		{
+			name:    "AmountCommitment",
+			info:    &FieldInfo{Nth: 45, IsVLEncoded: true, IsSerialized: true, IsSigningField: true, Type: "Blob"},
+			header:  &FieldHeader{TypeCode: 7, FieldCode: 45},
+			ordinal: 458797,
+		},
+		{
+			name:    "BalanceCommitment",
+			info:    &FieldInfo{Nth: 46, IsVLEncoded: true, IsSerialized: true, IsSigningField: true, Type: "Blob"},
+			header:  &FieldHeader{TypeCode: 7, FieldCode: 46},
+			ordinal: 458798,
+		},
 	}
 	for _, field := range mptFields {
 		t.Run(field.name, func(t *testing.T) {

--- a/binary-codec/definitions/definitions_test.go
+++ b/binary-codec/definitions/definitions_test.go
@@ -1,10 +1,26 @@
 package definitions
 
 import (
+	_ "embed"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ugorji/go/codec"
 )
+
+//go:embed definitions.json
+var definitionsDocBytes []byte
+
+type formatField struct {
+	Name        string `json:"name"`
+	Optionality int    `json:"optionality"`
+}
+
+type formatDefinitionsDoc struct {
+	LedgerEntryFormats map[string][]formatField `json:"LEDGER_ENTRY_FORMATS"`
+	TransactionFormats map[string][]formatField `json:"TRANSACTION_FORMATS"`
+	Hash               string                   `json:"hash"`
+}
 
 func TestLoadDefinitions(t *testing.T) {
 	loadDefinitions()
@@ -87,6 +103,110 @@ func TestLoadDefinitions(t *testing.T) {
 			require.Equal(t, field.info, definitions.Fields[field.name].FieldInfo)
 			require.Equal(t, field.header, definitions.Fields[field.name].FieldHeader)
 			require.Equal(t, field.ordinal, definitions.Fields[field.name].Ordinal)
+		})
+	}
+}
+
+func TestConfidentialMPTFormats(t *testing.T) {
+	var jsonHandle codec.JsonHandle
+	jsonHandle.MapKeyAsString = true
+
+	decoder := codec.NewDecoderBytes(definitionsDocBytes, &jsonHandle)
+	var document formatDefinitionsDoc
+	require.NoError(t, decoder.Decode(&document))
+	require.Empty(t, document.Hash, "the embedded definitions contain an additional protocol overlay, so a source snapshot hash would be invalid")
+
+	tests := []struct {
+		name     string
+		actual   []formatField
+		expected []formatField
+	}{
+		{
+			name:   "MPToken ledger entry",
+			actual: document.LedgerEntryFormats["MPToken"],
+			expected: []formatField{
+				{Name: "Account", Optionality: 0},
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+				{Name: "MPTAmount", Optionality: 2},
+				{Name: "LockedAmount", Optionality: 1},
+				{Name: "ConfidentialBalanceInbox", Optionality: 1},
+				{Name: "ConfidentialBalanceSpending", Optionality: 1},
+				{Name: "ConfidentialBalanceVersion", Optionality: 2},
+				{Name: "IssuerEncryptedBalance", Optionality: 1},
+				{Name: "AuditorEncryptedBalance", Optionality: 1},
+				{Name: "HolderEncryptionKey", Optionality: 1},
+				{Name: "OwnerNode", Optionality: 0},
+				{Name: "PreviousTxnID", Optionality: 0},
+				{Name: "PreviousTxnLgrSeq", Optionality: 0},
+			},
+		},
+		{
+			name:   "ConfidentialMPTConvert transaction",
+			actual: document.TransactionFormats["ConfidentialMPTConvert"],
+			expected: []formatField{
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+				{Name: "MPTAmount", Optionality: 0},
+				{Name: "HolderEncryptionKey", Optionality: 1},
+				{Name: "HolderEncryptedAmount", Optionality: 0},
+				{Name: "IssuerEncryptedAmount", Optionality: 0},
+				{Name: "AuditorEncryptedAmount", Optionality: 1},
+				{Name: "BlindingFactor", Optionality: 0},
+				{Name: "ZKProof", Optionality: 1},
+			},
+		},
+		{
+			name:   "ConfidentialMPTMergeInbox transaction",
+			actual: document.TransactionFormats["ConfidentialMPTMergeInbox"],
+			expected: []formatField{
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+			},
+		},
+		{
+			name:   "ConfidentialMPTConvertBack transaction",
+			actual: document.TransactionFormats["ConfidentialMPTConvertBack"],
+			expected: []formatField{
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+				{Name: "MPTAmount", Optionality: 0},
+				{Name: "HolderEncryptedAmount", Optionality: 0},
+				{Name: "IssuerEncryptedAmount", Optionality: 0},
+				{Name: "AuditorEncryptedAmount", Optionality: 1},
+				{Name: "BlindingFactor", Optionality: 0},
+				{Name: "ZKProof", Optionality: 0},
+				{Name: "BalanceCommitment", Optionality: 0},
+			},
+		},
+		{
+			name:   "ConfidentialMPTSend transaction",
+			actual: document.TransactionFormats["ConfidentialMPTSend"],
+			expected: []formatField{
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+				{Name: "Destination", Optionality: 0},
+				{Name: "DestinationTag", Optionality: 1},
+				{Name: "SenderEncryptedAmount", Optionality: 0},
+				{Name: "DestinationEncryptedAmount", Optionality: 0},
+				{Name: "IssuerEncryptedAmount", Optionality: 0},
+				{Name: "AuditorEncryptedAmount", Optionality: 1},
+				{Name: "ZKProof", Optionality: 0},
+				{Name: "AmountCommitment", Optionality: 0},
+				{Name: "BalanceCommitment", Optionality: 0},
+				{Name: "CredentialIDs", Optionality: 1},
+			},
+		},
+		{
+			name:   "ConfidentialMPTClawback transaction",
+			actual: document.TransactionFormats["ConfidentialMPTClawback"],
+			expected: []formatField{
+				{Name: "MPTokenIssuanceID", Optionality: 0},
+				{Name: "Holder", Optionality: 0},
+				{Name: "MPTAmount", Optionality: 0},
+				{Name: "ZKProof", Optionality: 0},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.actual)
 		})
 	}
 }

--- a/binary-codec/types/uint64.go
+++ b/binary-codec/types/uint64.go
@@ -20,7 +20,7 @@ const (
 // not available in the definitions consumed by the codec.
 func uint64JSONBaseForField(fieldName string) int {
 	switch fieldName {
-	case "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount":
+	case "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount", "ConfidentialOutstandingAmount":
 		return uint64JSONBaseDecimal
 	default:
 		return uint64JSONBaseHex


### PR DESCRIPTION
# fix(binary-codec): align confidential MPT wire fields

## Description

This PR aligns confidential MPT field definitions, transaction formats, and serialization with the current `rippled` wire format. The branch is rebuilt on the current `confidential-transfers` integration branch.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Define `BlindingFactor` as a non-variable-length `Hash256` field with ordinal 40.
- Set the canonical ordinals for `AmountCommitment` and `BalanceCommitment` to 45 and 46.
- Decode `ConfidentialOutstandingAmount` as a base-ten `UInt64` field.
- Add all five confidential MPT transaction formats.
- Add confidential MPT fields to the MPT ledger-entry formats.
- Add confidential MPT transaction and ledger flags while retaining the current `ImmutableFlags` model.
- Add field metadata, format, wire-encoding, and round-trip tests.

## Validation

- `make lint`
- `make test-ci`
- `go test ./binary-codec/...`

## CI status

Lint, tests, coverage, localnet integration, and Semgrep pass. `Run govulncheck` currently fails because the workflow uses Go 1.26.5 and reports standard-library vulnerabilities that are fixed in Go 1.26.6. This failure is not caused by this diff.

## Notes

This PR targets the temporary `confidential-transfers` integration branch. Changelog updates remain deferred until the integration branch stabilizes.
