### PR TITLE
fix: harden binary and address codec input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raised the minimum Go version to 1.25.12 and upgraded `golang.org/x/crypto` to v0.54.0, incorporating upstream standard-library and SSH security fixes.
 
+### Fixed
+
+#### address-codec
+
+- Base58Check checksum and family-seed-prefix comparisons now run in constant time (`crypto/subtle`) to avoid leaking timing information while decoding addresses and seeds.
+
+#### binary-codec
+
+- `BinaryParser.ReadBytes` now returns `ErrParserOutOfBound` for negative lengths instead of silently returning no data.
+- `DecodeQuality` now returns `ErrInvalidQuality` for malformed hex input or input that decodes to fewer than 8 bytes, instead of returning raw hex errors or panicking on short input.
+
 ## [v0.2.0]
 
 ### BREAKING CHANGES

--- a/address-codec/base58check.go
+++ b/address-codec/base58check.go
@@ -2,6 +2,7 @@ package addresscodec
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 )
 
 // checksum: first four bytes of sha256^2
@@ -31,12 +32,11 @@ func Base58CheckDecode(input string) (result []byte, err error) {
 		return nil, ErrInvalidFormat
 	}
 
-	var cksum [4]byte
-	copy(cksum[:], decoded[len(decoded)-4:])
-	if checksum(decoded[:len(decoded)-4]) != cksum {
+	result = decoded[:len(decoded)-4]
+	actualChecksum := decoded[len(decoded)-4:]
+	expectedChecksum := checksum(result)
+	if len(actualChecksum) != len(expectedChecksum) || subtle.ConstantTimeCompare(actualChecksum, expectedChecksum[:]) != 1 {
 		return nil, ErrChecksum
 	}
-
-	result = decoded[:len(decoded)-4]
 	return
 }

--- a/address-codec/codec.go
+++ b/address-codec/codec.go
@@ -2,6 +2,7 @@ package addresscodec
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 
@@ -128,6 +129,12 @@ func EncodeSeed(entropy []byte, encodingType interfaces.CryptoImplementation) (s
 	return "", errors.New("encoding type must be `ed25519` or `secp256k1`")
 }
 
+// hasPrefixConstantTime reports whether b starts with prefix, comparing the
+// prefix bytes in constant time.
+func hasPrefixConstantTime(b, prefix []byte) bool {
+	return len(b) >= len(prefix) && subtle.ConstantTimeCompare(b[:len(prefix)], prefix) == 1
+}
+
 // DecodeSeed returns the decoded seed and its corresponding algorithm.
 func DecodeSeed(seed string) ([]byte, interfaces.CryptoImplementation, error) {
 	decoded, err := Base58CheckDecode(seed)
@@ -137,7 +144,7 @@ func DecodeSeed(seed string) ([]byte, interfaces.CryptoImplementation, error) {
 
 	ed25519 := crypto.ED25519()
 	ed25519Prefix := ed25519.FamilySeedPrefix()
-	if bytes.HasPrefix(decoded, ed25519Prefix) {
+	if hasPrefixConstantTime(decoded, ed25519Prefix) {
 		if len(decoded) != len(ed25519Prefix)+FamilySeedLength {
 			return nil, nil, ErrInvalidSeedLength
 		}
@@ -146,7 +153,7 @@ func DecodeSeed(seed string) ([]byte, interfaces.CryptoImplementation, error) {
 
 	secp256k1 := crypto.SECP256K1()
 	secp256k1Prefix := secp256k1.FamilySeedPrefix()
-	if bytes.HasPrefix(decoded, secp256k1Prefix) {
+	if hasPrefixConstantTime(decoded, secp256k1Prefix) {
 		if len(decoded) != len(secp256k1Prefix)+FamilySeedLength {
 			return nil, nil, ErrInvalidSeedLength
 		}

--- a/address-codec/codec_test.go
+++ b/address-codec/codec_test.go
@@ -2,6 +2,7 @@ package addresscodec
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/address-codec/interfaces"
@@ -95,6 +96,51 @@ func TestDecode(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOutput, res)
+			}
+		})
+	}
+}
+
+func TestDecodersRejectChecksumCorruptionAtEveryPosition(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       string
+		decode      func(string) error
+		expectedErr error
+	}{
+		{
+			name:  "classic address",
+			input: "rDTXLQ7ZKZVKz33zJbHjgVShjsBnqMBhmN",
+			decode: func(input string) error {
+				_, err := Decode(input, []byte{AccountAddressPrefix})
+				return err
+			},
+			expectedErr: ErrChecksum,
+		},
+		{
+			name:  "seed",
+			input: "sEdTzRkEgPoxDG1mJ6WkSucHWnMkm1H",
+			decode: func(input string) error {
+				_, _, err := DecodeSeed(input)
+				return err
+			},
+			expectedErr: ErrInvalidSeed,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded := DecodeBase58(tc.input)
+			require.GreaterOrEqual(t, len(decoded), 4)
+
+			for i := range 4 {
+				t.Run(fmt.Sprintf("checksum byte %d", i), func(t *testing.T) {
+					corrupted := append([]byte(nil), decoded...)
+					corrupted[len(corrupted)-4+i] ^= 0xff
+
+					err := tc.decode(EncodeBase58(corrupted))
+					require.ErrorIs(t, err, tc.expectedErr)
+				})
 			}
 		})
 	}
@@ -291,8 +337,29 @@ func TestDecodeSeed(t *testing.T) {
 			expectedErr:       ErrInvalidSeedLength,
 		},
 		{
+			name:              "fail - checksum valid ED25519 seed with no entropy",
+			input:             Base58CheckEncode(nil, crypto.ED25519().FamilySeedPrefix()...),
+			expectedOutput:    nil,
+			expectedAlgorithm: nil,
+			expectedErr:       ErrInvalidSeedLength,
+		},
+		{
 			name:              "fail - checksum valid ED25519 seed with short entropy",
 			input:             Base58CheckEncode([]byte{0x00}, crypto.ED25519().FamilySeedPrefix()...),
+			expectedOutput:    nil,
+			expectedAlgorithm: nil,
+			expectedErr:       ErrInvalidSeedLength,
+		},
+		{
+			name:              "fail - checksum valid secp256k1 seed with long entropy",
+			input:             Base58CheckEncode(make([]byte, FamilySeedLength+1), FamilySeedPrefix),
+			expectedOutput:    nil,
+			expectedAlgorithm: nil,
+			expectedErr:       ErrInvalidSeedLength,
+		},
+		{
+			name:              "fail - checksum valid ED25519 seed with long entropy",
+			input:             Base58CheckEncode(make([]byte, FamilySeedLength+1), crypto.ED25519().FamilySeedPrefix()...),
 			expectedOutput:    nil,
 			expectedAlgorithm: nil,
 			expectedErr:       ErrInvalidSeedLength,
@@ -312,7 +379,8 @@ func TestDecodeSeed(t *testing.T) {
 
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
-				require.Nil(t, tc.expectedOutput)
+				require.Nil(t, got)
+				require.Nil(t, algorithm)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOutput, got)

--- a/binary-codec/quality.go
+++ b/binary-codec/quality.go
@@ -77,8 +77,8 @@ func DecodeQuality(quality string) (string, error) {
 	}
 
 	decoded, err := hex.DecodeString(quality)
-	if err != nil {
-		return "", err
+	if err != nil || len(decoded) < 8 {
+		return "", ErrInvalidQuality
 	}
 
 	bytes := decoded[len(decoded)-8:]

--- a/binary-codec/quality_test.go
+++ b/binary-codec/quality_test.go
@@ -112,6 +112,31 @@ func TestQualityCodec_Decode(t *testing.T) {
 			expectedErr: ErrInvalidQuality,
 		},
 		{
+			name:        "fail - invalid quality - two decoded bytes",
+			input:       "0000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - three decoded bytes",
+			input:       "000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - four decoded bytes",
+			input:       "00000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - five decoded bytes",
+			input:       "0000000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - six decoded bytes",
+			input:       "000000000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
 			name:        "fail - invalid quality - seven decoded bytes",
 			input:       "00000000000000",
 			expectedErr: ErrInvalidQuality,

--- a/binary-codec/quality_test.go
+++ b/binary-codec/quality_test.go
@@ -97,8 +97,33 @@ func TestQualityCodec_Decode(t *testing.T) {
 			expectedErr: ErrInvalidQuality,
 		},
 		{
-			name:     "pass - valid zero quality",
+			name:        "fail - invalid quality - malformed hex",
+			input:       "GG00000000000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - odd-length hex",
+			input:       "550000000000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - one decoded byte",
+			input:       "00",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:        "fail - invalid quality - seven decoded bytes",
+			input:       "00000000000000",
+			expectedErr: ErrInvalidQuality,
+		},
+		{
+			name:     "pass - exact eight decoded bytes - zero quality",
 			input:    "5500000000000000",
+			expected: "0",
+		},
+		{
+			name:     "pass - longer input uses final eight decoded bytes",
+			input:    "FF5500000000000000",
 			expected: "0",
 		},
 		{

--- a/binary-codec/serdes/binary_parser.go
+++ b/binary-codec/serdes/binary_parser.go
@@ -114,8 +114,12 @@ func (p *BinaryParser) Peek() (byte, error) {
 }
 
 // ReadBytes reads the next n bytes in the data.
-// It returns an error if fewer than n bytes are available.
+// It returns an error if n is negative or fewer than n bytes are available.
 func (p *BinaryParser) ReadBytes(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, ErrParserOutOfBound
+	}
+
 	var bytes []byte
 	for range n {
 		b, err := p.ReadByte()

--- a/binary-codec/serdes/binary_parser_test.go
+++ b/binary-codec/serdes/binary_parser_test.go
@@ -108,32 +108,40 @@ func TestBinaryParser_ReadByte(t *testing.T) {
 
 func TestBinaryParser_ReadBytes(t *testing.T) {
 	testcases := []struct {
-		name        string
-		input       []byte
-		length      int
-		expected    []byte
-		expectedErr error
+		name            string
+		input           []byte
+		length          int
+		expected        []byte
+		expectedErr     error
+		expectedHasMore bool
 	}{
 		{
-			name:        "fail - no more bytes",
-			input:       []byte{},
-			length:      1,
-			expected:    []byte{},
-			expectedErr: ErrParserOutOfBound,
+			name:            "fail - negative length",
+			input:           []byte{1, 2, 3, 4, 5},
+			length:          -1,
+			expectedErr:     ErrParserOutOfBound,
+			expectedHasMore: true,
 		},
 		{
-			name:        "fail - not enough bytes",
-			input:       []byte{1, 2, 3, 4, 5},
-			length:      6,
-			expected:    []byte{},
-			expectedErr: ErrParserOutOfBound,
+			name:            "pass - zero length",
+			input:           []byte{1, 2, 3, 4, 5},
+			length:          0,
+			expected:        nil,
+			expectedHasMore: true,
 		},
 		{
-			name:        "pass - returns first byte",
-			input:       []byte{1, 2, 3, 4, 5},
-			length:      5,
-			expected:    []byte{1, 2, 3, 4, 5},
-			expectedErr: nil,
+			name:            "pass - exact length",
+			input:           []byte{1, 2, 3, 4, 5},
+			length:          5,
+			expected:        []byte{1, 2, 3, 4, 5},
+			expectedHasMore: false,
+		},
+		{
+			name:            "fail - over-read",
+			input:           []byte{1, 2, 3, 4, 5},
+			length:          6,
+			expectedErr:     ErrParserOutOfBound,
+			expectedHasMore: false,
 		},
 	}
 
@@ -142,12 +150,27 @@ func TestBinaryParser_ReadBytes(t *testing.T) {
 			p := NewBinaryParser(tc.input, definitions.Get())
 			actual, err := p.ReadBytes(tc.length)
 			if tc.expectedErr != nil {
-				require.Error(t, err)
-				return
+				require.ErrorIs(t, err, tc.expectedErr)
+				require.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, actual)
 			}
-			require.Equal(t, tc.expected, actual)
+			require.Equal(t, tc.expectedHasMore, p.HasMore())
 		})
 	}
+}
+
+func TestBinaryParser_ReadBytes_NegativeLengthDoesNotConsume(t *testing.T) {
+	input := []byte{1, 2, 3, 4, 5}
+	p := NewBinaryParser(input, definitions.Get())
+
+	_, err := p.ReadBytes(-1)
+	require.ErrorIs(t, err, ErrParserOutOfBound)
+
+	remaining, err := p.ReadBytes(len(input))
+	require.NoError(t, err)
+	require.Equal(t, input, remaining)
 }
 
 func TestBinaryParser_HasMore(t *testing.T) {


### PR DESCRIPTION
## Description
This PR hardens binary-codec and address-codec input handling against malformed input and timing side channels, without changing any valid-input behavior.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- `BinaryParser.ReadBytes` rejects negative lengths with the existing `ErrParserOutOfBound` sentinel before reading or allocating. Parser state is unchanged after rejection. Previously `ReadBytes(-1)` returned an empty success.
- Base58Check checksum verification and both family-seed-prefix checks (`ed25519`, `secp256k1`) now use `crypto/subtle.ConstantTimeCompare` after explicit length validation, via a shared `hasPrefixConstantTime` helper. Public error values (`ErrChecksum`, `ErrInvalidSeed`, `ErrInvalidSeedLength`) are unchanged and never contain compared material.
- `DecodeQuality` returns the stable `ErrInvalidQuality` sentinel for malformed or odd-length hex and for inputs decoding to fewer than eight bytes, instead of panicking on short input or leaking raw hex errors. Exact-eight-byte and longer-input behavior is preserved. `EncodeQuality` is unchanged.
- Tests cover negative, zero, exact, and over-read parser lengths, corruption at each of the four checksum positions, zero/short/long-entropy malformed seeds for both algorithms, and quality inputs at every 1-7 decoded-byte length plus empty, malformed hex, exact eight, and longer.
