### PR TITLE
fix(docs): pin brace-expansion 1.1.17

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
   },
   "resolutions": {
     "ajv": "8.18.0",
-    "brace-expansion": "1.1.16",
+    "brace-expansion": "1.1.17",
     "schema-utils": "^4.3.0",
     "serialize-javascript": "7.0.5",
     "uuid": "11.1.1",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3934,10 +3934,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@1.1.16, brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+brace-expansion@1.1.17, brace-expansion@^1.1.7:
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.17.tgz#a375e14e41d672617de69526be02d0d7751a6909"
+  integrity sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
# fix(docs): pin brace-expansion 1.1.17

## Description
This PR aims to pin the docs dependency graph to the `brace-expansion` v1.1.17 security backport for CVE-2026-14257 (GHSA-mh99-v99m-4gvg).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes

- Updated the Yarn resolution in `docs/package.json` to pin `brace-expansion` at v1.1.17.