### PR TITLE
feat: add query field coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### xrpl/queries
 
-- Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with default and v1 JSON fixture coverage.
+- Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with protocol-accurate default and v1 JSON fixtures including the AMM expired-slot interval sentinel.
 
 #### xrpl/transaction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `MPTokenIssuance.ReferenceHolding`, `DirectoryNode.TakerPaysMPT`, and `DirectoryNode.TakerGetsMPT`, plus the `LsfMPTAMM` flag and `SetLsfMPTAMM` setter for AMM-owned MPT holdings.
 
+#### xrpl/queries
+
+- Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with default and v1 JSON fixture coverage.
+
 #### xrpl/transaction
 
 - Added `ErrMPTIssuanceCreateInvalidMutableFlags` and `ErrMPTIssuanceSetInvalidMutableFlags` for unsupported Dynamic MPT flag bits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raised the minimum Go version to 1.25.12 and upgraded `golang.org/x/crypto` to v0.54.0, incorporating upstream standard-library and SSH security fixes.
 
+#### xrpl/queries/amm
+
+- `InfoRequest.Validate` now rejects `amm_info` requests that combine `amm_account` with the `asset` and `asset2` lookup form.
+
 #### xrpl/transaction
 
 - `MPTokenIssuanceCreate` and `MPTokenIssuanceSet` validation now rejects unsupported `MutableFlags` bits in addition to an explicitly zero mask.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with protocol-accurate default and v1 JSON fixtures including the AMM expired-slot interval sentinel.
 
+#### xrpl/queries/amm
+
+- Added `ledger_hash` and `ledger_index` fields to `InfoRequest`, and `ledger_current_index` to `InfoResponse` for open-ledger responses.
+
 #### xrpl/transaction
 
 - Added `ErrMPTIssuanceCreateInvalidMutableFlags` and `ErrMPTIssuanceSetInvalidMutableFlags` for unsupported Dynamic MPT flag bits.

--- a/xrpl/queries/account/lines.go
+++ b/xrpl/queries/account/lines.go
@@ -14,12 +14,13 @@ import (
 // LinesRequest returns information about an account's trust lines, including balances in all non-XRP currencies and assets for a specific ledger version.
 type LinesRequest struct {
 	common.BaseRequest
-	Account     types.Address          `json:"account"`
-	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
-	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
-	Peer        types.Address          `json:"peer,omitempty"`
-	Limit       int                    `json:"limit,omitempty"`
-	Marker      any                    `json:"marker,omitempty"`
+	Account       types.Address          `json:"account"`
+	LedgerHash    common.LedgerHash      `json:"ledger_hash,omitempty"`
+	LedgerIndex   common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Peer          types.Address          `json:"peer,omitempty"`
+	IgnoreDefault bool                   `json:"ignore_default,omitempty"`
+	Limit         int                    `json:"limit,omitempty"`
+	Marker        any                    `json:"marker,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for LinesRequest.
@@ -50,4 +51,5 @@ type LinesResponse struct {
 	LedgerIndex        common.LedgerIndex       `json:"ledger_index,omitempty"`
 	LedgerHash         common.LedgerHash        `json:"ledger_hash,omitempty"`
 	Marker             any                      `json:"marker,omitempty"`
+	Limit              int                      `json:"limit,omitempty"`
 }

--- a/xrpl/queries/account/lines_test.go
+++ b/xrpl/queries/account/lines_test.go
@@ -34,26 +34,67 @@ func TestAccountLinesRequest(t *testing.T) {
 	}
 }
 
-func TestAccountLinesResponse(t *testing.T) {
-	s := LinesResponse{
-		Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-		Lines: []accounttypes.TrustLine{
-			{
-				Account:    "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-				Balance:    "123",
-				Currency:   "USD",
-				Limit:      "456",
-				LimitPeer:  "10",
-				QualityIn:  1,
-				QualityOut: 2,
-			},
+func TestAccountLinesRequest_IgnoreDefault(t *testing.T) {
+	const account = "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu"
+
+	tests := []struct {
+		name     string
+		request  LinesRequest
+		expected string
+	}{
+		{
+			name:    "present",
+			request: LinesRequest{Account: account, IgnoreDefault: true},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"ignore_default": true
+}`,
 		},
-		LedgerCurrentIndex: 123,
-		LedgerIndex:        345,
-		LedgerHash:         "abc",
+		{
+			name:    "omitted",
+			request: LinesRequest{Account: account},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu"
+}`,
+		},
 	}
 
-	j := `{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.request, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestAccountLinesResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response LinesResponse
+		expected string
+	}{
+		{
+			name: "present",
+			response: LinesResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				Lines: []accounttypes.TrustLine{
+					{
+						Account:    "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+						Balance:    "123",
+						Currency:   "USD",
+						Limit:      "456",
+						LimitPeer:  "10",
+						QualityIn:  1,
+						QualityOut: 2,
+					},
+				},
+				LedgerCurrentIndex: 123,
+				LedgerIndex:        345,
+				LedgerHash:         "abc",
+				Limit:              10,
+			},
+			expected: `{
 	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
 	"lines": [
 		{
@@ -68,10 +109,28 @@ func TestAccountLinesResponse(t *testing.T) {
 	],
 	"ledger_current_index": 123,
 	"ledger_index": 345,
-	"ledger_hash": "abc"
-}`
+	"ledger_hash": "abc",
+	"limit": 10
+}`,
+		},
+		{
+			name: "omitted",
+			response: LinesResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				Lines:   []accounttypes.TrustLine{},
+			},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"lines": []
+}`,
+		},
+	}
 
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.response, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/xrpl/queries/account/lines_test.go
+++ b/xrpl/queries/account/lines_test.go
@@ -92,6 +92,7 @@ func TestAccountLinesResponse(t *testing.T) {
 				LedgerCurrentIndex: 123,
 				LedgerIndex:        345,
 				LedgerHash:         "abc",
+				Marker:             "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh,5",
 				Limit:              10,
 			},
 			expected: `{
@@ -110,6 +111,7 @@ func TestAccountLinesResponse(t *testing.T) {
 	"ledger_current_index": 123,
 	"ledger_index": 345,
 	"ledger_hash": "abc",
+	"marker": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh,5",
 	"limit": 10
 }`,
 		},

--- a/xrpl/queries/account/nfts_test.go
+++ b/xrpl/queries/account/nfts_test.go
@@ -28,46 +28,72 @@ func TestAccountNFTsRequest(t *testing.T) {
 }
 
 func TestAccountNFTsResponse(t *testing.T) {
-	s := NFTsResponse{
-		Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-		AccountNFTs: []accounttypes.NFT{
-			{
-				Flags:        accounttypes.Burnable | accounttypes.OnlyXRP,
-				Issuer:       "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-				NFTokenID:    "abc",
-				NFTokenTaxon: 123,
-				URI:          "def",
-				NFTSerial:    456,
+	tests := []struct {
+		name     string
+		response NFTsResponse
+		expected string
+	}{
+		{
+			name: "validated ledger",
+			response: NFTsResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				AccountNFTs: []accounttypes.NFT{
+					{
+						Flags:        accounttypes.Burnable | accounttypes.OnlyXRP,
+						Issuer:       "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+						NFTokenID:    "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+						NFTokenTaxon: 123,
+						URI:          "def",
+						NFTSerial:    456,
+					},
+				},
+				LedgerIndex: 123,
+				LedgerHash:  "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+				Validated:   true,
+				Marker:      "abc",
+				Limit:       123,
 			},
-		},
-		LedgerIndex:        123,
-		LedgerHash:         "abc",
-		LedgerCurrentIndex: 1234,
-		Validated:          true,
-		Marker:             "abc",
-		Limit:              123,
-	}
-
-	j := `{
+			expected: `{
 	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
 	"account_nfts": [
 		{
 			"Flags": 3,
 			"Issuer": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-			"NFTokenID": "abc",
+			"NFTokenID": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 			"NFTokenTaxon": 123,
 			"URI": "def",
 			"nft_serial": 456
 		}
 	],
 	"ledger_index": 123,
-	"ledger_hash": "abc",
-	"ledger_current_index": 1234,
+	"ledger_hash": "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
 	"validated": true,
 	"marker": "abc",
 	"limit": 123
-}`
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
+}`,
+		},
+		{
+			name: "open ledger",
+			response: NFTsResponse{
+				Account:            "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				AccountNFTs:        []accounttypes.NFT{},
+				LedgerCurrentIndex: 1234,
+				Validated:          false,
+			},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"account_nfts": [],
+	"ledger_current_index": 1234,
+	"validated": false
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.response, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/xrpl/queries/account/v1/lines.go
+++ b/xrpl/queries/account/v1/lines.go
@@ -15,12 +15,13 @@ import (
 // All information is relative to a specific ledger version.
 type LinesRequest struct {
 	common.BaseRequest
-	Account     types.Address          `json:"account"`
-	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
-	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
-	Peer        types.Address          `json:"peer,omitempty"`
-	Limit       int                    `json:"limit,omitempty"`
-	Marker      any                    `json:"marker,omitempty"`
+	Account       types.Address          `json:"account"`
+	LedgerHash    common.LedgerHash      `json:"ledger_hash,omitempty"`
+	LedgerIndex   common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Peer          types.Address          `json:"peer,omitempty"`
+	IgnoreDefault bool                   `json:"ignore_default,omitempty"`
+	Limit         int                    `json:"limit,omitempty"`
+	Marker        any                    `json:"marker,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for LinesRequest.
@@ -50,4 +51,5 @@ type LinesResponse struct {
 	LedgerIndex        common.LedgerIndex       `json:"ledger_index,omitempty"`
 	LedgerHash         common.LedgerHash        `json:"ledger_hash,omitempty"`
 	Marker             any                      `json:"marker,omitempty"`
+	Limit              int                      `json:"limit,omitempty"`
 }

--- a/xrpl/queries/account/v1/lines_test.go
+++ b/xrpl/queries/account/v1/lines_test.go
@@ -34,26 +34,67 @@ func TestAccountLinesRequest(t *testing.T) {
 	}
 }
 
-func TestAccountLinesResponse(t *testing.T) {
-	s := LinesResponse{
-		Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-		Lines: []accounttypes.TrustLine{
-			{
-				Account:    "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-				Balance:    "123",
-				Currency:   "USD",
-				Limit:      "456",
-				LimitPeer:  "10",
-				QualityIn:  1,
-				QualityOut: 2,
-			},
+func TestAccountLinesRequest_IgnoreDefault(t *testing.T) {
+	const account = "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu"
+
+	tests := []struct {
+		name     string
+		request  LinesRequest
+		expected string
+	}{
+		{
+			name:    "present",
+			request: LinesRequest{Account: account, IgnoreDefault: true},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"ignore_default": true
+}`,
 		},
-		LedgerCurrentIndex: 123,
-		LedgerIndex:        345,
-		LedgerHash:         "abc",
+		{
+			name:    "omitted",
+			request: LinesRequest{Account: account},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu"
+}`,
+		},
 	}
 
-	j := `{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.request, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestAccountLinesResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response LinesResponse
+		expected string
+	}{
+		{
+			name: "present",
+			response: LinesResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				Lines: []accounttypes.TrustLine{
+					{
+						Account:    "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+						Balance:    "123",
+						Currency:   "USD",
+						Limit:      "456",
+						LimitPeer:  "10",
+						QualityIn:  1,
+						QualityOut: 2,
+					},
+				},
+				LedgerCurrentIndex: 123,
+				LedgerIndex:        345,
+				LedgerHash:         "abc",
+				Limit:              10,
+			},
+			expected: `{
 	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
 	"lines": [
 		{
@@ -68,10 +109,28 @@ func TestAccountLinesResponse(t *testing.T) {
 	],
 	"ledger_current_index": 123,
 	"ledger_index": 345,
-	"ledger_hash": "abc"
-}`
+	"ledger_hash": "abc",
+	"limit": 10
+}`,
+		},
+		{
+			name: "omitted",
+			response: LinesResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				Lines:   []accounttypes.TrustLine{},
+			},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"lines": []
+}`,
+		},
+	}
 
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.response, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/xrpl/queries/account/v1/lines_test.go
+++ b/xrpl/queries/account/v1/lines_test.go
@@ -92,6 +92,7 @@ func TestAccountLinesResponse(t *testing.T) {
 				LedgerCurrentIndex: 123,
 				LedgerIndex:        345,
 				LedgerHash:         "abc",
+				Marker:             "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh,5",
 				Limit:              10,
 			},
 			expected: `{
@@ -110,6 +111,7 @@ func TestAccountLinesResponse(t *testing.T) {
 	"ledger_current_index": 123,
 	"ledger_index": 345,
 	"ledger_hash": "abc",
+	"marker": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh,5",
 	"limit": 10
 }`,
 		},

--- a/xrpl/queries/account/v1/nfts.go
+++ b/xrpl/queries/account/v1/nfts.go
@@ -46,6 +46,8 @@ func (*NFTsRequest) Validate() error {
 type NFTsResponse struct {
 	Account            types.Address      `json:"account"`
 	AccountNFTs        []accounttypes.NFT `json:"account_nfts"`
+	LedgerIndex        common.LedgerIndex `json:"ledger_index,omitempty"`
+	LedgerHash         common.LedgerHash  `json:"ledger_hash,omitempty"`
 	LedgerCurrentIndex common.LedgerIndex `json:"ledger_current_index,omitempty"`
 	Validated          bool               `json:"validated"`
 	Marker             any                `json:"marker,omitempty"`

--- a/xrpl/queries/account/v1/nfts_test.go
+++ b/xrpl/queries/account/v1/nfts_test.go
@@ -28,42 +28,72 @@ func TestAccountNFTsRequest(t *testing.T) {
 }
 
 func TestAccountNFTsResponse(t *testing.T) {
-	s := NFTsResponse{
-		Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-		AccountNFTs: []accounttypes.NFT{
-			{
-				Flags:        accounttypes.Burnable | accounttypes.OnlyXRP,
-				Issuer:       "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-				NFTokenID:    "abc",
-				NFTokenTaxon: 123,
-				URI:          "def",
-				NFTSerial:    456,
+	tests := []struct {
+		name     string
+		response NFTsResponse
+		expected string
+	}{
+		{
+			name: "validated ledger",
+			response: NFTsResponse{
+				Account: "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				AccountNFTs: []accounttypes.NFT{
+					{
+						Flags:        accounttypes.Burnable | accounttypes.OnlyXRP,
+						Issuer:       "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+						NFTokenID:    "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+						NFTokenTaxon: 123,
+						URI:          "def",
+						NFTSerial:    456,
+					},
+				},
+				LedgerIndex: 123,
+				LedgerHash:  "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+				Validated:   true,
+				Marker:      "abc",
+				Limit:       123,
 			},
-		},
-		LedgerCurrentIndex: 1234,
-		Validated:          true,
-		Marker:             "abc",
-		Limit:              123,
-	}
-
-	j := `{
+			expected: `{
 	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
 	"account_nfts": [
 		{
 			"Flags": 3,
 			"Issuer": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
-			"NFTokenID": "abc",
+			"NFTokenID": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 			"NFTokenTaxon": 123,
 			"URI": "def",
 			"nft_serial": 456
 		}
 	],
-	"ledger_current_index": 1234,
+	"ledger_index": 123,
+	"ledger_hash": "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
 	"validated": true,
 	"marker": "abc",
 	"limit": 123
-}`
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
+}`,
+		},
+		{
+			name: "open ledger",
+			response: NFTsResponse{
+				Account:            "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+				AccountNFTs:        []accounttypes.NFT{},
+				LedgerCurrentIndex: 1234,
+				Validated:          false,
+			},
+			expected: `{
+	"account": "rLHmBn4fT92w4F6ViyYbjoizLTo83tHTHu",
+	"account_nfts": [],
+	"ledger_current_index": 1234,
+	"validated": false
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.response, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/xrpl/queries/amm/amm_info.go
+++ b/xrpl/queries/amm/amm_info.go
@@ -25,6 +25,10 @@ type InfoRequest struct {
 	AMMAccount types.Address `json:"amm_account,omitempty"`
 	// (Optional) A liquidity provider whose LP Token holdings should be returned.
 	Account types.Address `json:"account,omitempty"`
+	// (Optional) The identifying hash of the ledger to use.
+	LedgerHash common.LedgerHash `json:"ledger_hash,omitempty"`
+	// (Optional) The ledger version to use.
+	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for InfoRequest.
@@ -140,6 +144,8 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 type InfoResponse struct {
 	// The AMM data.
 	AMM Info `json:"amm"`
+	// The index of the current in-progress ledger used to generate this response.
+	LedgerCurrentIndex common.LedgerIndex `json:"ledger_current_index,omitempty"`
 	// The identifying hash of the ledger used to generate this response.
 	LedgerHash common.LedgerHash `json:"ledger_hash,omitempty"`
 	// The ledger index of the ledger version used to generate this response.

--- a/xrpl/queries/amm/amm_info.go
+++ b/xrpl/queries/amm/amm_info.go
@@ -65,7 +65,7 @@ type AuctionSlotInfo struct {
 	Price types.IssuedCurrencyAmount `json:"price"`
 	// The time when this slot expires. Returned as a formatted date string by the server.
 	Expiration string `json:"expiration,omitempty"`
-	// The current 72-minute auction interval, from 0 to 19.
+	// The current 72-minute auction interval, from 0 to 19, or 20 when no active interval applies.
 	TimeInterval uint8 `json:"time_interval"`
 }
 

--- a/xrpl/queries/amm/amm_info.go
+++ b/xrpl/queries/amm/amm_info.go
@@ -18,11 +18,13 @@ import (
 type InfoRequest struct {
 	common.BaseRequest
 	// The definition for one of the two assets this AMM holds.
-	Asset ledger.Asset `json:"asset"`
+	Asset ledger.Asset `json:"asset,omitzero"`
 	// The definition for the other asset this AMM holds.
-	Asset2 ledger.Asset `json:"asset2"`
+	Asset2 ledger.Asset `json:"asset2,omitzero"`
 	// (Optional) The AMM Account to look up.
 	AMMAccount types.Address `json:"amm_account,omitempty"`
+	// (Optional) A liquidity provider whose LP Token holdings should be returned.
+	Account types.Address `json:"account,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for InfoRequest.
@@ -36,11 +38,12 @@ func (*InfoRequest) APIVersion() int {
 }
 
 // Validate performs validation on InfoRequest.
-// Either amm_account or both asset and asset2 must be specified.
+// Exactly one lookup must be specified: amm_account, or both asset and asset2.
 func (i *InfoRequest) Validate() error {
 	hasAMMAccount := i.AMMAccount != ""
-	hasAssets := i.Asset != (ledger.Asset{}) && i.Asset2 != (ledger.Asset{})
-	if !hasAMMAccount && !hasAssets {
+	hasAsset := i.Asset != (ledger.Asset{})
+	hasAsset2 := i.Asset2 != (ledger.Asset{})
+	if hasAsset != hasAsset2 || hasAsset == hasAMMAccount {
 		return ErrInvalidInfoRequest
 	}
 	return nil
@@ -62,6 +65,8 @@ type AuctionSlotInfo struct {
 	Price types.IssuedCurrencyAmount `json:"price"`
 	// The time when this slot expires. Returned as a formatted date string by the server.
 	Expiration string `json:"expiration,omitempty"`
+	// The current 72-minute auction interval, from 0 to 19.
+	TimeInterval uint8 `json:"time_interval"`
 }
 
 // AuthAccountInfo represents an account authorized to trade at the discounted fee.
@@ -88,6 +93,10 @@ type Info struct {
 	Amount types.CurrencyAmount `json:"amount"`
 	// The second asset this AMM holds. Either XRPCurrencyAmount (drops string) or IssuedCurrencyAmount.
 	Amount2 types.CurrencyAmount `json:"amount2"`
+	// Whether the first asset is frozen. Omitted when the first asset is XRP.
+	AssetFrozen *bool `json:"asset_frozen,omitempty"`
+	// Whether the second asset is frozen. Omitted when the second asset is XRP.
+	Asset2Frozen *bool `json:"asset2_frozen,omitempty"`
 	// Details of the current auction slot owner.
 	AuctionSlot *AuctionSlotInfo `json:"auction_slot,omitempty"`
 	// The total outstanding balance of LP tokens from this AMM instance.

--- a/xrpl/queries/amm/amm_info_test.go
+++ b/xrpl/queries/amm/amm_info_test.go
@@ -175,6 +175,33 @@ func TestAMMInfoResponse(t *testing.T) {
 	}
 }
 
+func TestAuctionSlotInfo_TimeIntervalExpiredSentinel(t *testing.T) {
+	s := AuctionSlotInfo{
+		Account:       "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+		DiscountedFee: 0,
+		Price: types.IssuedCurrencyAmount{
+			Currency: "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+			Issuer:   "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+			Value:    "100",
+		},
+		TimeInterval: 20,
+	}
+
+	j := `{
+	"account": "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+	"discounted_fee": 0,
+	"price": {
+		"issuer": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+		"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		"value": "100"
+	},
+	"time_interval": 20
+}`
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 	asset2Frozen := false
 

--- a/xrpl/queries/amm/amm_info_test.go
+++ b/xrpl/queries/amm/amm_info_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	ledger "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,48 @@ func TestAMMInfoRequest(t *testing.T) {
 				t.Error(err)
 			}
 		})
+	}
+}
+
+func TestAMMInfoRequest_WithLedgerIndex(t *testing.T) {
+	s := InfoRequest{
+		Asset: ledger.Asset{
+			Currency: "USD",
+			Issuer:   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		},
+		Asset2: ledger.Asset{
+			Currency: "XRP",
+		},
+		LedgerIndex: common.Validated,
+	}
+
+	j := `{
+	"asset": {
+		"currency": "USD",
+		"issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	},
+	"asset2": {
+		"currency": "XRP"
+	},
+	"ledger_index": "validated"
+}`
+	if err := testutil.Serialize(t, s, j); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAMMInfoRequest_WithAMMAccountAndLedgerHash(t *testing.T) {
+	s := InfoRequest{
+		AMMAccount: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+		LedgerHash: "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+	}
+
+	j := `{
+	"amm_account": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+	"ledger_hash": "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659"
+}`
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -202,7 +245,7 @@ func TestAuctionSlotInfo_TimeIntervalExpiredSentinel(t *testing.T) {
 	}
 }
 
-func TestAMMInfoResponse_XRPAssets(t *testing.T) {
+func TestAMMInfoResponse_OpenLedgerWithXRPAssets(t *testing.T) {
 	asset2Frozen := false
 
 	s := InfoResponse{
@@ -222,7 +265,8 @@ func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 			},
 			TradingFee: 600,
 		},
-		Validated: false,
+		LedgerCurrentIndex: 106107390,
+		Validated:          false,
 	}
 
 	j := `{
@@ -241,7 +285,8 @@ func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 			"value": "22360679.77"
 		},
 		"trading_fee": 600
-	}
+	},
+	"ledger_current_index": 106107390
 }`
 	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
 		t.Error(err)

--- a/xrpl/queries/amm/amm_info_test.go
+++ b/xrpl/queries/amm/amm_info_test.go
@@ -10,17 +10,18 @@ import (
 )
 
 func TestAMMInfoRequest(t *testing.T) {
-	s := InfoRequest{
-		Asset: ledger.Asset{
-			Currency: "USD",
-			Issuer:   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-		},
-		Asset2: ledger.Asset{
-			Currency: "XRP",
-		},
-	}
-
-	j := `{
+	tests := []struct {
+		name     string
+		request  InfoRequest
+		expected string
+	}{
+		{
+			name: "asset pair",
+			request: InfoRequest{
+				Asset:  ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+				Asset2: ledger.Asset{Currency: "XRP"},
+			},
+			expected: `{
 	"asset": {
 		"currency": "USD",
 		"issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
@@ -28,42 +29,50 @@ func TestAMMInfoRequest(t *testing.T) {
 	"asset2": {
 		"currency": "XRP"
 	}
-}`
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestAMMInfoRequest_WithAMMAccount(t *testing.T) {
-	s := InfoRequest{
-		Asset: ledger.Asset{
-			Currency: "USD",
-			Issuer:   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+}`,
 		},
-		Asset2: ledger.Asset{
-			Currency: "BTC",
-			Issuer:   "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
-		},
-		AMMAccount: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-	}
-
-	j := `{
+		{
+			name: "asset pair with liquidity provider",
+			request: InfoRequest{
+				Asset:   ledger.Asset{Currency: "XRP"},
+				Asset2:  ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+				Account: "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
+			},
+			expected: `{
 	"asset": {
+		"currency": "XRP"
+	},
+	"asset2": {
 		"currency": "USD",
 		"issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 	},
-	"asset2": {
-		"currency": "BTC",
-		"issuer": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"
-	},
+	"account": "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"
+}`,
+		},
+		{
+			name: "amm_account",
+			request: InfoRequest{
+				AMMAccount: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+			},
+			expected: `{
 	"amm_account": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S"
-}`
-	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
-		t.Error(err)
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.request, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
 func TestAMMInfoResponse(t *testing.T) {
+	assetFrozen := true
+	asset2Frozen := false
+
 	s := InfoResponse{
 		AMM: Info{
 			Account: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
@@ -77,6 +86,8 @@ func TestAMMInfoResponse(t *testing.T) {
 				Issuer:   "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
 				Value:    "0.5",
 			},
+			AssetFrozen:  &assetFrozen,
+			Asset2Frozen: &asset2Frozen,
 			AuctionSlot: &AuctionSlotInfo{
 				Account: "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
 				AuthAccounts: []AuthAccountInfo{
@@ -88,7 +99,8 @@ func TestAMMInfoResponse(t *testing.T) {
 					Issuer:   "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
 					Value:    "100",
 				},
-				Expiration: "2024-01-01T00:00:00Z",
+				Expiration:   "2024-01-01T00:00:00Z",
+				TimeInterval: 0,
 			},
 			LPToken: types.IssuedCurrencyAmount{
 				Currency: "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
@@ -122,6 +134,8 @@ func TestAMMInfoResponse(t *testing.T) {
 			"currency": "BTC",
 			"value": "0.5"
 		},
+		"asset_frozen": true,
+		"asset2_frozen": false,
 		"auction_slot": {
 			"account": "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm",
 			"auth_accounts": [
@@ -135,7 +149,8 @@ func TestAMMInfoResponse(t *testing.T) {
 				"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
 				"value": "100"
 			},
-			"expiration": "2024-01-01T00:00:00Z"
+			"expiration": "2024-01-01T00:00:00Z",
+			"time_interval": 0
 		},
 		"lp_token": {
 			"issuer": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
@@ -155,12 +170,14 @@ func TestAMMInfoResponse(t *testing.T) {
 	"ledger_index": 1234,
 	"validated": true
 }`
-	if err := testutil.Serialize(t, s, j); err != nil {
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestAMMInfoResponse_XRPAssets(t *testing.T) {
+	asset2Frozen := false
+
 	s := InfoResponse{
 		AMM: Info{
 			Account: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
@@ -170,6 +187,7 @@ func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 				Issuer:   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 				Value:    "500",
 			},
+			Asset2Frozen: &asset2Frozen,
 			LPToken: types.IssuedCurrencyAmount{
 				Currency: "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
 				Issuer:   "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
@@ -189,6 +207,7 @@ func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 			"currency": "USD",
 			"value": "500"
 		},
+		"asset2_frozen": false,
 		"lp_token": {
 			"issuer": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
 			"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
@@ -197,52 +216,123 @@ func TestAMMInfoResponse_XRPAssets(t *testing.T) {
 		"trading_fee": 600
 	}
 }`
-	if err := testutil.Serialize(t, s, j); err != nil {
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
 		t.Error(err)
 	}
 }
 
+func TestAMMInfoResponse_FrozenFieldOptionality(t *testing.T) {
+	unfrozen := false
+	issuedAmount := types.IssuedCurrencyAmount{
+		Currency: "USD",
+		Issuer:   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		Value:    "500",
+	}
+	lpToken := types.IssuedCurrencyAmount{
+		Currency: "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		Issuer:   "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+		Value:    "22360679.77",
+	}
+
+	tests := []struct {
+		name     string
+		info     Info
+		expected string
+	}{
+		{
+			name: "asset is XRP",
+			info: Info{
+				Account:      "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+				Amount:       types.XRPCurrencyAmount(1000000),
+				Amount2:      issuedAmount,
+				Asset2Frozen: &unfrozen,
+				LPToken:      lpToken,
+			},
+			expected: `{
+	"account": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+	"amount": "1000000",
+	"amount2": {
+		"issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"currency": "USD",
+		"value": "500"
+	},
+	"asset2_frozen": false,
+	"lp_token": {
+		"issuer": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+		"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		"value": "22360679.77"
+	},
+	"trading_fee": 0
+}`,
+		},
+		{
+			name: "asset2 is XRP",
+			info: Info{
+				Account:     "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+				Amount:      issuedAmount,
+				Amount2:     types.XRPCurrencyAmount(1000000),
+				AssetFrozen: &unfrozen,
+				LPToken:     lpToken,
+			},
+			expected: `{
+	"account": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+	"amount": {
+		"issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"currency": "USD",
+		"value": "500"
+	},
+	"amount2": "1000000",
+	"asset_frozen": false,
+	"lp_token": {
+		"issuer": "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+		"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		"value": "22360679.77"
+	},
+	"trading_fee": 0
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.info, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestAMMInfoRequest_Validate(t *testing.T) {
-	t.Run("pass - with asset and asset2", func(t *testing.T) {
-		req := InfoRequest{
-			Asset:  ledger.Asset{Currency: "XRP"},
-			Asset2: ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
-		}
-		require.NoError(t, req.Validate())
-	})
+	asset := ledger.Asset{Currency: "XRP"}
+	asset2 := ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}
+	const ammAccount = "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S"
+	const liquidityProvider = "rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"
 
-	t.Run("pass - with amm_account", func(t *testing.T) {
-		req := InfoRequest{
-			AMMAccount: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-		}
-		require.NoError(t, req.Validate())
-	})
+	tests := []struct {
+		name     string
+		request  InfoRequest
+		expected error
+	}{
+		{name: "no selector", request: InfoRequest{}, expected: ErrInvalidInfoRequest},
+		{name: "asset only", request: InfoRequest{Asset: asset}, expected: ErrInvalidInfoRequest},
+		{name: "asset2 only", request: InfoRequest{Asset2: asset2}, expected: ErrInvalidInfoRequest},
+		{name: "asset pair", request: InfoRequest{Asset: asset, Asset2: asset2}},
+		{name: "amm_account only", request: InfoRequest{AMMAccount: ammAccount}},
+		{name: "asset and amm_account", request: InfoRequest{Asset: asset, AMMAccount: ammAccount}, expected: ErrInvalidInfoRequest},
+		{name: "asset2 and amm_account", request: InfoRequest{Asset2: asset2, AMMAccount: ammAccount}, expected: ErrInvalidInfoRequest},
+		{name: "asset pair and amm_account", request: InfoRequest{Asset: asset, Asset2: asset2, AMMAccount: ammAccount}, expected: ErrInvalidInfoRequest},
+		{name: "liquidity provider only", request: InfoRequest{Account: liquidityProvider}, expected: ErrInvalidInfoRequest},
+		{name: "amm_account with liquidity provider", request: InfoRequest{AMMAccount: ammAccount, Account: liquidityProvider}},
+	}
 
-	t.Run("pass - with amm_account and assets", func(t *testing.T) {
-		req := InfoRequest{
-			Asset:      ledger.Asset{Currency: "XRP"},
-			Asset2:     ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
-			AMMAccount: "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
-		}
-		require.NoError(t, req.Validate())
-	})
-
-	t.Run("fail - no amm_account and no assets", func(t *testing.T) {
-		req := InfoRequest{}
-		require.ErrorIs(t, req.Validate(), ErrInvalidInfoRequest)
-	})
-
-	t.Run("fail - only asset specified", func(t *testing.T) {
-		req := InfoRequest{
-			Asset: ledger.Asset{Currency: "XRP"},
-		}
-		require.ErrorIs(t, req.Validate(), ErrInvalidInfoRequest)
-	})
-
-	t.Run("fail - only asset2 specified", func(t *testing.T) {
-		req := InfoRequest{
-			Asset2: ledger.Asset{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
-		}
-		require.ErrorIs(t, req.Validate(), ErrInvalidInfoRequest)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expected == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.expected)
+		})
+	}
 }

--- a/xrpl/queries/amm/errors.go
+++ b/xrpl/queries/amm/errors.go
@@ -2,5 +2,6 @@ package amm
 
 import "errors"
 
-// ErrInvalidInfoRequest is returned when neither amm_account nor both asset and asset2 are specified.
-var ErrInvalidInfoRequest = errors.New("amm_info: must specify either amm_account or both asset and asset2")
+// ErrInvalidInfoRequest is returned unless exactly one AMM lookup is specified:
+// either amm_account, or both asset and asset2.
+var ErrInvalidInfoRequest = errors.New("amm_info: must specify exactly one of amm_account or both asset and asset2")

--- a/xrpl/queries/nft/nftoken_buy_offers.go
+++ b/xrpl/queries/nft/nftoken_buy_offers.go
@@ -19,6 +19,8 @@ type NFTokenBuyOffersRequest struct {
 	NFTokenID   types.NFTokenID        `json:"nft_id"`
 	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
 	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Limit       int                    `json:"limit,omitempty"`
+	Marker      any                    `json:"marker,omitempty"`
 }
 
 // Method returns the XRPL JSON-RPC method name for NFTokenBuyOffersRequest.
@@ -45,4 +47,6 @@ func (*NFTokenBuyOffersRequest) Validate() error {
 type NFTokenBuyOffersResponse struct {
 	NFTokenID types.NFTokenID         `json:"nft_id"`
 	Offers    []nfttypes.NFTokenOffer `json:"offers"`
+	Limit     int                     `json:"limit,omitempty"`
+	Marker    any                     `json:"marker,omitempty"`
 }

--- a/xrpl/queries/nft/nftoken_buy_offers_test.go
+++ b/xrpl/queries/nft/nftoken_buy_offers_test.go
@@ -1,12 +1,15 @@
 package nft
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	nfttypes "github.com/Peersyst/xrpl-go/xrpl/queries/nft/types"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNFTokenBuyOffersRequest(t *testing.T) {
@@ -28,62 +31,74 @@ func TestNFTokenBuyOffersRequest(t *testing.T) {
 func TestNFTokenBuyOffers_Pagination(t *testing.T) {
 	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
 	const marker = "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+	const owner = "rsuHaTvJh1bDmDoxX9QcKP7HEBSBt4XsHx"
 
-	tests := []struct {
-		name     string
-		value    any
-		expected string
-	}{
-		{
-			name: "first page response",
-			value: NFTokenBuyOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50,
-	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
-}`,
-		},
-		{
-			name: "continuation request",
-			value: NFTokenBuyOffersRequest{
-				NFTokenID: nftID,
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
+	firstPage := NFTokenBuyOffersResponse{
+		NFTokenID: nftID,
+		Offers:    makePaginationOffers(50, "1500", 0, owner),
+		Limit:     50,
+		Marker:    marker,
+	}
+	firstPageJSON, err := json.Marshal(firstPage)
+	require.NoError(t, err)
+
+	var decodedFirstPage NFTokenBuyOffersResponse
+	require.NoError(t, json.Unmarshal(firstPageJSON, &decodedFirstPage))
+	require.Equal(t, firstPage, decodedFirstPage)
+
+	firstPageFields := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal(firstPageJSON, &firstPageFields))
+	require.Contains(t, firstPageFields, "limit")
+	require.Contains(t, firstPageFields, "marker")
+
+	continuation := NFTokenBuyOffersRequest{
+		NFTokenID: nftID,
+		Limit:     decodedFirstPage.Limit,
+		Marker:    decodedFirstPage.Marker,
+	}
+	continuationJSON := `{
 	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 	"limit": 50,
 	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
-}`,
-		},
-		{
-			name: "last page response without marker",
-			value: NFTokenBuyOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50
-}`,
-		},
-	}
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, continuation, continuationJSON))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
-				t.Error(err)
-			}
-		})
+	lastPage := NFTokenBuyOffersResponse{
+		NFTokenID: nftID,
+		Offers: []nfttypes.NFTokenOffer{
+			{
+				Amount:            "1500",
+				Flags:             0,
+				NFTokenOfferIndex: marker,
+				Owner:             owner,
+			},
+		},
 	}
+	lastPageJSON := `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [
+		{
+			"amount": "1500",
+			"flags": 0,
+			"nft_offer_index": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F",
+			"owner": "rsuHaTvJh1bDmDoxX9QcKP7HEBSBt4XsHx"
+		}
+	]
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, lastPage, lastPageJSON))
+}
+
+func makePaginationOffers(count int, amount string, flags uint, owner types.Address) []nfttypes.NFTokenOffer {
+	offers := make([]nfttypes.NFTokenOffer, count)
+	for i := range offers {
+		offers[i] = nfttypes.NFTokenOffer{
+			Amount:            amount,
+			Flags:             flags,
+			NFTokenOfferIndex: fmt.Sprintf("%064X", i+1),
+			Owner:             owner,
+		}
+	}
+	return offers
 }
 
 func TestNFTokenBuyOffersResponse(t *testing.T) {

--- a/xrpl/queries/nft/nftoken_buy_offers_test.go
+++ b/xrpl/queries/nft/nftoken_buy_offers_test.go
@@ -25,6 +25,67 @@ func TestNFTokenBuyOffersRequest(t *testing.T) {
 	}
 }
 
+func TestNFTokenBuyOffers_Pagination(t *testing.T) {
+	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
+	const marker = "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{
+			name: "first page response",
+			value: NFTokenBuyOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50,
+	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+}`,
+		},
+		{
+			name: "continuation request",
+			value: NFTokenBuyOffersRequest{
+				NFTokenID: nftID,
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"limit": 50,
+	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+}`,
+		},
+		{
+			name: "last page response without marker",
+			value: NFTokenBuyOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestNFTokenBuyOffersResponse(t *testing.T) {
 	s := NFTokenBuyOffersResponse{
 		NFTokenID: "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",

--- a/xrpl/queries/nft/nftoken_sell_offers.go
+++ b/xrpl/queries/nft/nftoken_sell_offers.go
@@ -18,6 +18,8 @@ type NFTokenSellOffersRequest struct {
 	NFTokenID   types.NFTokenID        `json:"nft_id"`
 	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
 	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Limit       int                    `json:"limit,omitempty"`
+	Marker      any                    `json:"marker,omitempty"`
 }
 
 // Method returns the XRPL JSON-RPC method name for NFTokenSellOffersRequest.
@@ -43,4 +45,6 @@ func (*NFTokenSellOffersRequest) Validate() error {
 type NFTokenSellOffersResponse struct {
 	NFTokenID types.NFTokenID         `json:"nft_id"`
 	Offers    []nfttypes.NFTokenOffer `json:"offers"`
+	Limit     int                     `json:"limit,omitempty"`
+	Marker    any                     `json:"marker,omitempty"`
 }

--- a/xrpl/queries/nft/nftoken_sell_offers_test.go
+++ b/xrpl/queries/nft/nftoken_sell_offers_test.go
@@ -24,6 +24,67 @@ func TestNFTokenSellOffersRequest(t *testing.T) {
 	}
 }
 
+func TestNFTokenSellOffers_Pagination(t *testing.T) {
+	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
+	const marker = "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{
+			name: "first page response",
+			value: NFTokenSellOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50,
+	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+}`,
+		},
+		{
+			name: "continuation request",
+			value: NFTokenSellOffersRequest{
+				NFTokenID: nftID,
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"limit": 50,
+	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+}`,
+		},
+		{
+			name: "last page response without marker",
+			value: NFTokenSellOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestNFTokenSellOffersResponse(t *testing.T) {
 	s := NFTokenSellOffersResponse{
 		NFTokenID: "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",

--- a/xrpl/queries/nft/nftoken_sell_offers_test.go
+++ b/xrpl/queries/nft/nftoken_sell_offers_test.go
@@ -1,12 +1,14 @@
 package nft
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	nfttypes "github.com/Peersyst/xrpl-go/xrpl/queries/nft/types"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNFTokenSellOffersRequest(t *testing.T) {
@@ -27,62 +29,61 @@ func TestNFTokenSellOffersRequest(t *testing.T) {
 func TestNFTokenSellOffers_Pagination(t *testing.T) {
 	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
 	const marker = "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+	const owner = "rLpSRZ1E8JHyNDZeHYsQs1R5cwDCB3uuZt"
 
-	tests := []struct {
-		name     string
-		value    any
-		expected string
-	}{
-		{
-			name: "first page response",
-			value: NFTokenSellOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50,
-	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
-}`,
-		},
-		{
-			name: "continuation request",
-			value: NFTokenSellOffersRequest{
-				NFTokenID: nftID,
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
+	firstPage := NFTokenSellOffersResponse{
+		NFTokenID: nftID,
+		Offers:    makePaginationOffers(50, "1000", 1, owner),
+		Limit:     50,
+		Marker:    marker,
+	}
+	firstPageJSON, err := json.Marshal(firstPage)
+	require.NoError(t, err)
+
+	var decodedFirstPage NFTokenSellOffersResponse
+	require.NoError(t, json.Unmarshal(firstPageJSON, &decodedFirstPage))
+	require.Equal(t, firstPage, decodedFirstPage)
+
+	firstPageFields := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal(firstPageJSON, &firstPageFields))
+	require.Contains(t, firstPageFields, "limit")
+	require.Contains(t, firstPageFields, "marker")
+
+	continuation := NFTokenSellOffersRequest{
+		NFTokenID: nftID,
+		Limit:     decodedFirstPage.Limit,
+		Marker:    decodedFirstPage.Marker,
+	}
+	continuationJSON := `{
 	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 	"limit": 50,
 	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
-}`,
-		},
-		{
-			name: "last page response without marker",
-			value: NFTokenSellOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50
-}`,
-		},
-	}
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, continuation, continuationJSON))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
-				t.Error(err)
-			}
-		})
+	lastPage := NFTokenSellOffersResponse{
+		NFTokenID: nftID,
+		Offers: []nfttypes.NFTokenOffer{
+			{
+				Amount:            "1000",
+				Flags:             1,
+				NFTokenOfferIndex: marker,
+				Owner:             owner,
+			},
+		},
 	}
+	lastPageJSON := `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [
+		{
+			"amount": "1000",
+			"flags": 1,
+			"nft_offer_index": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1",
+			"owner": "rLpSRZ1E8JHyNDZeHYsQs1R5cwDCB3uuZt"
+		}
+	]
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, lastPage, lastPageJSON))
 }
 
 func TestNFTokenSellOffersResponse(t *testing.T) {

--- a/xrpl/queries/nft/v1/nftoken_buy_offers.go
+++ b/xrpl/queries/nft/v1/nftoken_buy_offers.go
@@ -19,6 +19,8 @@ type NFTokenBuyOffersRequest struct {
 	NFTokenID   types.NFTokenID        `json:"nft_id"`
 	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
 	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Limit       int                    `json:"limit,omitempty"`
+	Marker      any                    `json:"marker,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for the NFTokenBuyOffersRequest.
@@ -45,4 +47,6 @@ func (*NFTokenBuyOffersRequest) Validate() error {
 type NFTokenBuyOffersResponse struct {
 	NFTokenID types.NFTokenID         `json:"nft_id"`
 	Offers    []nfttypes.NFTokenOffer `json:"offers"`
+	Limit     int                     `json:"limit,omitempty"`
+	Marker    any                     `json:"marker,omitempty"`
 }

--- a/xrpl/queries/nft/v1/nftoken_buy_offers_test.go
+++ b/xrpl/queries/nft/v1/nftoken_buy_offers_test.go
@@ -25,6 +25,67 @@ func TestNFTokenBuyOffersRequest(t *testing.T) {
 	}
 }
 
+func TestNFTokenBuyOffers_Pagination(t *testing.T) {
+	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
+	const marker = "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{
+			name: "first page response",
+			value: NFTokenBuyOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50,
+	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+}`,
+		},
+		{
+			name: "continuation request",
+			value: NFTokenBuyOffersRequest{
+				NFTokenID: nftID,
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"limit": 50,
+	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+}`,
+		},
+		{
+			name: "last page response without marker",
+			value: NFTokenBuyOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestNFTokenBuyOffersResponse(t *testing.T) {
 	s := NFTokenBuyOffersResponse{
 		NFTokenID: "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",

--- a/xrpl/queries/nft/v1/nftoken_buy_offers_test.go
+++ b/xrpl/queries/nft/v1/nftoken_buy_offers_test.go
@@ -1,12 +1,15 @@
 package v1
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	nfttypes "github.com/Peersyst/xrpl-go/xrpl/queries/nft/types"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNFTokenBuyOffersRequest(t *testing.T) {
@@ -28,62 +31,74 @@ func TestNFTokenBuyOffersRequest(t *testing.T) {
 func TestNFTokenBuyOffers_Pagination(t *testing.T) {
 	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
 	const marker = "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
+	const owner = "rsuHaTvJh1bDmDoxX9QcKP7HEBSBt4XsHx"
 
-	tests := []struct {
-		name     string
-		value    any
-		expected string
-	}{
-		{
-			name: "first page response",
-			value: NFTokenBuyOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50,
-	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
-}`,
-		},
-		{
-			name: "continuation request",
-			value: NFTokenBuyOffersRequest{
-				NFTokenID: nftID,
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
+	firstPage := NFTokenBuyOffersResponse{
+		NFTokenID: nftID,
+		Offers:    makePaginationOffers(50, "1500", 0, owner),
+		Limit:     50,
+		Marker:    marker,
+	}
+	firstPageJSON, err := json.Marshal(firstPage)
+	require.NoError(t, err)
+
+	var decodedFirstPage NFTokenBuyOffersResponse
+	require.NoError(t, json.Unmarshal(firstPageJSON, &decodedFirstPage))
+	require.Equal(t, firstPage, decodedFirstPage)
+
+	firstPageFields := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal(firstPageJSON, &firstPageFields))
+	require.Contains(t, firstPageFields, "limit")
+	require.Contains(t, firstPageFields, "marker")
+
+	continuation := NFTokenBuyOffersRequest{
+		NFTokenID: nftID,
+		Limit:     decodedFirstPage.Limit,
+		Marker:    decodedFirstPage.Marker,
+	}
+	continuationJSON := `{
 	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 	"limit": 50,
 	"marker": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F"
-}`,
-		},
-		{
-			name: "last page response without marker",
-			value: NFTokenBuyOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50
-}`,
-		},
-	}
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, continuation, continuationJSON))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
-				t.Error(err)
-			}
-		})
+	lastPage := NFTokenBuyOffersResponse{
+		NFTokenID: nftID,
+		Offers: []nfttypes.NFTokenOffer{
+			{
+				Amount:            "1500",
+				Flags:             0,
+				NFTokenOfferIndex: marker,
+				Owner:             owner,
+			},
+		},
 	}
+	lastPageJSON := `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [
+		{
+			"amount": "1500",
+			"flags": 0,
+			"nft_offer_index": "3212D26DB00031889D4EF7D9129BB0FA673B5B40B1759564486C0F0946BA203F",
+			"owner": "rsuHaTvJh1bDmDoxX9QcKP7HEBSBt4XsHx"
+		}
+	]
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, lastPage, lastPageJSON))
+}
+
+func makePaginationOffers(count int, amount string, flags uint, owner types.Address) []nfttypes.NFTokenOffer {
+	offers := make([]nfttypes.NFTokenOffer, count)
+	for i := range offers {
+		offers[i] = nfttypes.NFTokenOffer{
+			Amount:            amount,
+			Flags:             flags,
+			NFTokenOfferIndex: fmt.Sprintf("%064X", i+1),
+			Owner:             owner,
+		}
+	}
+	return offers
 }
 
 func TestNFTokenBuyOffersResponse(t *testing.T) {

--- a/xrpl/queries/nft/v1/nftoken_sell_offers.go
+++ b/xrpl/queries/nft/v1/nftoken_sell_offers.go
@@ -17,6 +17,8 @@ type NFTokenSellOffersRequest struct {
 	NFTokenID   types.NFTokenID        `json:"nft_id"`
 	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
 	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
+	Limit       int                    `json:"limit,omitempty"`
+	Marker      any                    `json:"marker,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for the NFTokenSellOffersRequest.
@@ -43,4 +45,6 @@ func (*NFTokenSellOffersRequest) Validate() error {
 type NFTokenSellOffersResponse struct {
 	NFTokenID types.NFTokenID         `json:"nft_id"`
 	Offers    []nfttypes.NFTokenOffer `json:"offers"`
+	Limit     int                     `json:"limit,omitempty"`
+	Marker    any                     `json:"marker,omitempty"`
 }

--- a/xrpl/queries/nft/v1/nftoken_sell_offers_test.go
+++ b/xrpl/queries/nft/v1/nftoken_sell_offers_test.go
@@ -1,12 +1,14 @@
 package v1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	nfttypes "github.com/Peersyst/xrpl-go/xrpl/queries/nft/types"
 	"github.com/Peersyst/xrpl-go/xrpl/testutil"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNFTokenSellOffersRequest(t *testing.T) {
@@ -27,62 +29,61 @@ func TestNFTokenSellOffersRequest(t *testing.T) {
 func TestNFTokenSellOffers_Pagination(t *testing.T) {
 	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
 	const marker = "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+	const owner = "rLpSRZ1E8JHyNDZeHYsQs1R5cwDCB3uuZt"
 
-	tests := []struct {
-		name     string
-		value    any
-		expected string
-	}{
-		{
-			name: "first page response",
-			value: NFTokenSellOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50,
-	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
-}`,
-		},
-		{
-			name: "continuation request",
-			value: NFTokenSellOffersRequest{
-				NFTokenID: nftID,
-				Limit:     50,
-				Marker:    marker,
-			},
-			expected: `{
+	firstPage := NFTokenSellOffersResponse{
+		NFTokenID: nftID,
+		Offers:    makePaginationOffers(50, "1000", 1, owner),
+		Limit:     50,
+		Marker:    marker,
+	}
+	firstPageJSON, err := json.Marshal(firstPage)
+	require.NoError(t, err)
+
+	var decodedFirstPage NFTokenSellOffersResponse
+	require.NoError(t, json.Unmarshal(firstPageJSON, &decodedFirstPage))
+	require.Equal(t, firstPage, decodedFirstPage)
+
+	firstPageFields := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal(firstPageJSON, &firstPageFields))
+	require.Contains(t, firstPageFields, "limit")
+	require.Contains(t, firstPageFields, "marker")
+
+	continuation := NFTokenSellOffersRequest{
+		NFTokenID: nftID,
+		Limit:     decodedFirstPage.Limit,
+		Marker:    decodedFirstPage.Marker,
+	}
+	continuationJSON := `{
 	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
 	"limit": 50,
 	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
-}`,
-		},
-		{
-			name: "last page response without marker",
-			value: NFTokenSellOffersResponse{
-				NFTokenID: nftID,
-				Offers:    []nfttypes.NFTokenOffer{},
-				Limit:     50,
-			},
-			expected: `{
-	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
-	"offers": [],
-	"limit": 50
-}`,
-		},
-	}
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, continuation, continuationJSON))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
-				t.Error(err)
-			}
-		})
+	lastPage := NFTokenSellOffersResponse{
+		NFTokenID: nftID,
+		Offers: []nfttypes.NFTokenOffer{
+			{
+				Amount:            "1000",
+				Flags:             1,
+				NFTokenOfferIndex: marker,
+				Owner:             owner,
+			},
+		},
 	}
+	lastPageJSON := `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [
+		{
+			"amount": "1000",
+			"flags": 1,
+			"nft_offer_index": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1",
+			"owner": "rLpSRZ1E8JHyNDZeHYsQs1R5cwDCB3uuZt"
+		}
+	]
+}`
+	require.NoError(t, testutil.SerializeAndDeserialize(t, lastPage, lastPageJSON))
 }
 
 func TestNFTokenSellOffersResponse(t *testing.T) {

--- a/xrpl/queries/nft/v1/nftoken_sell_offers_test.go
+++ b/xrpl/queries/nft/v1/nftoken_sell_offers_test.go
@@ -24,6 +24,67 @@ func TestNFTokenSellOffersRequest(t *testing.T) {
 	}
 }
 
+func TestNFTokenSellOffers_Pagination(t *testing.T) {
+	const nftID = "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007"
+	const marker = "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{
+			name: "first page response",
+			value: NFTokenSellOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50,
+	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+}`,
+		},
+		{
+			name: "continuation request",
+			value: NFTokenSellOffersRequest{
+				NFTokenID: nftID,
+				Limit:     50,
+				Marker:    marker,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"limit": 50,
+	"marker": "9E28E366573187F8E5B85CE301F229E061A619EE5A589EF740088F8843BF10A1"
+}`,
+		},
+		{
+			name: "last page response without marker",
+			value: NFTokenSellOffersResponse{
+				NFTokenID: nftID,
+				Offers:    []nfttypes.NFTokenOffer{},
+				Limit:     50,
+			},
+			expected: `{
+	"nft_id": "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",
+	"offers": [],
+	"limit": 50
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := testutil.SerializeAndDeserialize(t, tt.value, tt.expected); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestNFTokenSellOffersResponse(t *testing.T) {
 	s := NFTokenSellOffersResponse{
 		NFTokenID: "00090000D0B007439B080E9B05BF62403911301A7B1F0CFAA048C0A200000007",

--- a/xrpl/queries/vault/vault_info.go
+++ b/xrpl/queries/vault/vault_info.go
@@ -156,6 +156,8 @@ type Response struct {
 	LedgerHash string `json:"ledger_hash,omitempty"`
 	// The ledger index of the ledger version that was used to generate this response.
 	LedgerIndex *uint32 `json:"ledger_index,omitempty"`
+	// The ledger index of the current in-progress ledger used to generate this response.
+	LedgerCurrentIndex *uint32 `json:"ledger_current_index,omitempty"`
 	// If included and set to true, the information in this response comes from
 	// a validated ledger version. Otherwise, the information is subject to change.
 	Validated bool `json:"validated,omitempty"`

--- a/xrpl/queries/vault/vault_info_test.go
+++ b/xrpl/queries/vault/vault_info_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"encoding/json"
 	"testing"
 
 	ledger "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
@@ -119,9 +120,65 @@ func TestInfoRequest_Validate(t *testing.T) {
 	}
 }
 
+func TestVaultInfoResponse_LedgerMetadata(t *testing.T) {
+	currentIndex := uint32(3280200)
+	zeroIndex := uint32(0)
+	validatedIndex := uint32(3280199)
+
+	tests := []struct {
+		name     string
+		response Response
+	}{
+		{
+			name: "open ledger",
+			response: Response{
+				LedgerCurrentIndex: &currentIndex,
+			},
+		},
+		{
+			name: "present zero current index",
+			response: Response{
+				LedgerCurrentIndex: &zeroIndex,
+			},
+		},
+		{
+			name:     "omitted ledger metadata",
+			response: Response{},
+		},
+		{
+			name: "validated ledger",
+			response: Response{
+				LedgerHash:  "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+				LedgerIndex: &validatedIndex,
+				Validated:   true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.response)
+			require.NoError(t, err)
+
+			var encoded map[string]any
+			require.NoError(t, json.Unmarshal(data, &encoded))
+			if tt.response.LedgerCurrentIndex == nil {
+				require.NotContains(t, encoded, "ledger_current_index")
+			} else {
+				require.EqualValues(t, *tt.response.LedgerCurrentIndex, encoded["ledger_current_index"])
+			}
+
+			var decoded Response
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			require.Equal(t, tt.response, decoded)
+		})
+	}
+}
+
 func TestVaultInfoResponse(t *testing.T) {
 	withdrawalPolicy := types.VaultWithdrawalPolicy(0)
 	flags := uint32(0)
+	ledgerIndex := uint32(1234)
 
 	s := Response{
 		Vault: Vault{
@@ -153,8 +210,9 @@ func TestVaultInfoResponse(t *testing.T) {
 			OwnerNode:        "0000000000000000",
 			Flags:            &flags,
 		},
-		LedgerHash: "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
-		Validated:  true,
+		LedgerHash:  "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+		LedgerIndex: &ledgerIndex,
+		Validated:   true,
 	}
 
 	j := `{
@@ -188,9 +246,10 @@ func TestVaultInfoResponse(t *testing.T) {
 		"Flags": 0
 	},
 	"ledger_hash": "4C99E5F63C0D0B1C2283B4F5DCE2239F80CE92E8B1A6AED1E110C198FC96E659",
+	"ledger_index": 1234,
 	"validated": true
 }`
-	if err := testutil.Serialize(t, s, j); err != nil {
+	if err := testutil.SerializeAndDeserialize(t, s, j); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
## Description
This PR adds the request and response field additions to the query models while keeping the rippled API v1 and default (v2) packages aligned.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- `account_lines` (default + v1): request `ignore_default`, response `limit`, exact snake-case tags with round-trip and omission fixtures.
- `amm_info`: new request `account` (liquidity provider whose LP-token holdings are returned) kept distinct from the existing `amm_account` selector, response `asset_frozen`/`asset2_frozen` as `*bool` (omitted for XRP sides), and auction-slot `time_interval` (`uint8`, 0-19 while active, 20 when no active interval applies, and zero is valid). `Validate` now requires exactly one lookup style, either `amm_account` or the complete `asset`/`asset2` pair, and the asset pair uses `omitzero` so `amm_account` lookups no longer serialize empty asset objects.
- `nft_buy_offers` / `nft_sell_offers` (default + v1): request and response `limit` + `marker`. Markers stay opaque (`any`) and multi-page fixtures feed the decoded marker into continuation requests unchanged.
- `vault_info`: optional response `ledger_current_index` (`*uint32`), preserving present-zero, omitted, open-ledger, and validated-ledger states.
- v1 `account_nfts`: optional `ledger_hash` and `ledger_index` response fields matching the default package, with the default/v2 model unchanged and open/current plus validated fixtures for both API versions.
