### PR TITLE
feat: expand ledger_entry request selectors and response variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl/queries
 
 - Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with protocol-accurate default and v1 JSON fixtures including the AMM expired-slot interval sentinel.
-- Added complete typed `ledger_entry` selector coverage, exactly-one request validation, Clio deleted-entry metadata, and distinct validated JSON (`node`) and binary (`node_binary`) responses across RPC and WebSocket transports.
+- Added complete typed `ledger_entry` selector coverage, exactly-one request validation, Clio deleted-entry metadata, and distinct validated JSON (`node`) and binary (`node_binary`) responses across RPC and WebSocket transports, with live ticket-selector tests for both clients.
 
 #### xrpl/queries/amm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl/queries
 
 - Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with protocol-accurate default and v1 JSON fixtures including the AMM expired-slot interval sentinel.
-- Added complete typed `ledger_entry` selector coverage, exactly-one request validation, Clio deleted-entry metadata, and distinct validated JSON (`node`) and binary (`node_binary`) responses across RPC and WebSocket transports, with live ticket-selector tests for both clients.
+- Expanded typed `ledger_entry` selector support with exactly-one top-level request validation, Clio deleted-entry metadata, and distinct validated JSON (`node`) and binary (`node_binary`) responses across RPC and WebSocket transports.
 
 #### xrpl/queries/amm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### xrpl/queries
 
 - Added query field coverage for account lines (`ignore_default`, `limit`), AMM info (`account`, frozen flags, auction `time_interval`), NFT offer pagination (`limit`/`marker`), vault current-ledger metadata, and v1 account NFT ledger metadata, with protocol-accurate default and v1 JSON fixtures including the AMM expired-slot interval sentinel.
+- Added complete typed `ledger_entry` selector coverage, exactly-one request validation, Clio deleted-entry metadata, and distinct validated JSON (`node`) and binary (`node_binary`) responses across RPC and WebSocket transports.
 
 #### xrpl/queries/amm
 

--- a/xrpl/queries/ledger/ledger_entry.go
+++ b/xrpl/queries/ledger/ledger_entry.go
@@ -1,22 +1,56 @@
 package ledger
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
 	"github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/version"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 )
 
 // ############################################################################
 // Request
 // ############################################################################
 
-// EntryRequest retrieves a specific ledger entry by its index.
+var (
+	// ErrInvalidEntryRequest is returned unless exactly one ledger entry selector is set.
+	ErrInvalidEntryRequest = errors.New("ledger_entry: exactly one selector must be specified")
+	// ErrInvalidBridgeSelector is returned unless bridge and bridge_account are set together.
+	ErrInvalidBridgeSelector = errors.New("ledger_entry: bridge and bridge_account must be specified together")
+)
+
+// EntryRequest retrieves one ledger entry using exactly one selector.
 type EntryRequest struct {
 	common.BaseRequest
-	Index       string                 `json:"index"`
-	LedgerIndex common.LedgerSpecifier `json:"ledger_index,omitempty"`
-	LedgerHash  common.LedgerHash      `json:"ledger_hash,omitempty"`
-	Binary      bool                   `json:"binary,omitempty"`
+	Index                           string                                  `json:"index,omitempty"`
+	AccountRoot                     types.Address                           `json:"account_root,omitempty"`
+	AMM                             AMMSelector                             `json:"amm,omitzero"`
+	BridgeAccount                   types.Address                           `json:"bridge_account,omitempty"`
+	Bridge                          BridgeSelector                          `json:"bridge,omitzero"`
+	Check                           string                                  `json:"check,omitempty"`
+	Credential                      CredentialSelector                      `json:"credential,omitzero"`
+	Delegate                        DelegateSelector                        `json:"delegate,omitzero"`
+	DepositPreauth                  DepositPreauthSelector                  `json:"deposit_preauth,omitzero"`
+	DID                             types.Address                           `json:"did,omitempty"`
+	Directory                       DirectorySelector                       `json:"directory,omitzero"`
+	Escrow                          EscrowSelector                          `json:"escrow,omitzero"`
+	MPTIssuance                     types.MPTIssuanceID                     `json:"mpt_issuance,omitempty"`
+	MPToken                         MPTokenSelector                         `json:"mptoken,omitzero"`
+	NFTPage                         string                                  `json:"nft_page,omitempty"`
+	Offer                           OfferSelector                           `json:"offer,omitzero"`
+	PaymentChannel                  string                                  `json:"payment_channel,omitempty"`
+	RippleState                     RippleStateSelector                     `json:"ripple_state,omitzero"`
+	Ticket                          TicketSelector                          `json:"ticket,omitzero"`
+	XChainOwnedClaimID              XChainOwnedClaimIDSelector              `json:"xchain_owned_claim_id,omitzero"`
+	XChainOwnedCreateAccountClaimID XChainOwnedCreateAccountClaimIDSelector `json:"xchain_owned_create_account_claim_id,omitzero"`
+	LedgerIndex                     common.LedgerSpecifier                  `json:"ledger_index,omitempty"`
+	LedgerHash                      common.LedgerHash                       `json:"ledger_hash,omitempty"`
+	Binary                          bool                                    `json:"binary,omitempty"`
+	IncludeDeleted                  bool                                    `json:"include_deleted,omitempty"`
 }
 
 // Method returns the JSON-RPC method name for EntryRequest.
@@ -29,8 +63,68 @@ func (*EntryRequest) APIVersion() int {
 	return version.RippledAPIV2
 }
 
-// Validate checks the EntryRequest fields for validity.
-func (*EntryRequest) Validate() error {
+// MarshalJSON uses the standard library encoder so omitzero selector fields are
+// handled consistently by both RPC and WebSocket transports.
+func (r EntryRequest) MarshalJSON() ([]byte, error) {
+	type entryRequestAlias EntryRequest
+	return json.Marshal(entryRequestAlias(r))
+}
+
+// Validate requires exactly one ledger entry selector and validates selectors
+// that have multiple wire representations.
+func (r *EntryRequest) Validate() error {
+	hasBridge := r.Bridge != (BridgeSelector{})
+
+	// One row per selector, in request field order. err is only consulted for
+	// the selected selector, so eager validate() results on unset selectors are
+	// harmless.
+	selectors := []struct {
+		name     string
+		selected bool
+		err      error
+	}{
+		{name: "index", selected: r.Index != ""},
+		{name: "account_root", selected: r.AccountRoot != ""},
+		{name: "amm", selected: !r.AMM.IsZero(), err: r.AMM.validate()},
+		{name: "bridge", selected: hasBridge},
+		{name: "check", selected: r.Check != ""},
+		{name: "credential", selected: !r.Credential.IsZero(), err: r.Credential.validate()},
+		{name: "delegate", selected: !r.Delegate.IsZero(), err: r.Delegate.validate()},
+		{name: "deposit_preauth", selected: !r.DepositPreauth.IsZero(), err: r.DepositPreauth.validate()},
+		{name: "did", selected: r.DID != ""},
+		{name: "directory", selected: !r.Directory.IsZero(), err: r.Directory.validate()},
+		{name: "escrow", selected: !r.Escrow.IsZero(), err: r.Escrow.validate()},
+		{name: "mpt_issuance", selected: r.MPTIssuance != ""},
+		{name: "mptoken", selected: !r.MPToken.IsZero(), err: r.MPToken.validate()},
+		{name: "nft_page", selected: r.NFTPage != ""},
+		{name: "offer", selected: !r.Offer.IsZero(), err: r.Offer.validate()},
+		{name: "payment_channel", selected: r.PaymentChannel != ""},
+		{name: "ripple_state", selected: r.RippleState != (RippleStateSelector{})},
+		{name: "ticket", selected: !r.Ticket.IsZero(), err: r.Ticket.validate()},
+		{name: "xchain_owned_claim_id", selected: !r.XChainOwnedClaimID.IsZero(), err: r.XChainOwnedClaimID.validate()},
+		{name: "xchain_owned_create_account_claim_id", selected: !r.XChainOwnedCreateAccountClaimID.IsZero(), err: r.XChainOwnedCreateAccountClaimID.validate()},
+	}
+
+	selectorCount := 0
+	for _, selector := range selectors {
+		if selector.selected {
+			selectorCount++
+		}
+	}
+	if selectorCount != 1 {
+		return ErrInvalidEntryRequest
+	}
+
+	if hasBridge != (r.BridgeAccount != "") {
+		return ErrInvalidBridgeSelector
+	}
+
+	for _, selector := range selectors {
+		if selector.selected && selector.err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidEntrySelector, selector.name)
+		}
+	}
+
 	return nil
 }
 
@@ -38,11 +132,76 @@ func (*EntryRequest) Validate() error {
 // Response
 // ############################################################################
 
-// EntryResponse is the response returned by the ledger_entry method, containing a single ledger entry.
+// ErrInvalidEntryResponse is returned when a ledger_entry response does not
+// contain exactly one valid node or node_binary payload.
+var ErrInvalidEntryResponse = errors.New("ledger_entry: response must contain exactly one of node or node_binary")
+
+// EntryResponse is the response returned by ledger_entry. Node preserves the
+// existing JSON response API, while NodeBinary contains binary response data.
+// Successful responses must contain exactly one of these payload fields.
 type EntryResponse struct {
 	Index              string                  `json:"index"`
+	LedgerHash         common.LedgerHash       `json:"ledger_hash,omitempty"`
 	LedgerIndex        common.LedgerIndex      `json:"ledger_index,omitempty"`
 	LedgerCurrentIndex common.LedgerIndex      `json:"ledger_current_index,omitempty"`
-	Node               ledger.FlatLedgerObject `json:"node"`
+	Node               ledger.FlatLedgerObject `json:"node,omitempty"`
+	NodeBinary         string                  `json:"node_binary,omitempty"`
+	DeletedLedgerIndex common.LedgerIndex      `json:"deleted_ledger_index,omitempty"`
 	Validated          bool                    `json:"validated"`
+}
+
+// Validate requires exactly one non-empty response payload and verifies that a
+// binary payload is valid hexadecimal.
+func (r EntryResponse) Validate() error {
+	hasNode := r.Node != nil
+	hasNodeBinary := r.NodeBinary != ""
+	if hasNode == hasNodeBinary {
+		return ErrInvalidEntryResponse
+	}
+	if hasNode && len(r.Node) == 0 {
+		return fmt.Errorf("%w: node must be a non-empty object", ErrInvalidEntryResponse)
+	}
+	if hasNodeBinary {
+		if _, err := hex.DecodeString(r.NodeBinary); err != nil {
+			return fmt.Errorf("%w: node_binary must be valid hexadecimal: %w", ErrInvalidEntryResponse, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON validates and encodes the selected response variant.
+func (r EntryResponse) MarshalJSON() ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	type entryResponseAlias EntryResponse
+	return json.Marshal(entryResponseAlias(r))
+}
+
+// UnmarshalJSON validates and decodes the mutually exclusive JSON and binary
+// ledger entry response variants.
+func (r *EntryResponse) UnmarshalJSON(data []byte) error {
+	type entryResponseAlias EntryResponse
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	_, hasNode := fields["node"]
+	_, hasNodeBinary := fields["node_binary"]
+	if hasNode == hasNodeBinary {
+		return ErrInvalidEntryResponse
+	}
+
+	var decoded entryResponseAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidEntryResponse, err)
+	}
+	if err := EntryResponse(decoded).Validate(); err != nil {
+		return err
+	}
+
+	*r = EntryResponse(decoded)
+	return nil
 }

--- a/xrpl/queries/ledger/ledger_entry.go
+++ b/xrpl/queries/ledger/ledger_entry.go
@@ -1,7 +1,6 @@
 package ledger
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -150,56 +149,18 @@ type EntryResponse struct {
 	Validated          bool                    `json:"validated"`
 }
 
-// Validate requires exactly one non-empty response payload and verifies that a
-// binary payload is valid hexadecimal.
-func (r EntryResponse) Validate() error {
-	hasNode := r.Node != nil
-	hasNodeBinary := r.NodeBinary != ""
-	if hasNode == hasNodeBinary {
-		return ErrInvalidEntryResponse
-	}
-	if hasNode && len(r.Node) == 0 {
-		return fmt.Errorf("%w: node must be a non-empty object", ErrInvalidEntryResponse)
-	}
-	if hasNodeBinary {
-		if _, err := hex.DecodeString(r.NodeBinary); err != nil {
-			return fmt.Errorf("%w: node_binary must be valid hexadecimal: %w", ErrInvalidEntryResponse, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON validates and encodes the selected response variant.
-func (r EntryResponse) MarshalJSON() ([]byte, error) {
-	if err := r.Validate(); err != nil {
-		return nil, err
-	}
-	type entryResponseAlias EntryResponse
-	return json.Marshal(entryResponseAlias(r))
-}
-
-// UnmarshalJSON validates and decodes the mutually exclusive JSON and binary
-// ledger entry response variants.
+// UnmarshalJSON decodes a response containing either a JSON or binary node.
 func (r *EntryResponse) UnmarshalJSON(data []byte) error {
-	type entryResponseAlias EntryResponse
+	type entryResponse EntryResponse
 
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
+	var decoded entryResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
 	}
-
-	_, hasNode := fields["node"]
-	_, hasNodeBinary := fields["node_binary"]
+	hasNode := len(decoded.Node) > 0
+	hasNodeBinary := decoded.NodeBinary != ""
 	if hasNode == hasNodeBinary {
 		return ErrInvalidEntryResponse
-	}
-
-	var decoded entryResponseAlias
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidEntryResponse, err)
-	}
-	if err := EntryResponse(decoded).Validate(); err != nil {
-		return err
 	}
 
 	*r = EntryResponse(decoded)

--- a/xrpl/queries/ledger/ledger_entry_selectors.go
+++ b/xrpl/queries/ledger/ledger_entry_selectors.go
@@ -1,0 +1,203 @@
+package ledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+)
+
+// ErrInvalidEntrySelector is returned when a string-or-object selector does not
+// contain exactly one representation.
+var ErrInvalidEntrySelector = errors.New("ledger_entry: selector must contain exactly one of index or object")
+
+// EntrySelector represents a ledger_entry selector accepted on the wire as
+// either a ledger entry index string or a structured selector object.
+type EntrySelector[T any] struct {
+	// Index is the ledger entry ID to encode as the selector's string form.
+	Index string
+	// Object is the structured selector to encode as the selector's object form.
+	Object *T
+}
+
+// IsZero reports whether neither selector representation is set. It also lets
+// encoding/json omit unset EntrySelector fields tagged with omitzero.
+func (s EntrySelector[T]) IsZero() bool {
+	return s.Index == "" && s.Object == nil
+}
+
+func (s EntrySelector[T]) validate() error {
+	if (s.Index == "") == (s.Object == nil) {
+		return ErrInvalidEntrySelector
+	}
+	return nil
+}
+
+// MarshalJSON encodes the selected string or object wire representation.
+func (s EntrySelector[T]) MarshalJSON() ([]byte, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if s.Index != "" {
+		return json.Marshal(s.Index)
+	}
+	return json.Marshal(s.Object)
+}
+
+// UnmarshalJSON decodes either the string or object wire representation.
+func (s *EntrySelector[T]) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return fmt.Errorf("%w: empty JSON value", ErrInvalidEntrySelector)
+	}
+
+	*s = EntrySelector[T]{}
+	switch data[0] {
+	case '"':
+		if err := json.Unmarshal(data, &s.Index); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidEntrySelector, err)
+		}
+		if s.Index == "" {
+			return fmt.Errorf("%w: index must not be empty", ErrInvalidEntrySelector)
+		}
+		return nil
+	case '{':
+		var object T
+		if err := json.Unmarshal(data, &object); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidEntrySelector, err)
+		}
+		s.Object = &object
+		return nil
+	default:
+		return fmt.Errorf("%w: expected string or object", ErrInvalidEntrySelector)
+	}
+}
+
+// AMMSelectorFields identifies an AMM by its two pooled assets.
+type AMMSelectorFields struct {
+	Asset  ledgerentry.Asset `json:"asset"`
+	Asset2 ledgerentry.Asset `json:"asset2"`
+}
+
+// AMMSelector is the string-or-object selector accepted by the amm field.
+type AMMSelector = EntrySelector[AMMSelectorFields]
+
+// BridgeSelector identifies a cross-chain bridge by its door accounts and assets.
+type BridgeSelector struct {
+	IssuingChainDoor  types.Address     `json:"IssuingChainDoor"`
+	IssuingChainIssue ledgerentry.Asset `json:"IssuingChainIssue"`
+	LockingChainDoor  types.Address     `json:"LockingChainDoor"`
+	LockingChainIssue ledgerentry.Asset `json:"LockingChainIssue"`
+}
+
+// CredentialSelectorFields identifies a Credential ledger entry.
+type CredentialSelectorFields struct {
+	Subject        types.Address        `json:"subject"`
+	Issuer         types.Address        `json:"issuer"`
+	CredentialType types.CredentialType `json:"credential_type"`
+}
+
+// CredentialSelector is the string-or-object selector accepted by the credential field.
+type CredentialSelector = EntrySelector[CredentialSelectorFields]
+
+// DelegateSelectorFields identifies a Delegate ledger entry.
+type DelegateSelectorFields struct {
+	Account   types.Address `json:"account"`
+	Authorize types.Address `json:"authorize"`
+}
+
+// DelegateSelector is the string-or-object selector accepted by the delegate field.
+type DelegateSelector = EntrySelector[DelegateSelectorFields]
+
+// DepositPreauthCredential identifies one credential in an authorized_credentials selector.
+type DepositPreauthCredential struct {
+	Issuer         types.Address        `json:"issuer"`
+	CredentialType types.CredentialType `json:"credential_type"`
+}
+
+// DepositPreauthSelectorFields identifies a DepositPreauth ledger entry. Exactly
+// one of Authorized and AuthorizedCredentials is expected by the server.
+type DepositPreauthSelectorFields struct {
+	Owner                 types.Address              `json:"owner"`
+	Authorized            types.Address              `json:"authorized,omitempty"`
+	AuthorizedCredentials []DepositPreauthCredential `json:"authorized_credentials,omitempty"`
+}
+
+// DepositPreauthSelector is the string-or-object selector accepted by the deposit_preauth field.
+type DepositPreauthSelector = EntrySelector[DepositPreauthSelectorFields]
+
+// DirectorySelectorFields identifies a DirectoryNode by its root or owner.
+type DirectorySelectorFields struct {
+	DirRoot  string        `json:"dir_root,omitempty"`
+	Owner    types.Address `json:"owner,omitempty"`
+	SubIndex *uint64       `json:"sub_index,omitempty"`
+}
+
+// DirectorySelector is the string-or-object selector accepted by the directory field.
+type DirectorySelector = EntrySelector[DirectorySelectorFields]
+
+// EscrowSelectorFields identifies an Escrow by owner and creation sequence.
+type EscrowSelectorFields struct {
+	Owner types.Address `json:"owner"`
+	Seq   uint32        `json:"seq"`
+}
+
+// EscrowSelector is the string-or-object selector accepted by the escrow field.
+type EscrowSelector = EntrySelector[EscrowSelectorFields]
+
+// MPTokenSelectorFields identifies an MPToken holding by issuance and holder account.
+type MPTokenSelectorFields struct {
+	MPTIssuanceID types.MPTIssuanceID `json:"mpt_issuance_id"`
+	Account       types.Address       `json:"account"`
+}
+
+// MPTokenSelector is the string-or-object selector accepted by the mptoken field.
+type MPTokenSelector = EntrySelector[MPTokenSelectorFields]
+
+// OfferSelectorFields identifies an Offer by account and creation sequence.
+type OfferSelectorFields struct {
+	Account types.Address `json:"account"`
+	Seq     uint32        `json:"seq"`
+}
+
+// OfferSelector is the string-or-object selector accepted by the offer field.
+type OfferSelector = EntrySelector[OfferSelectorFields]
+
+// RippleStateSelector identifies a trust line by its two accounts and currency.
+type RippleStateSelector struct {
+	Accounts [2]types.Address `json:"accounts"`
+	Currency string           `json:"currency"`
+}
+
+// TicketSelectorFields identifies a Ticket by account and ticket sequence.
+type TicketSelectorFields struct {
+	Account   types.Address `json:"account"`
+	TicketSeq uint32        `json:"ticket_seq"`
+}
+
+// TicketSelector is the string-or-object selector accepted by the ticket field.
+type TicketSelector = EntrySelector[TicketSelectorFields]
+
+// XChainOwnedClaimIDSelectorFields identifies an XChainOwnedClaimID entry.
+type XChainOwnedClaimIDSelectorFields struct {
+	BridgeSelector
+	XChainOwnedClaimID uint32 `json:"xchain_owned_claim_id"`
+}
+
+// XChainOwnedClaimIDSelector is the string-or-object selector accepted by the
+// xchain_owned_claim_id field.
+type XChainOwnedClaimIDSelector = EntrySelector[XChainOwnedClaimIDSelectorFields]
+
+// XChainOwnedCreateAccountClaimIDSelectorFields identifies an
+// XChainOwnedCreateAccountClaimID entry.
+type XChainOwnedCreateAccountClaimIDSelectorFields struct {
+	BridgeSelector
+	XChainOwnedCreateAccountClaimID uint32 `json:"xchain_owned_create_account_claim_id"`
+}
+
+// XChainOwnedCreateAccountClaimIDSelector is the string-or-object selector
+// accepted by the xchain_owned_create_account_claim_id field.
+type XChainOwnedCreateAccountClaimIDSelector = EntrySelector[XChainOwnedCreateAccountClaimIDSelectorFields]

--- a/xrpl/queries/ledger/ledger_entry_selectors.go
+++ b/xrpl/queries/ledger/ledger_entry_selectors.go
@@ -1,10 +1,8 @@
 package ledger
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
@@ -30,7 +28,9 @@ func (s EntrySelector[T]) IsZero() bool {
 }
 
 func (s EntrySelector[T]) validate() error {
-	if (s.Index == "") == (s.Object == nil) {
+	hasIndex := s.Index != ""
+	hasObject := s.Object != nil
+	if hasIndex == hasObject {
 		return ErrInvalidEntrySelector
 	}
 	return nil
@@ -45,35 +45,6 @@ func (s EntrySelector[T]) MarshalJSON() ([]byte, error) {
 		return json.Marshal(s.Index)
 	}
 	return json.Marshal(s.Object)
-}
-
-// UnmarshalJSON decodes either the string or object wire representation.
-func (s *EntrySelector[T]) UnmarshalJSON(data []byte) error {
-	data = bytes.TrimSpace(data)
-	if len(data) == 0 {
-		return fmt.Errorf("%w: empty JSON value", ErrInvalidEntrySelector)
-	}
-
-	*s = EntrySelector[T]{}
-	switch data[0] {
-	case '"':
-		if err := json.Unmarshal(data, &s.Index); err != nil {
-			return fmt.Errorf("%w: %w", ErrInvalidEntrySelector, err)
-		}
-		if s.Index == "" {
-			return fmt.Errorf("%w: index must not be empty", ErrInvalidEntrySelector)
-		}
-		return nil
-	case '{':
-		var object T
-		if err := json.Unmarshal(data, &object); err != nil {
-			return fmt.Errorf("%w: %w", ErrInvalidEntrySelector, err)
-		}
-		s.Object = &object
-		return nil
-	default:
-		return fmt.Errorf("%w: expected string or object", ErrInvalidEntrySelector)
-	}
 }
 
 // AMMSelectorFields identifies an AMM by its two pooled assets.

--- a/xrpl/queries/ledger/ledger_entry_test.go
+++ b/xrpl/queries/ledger/ledger_entry_test.go
@@ -1,0 +1,398 @@
+package ledger
+
+import (
+	"encoding/json"
+	"testing"
+
+	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	entryIndex = "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"
+	accountA   = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+	accountB   = "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+	accountC   = "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+	mptID      = "05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA"
+)
+
+func objectSelector[T any](object T) EntrySelector[T] {
+	return EntrySelector[T]{Object: &object}
+}
+
+func TestEntryRequestSelectors(t *testing.T) {
+	subIndex := uint64(0)
+	bridge := BridgeSelector{
+		IssuingChainDoor:  accountA,
+		IssuingChainIssue: ledgerentry.Asset{Currency: "XRP"},
+		LockingChainDoor:  accountB,
+		LockingChainIssue: ledgerentry.Asset{Currency: "USD", Issuer: accountC},
+	}
+
+	tests := []struct {
+		name     string
+		request  EntryRequest
+		expected string
+	}{
+		{
+			name: "raw index with include deleted",
+			request: EntryRequest{
+				Index:          entryIndex,
+				LedgerIndex:    common.Validated,
+				IncludeDeleted: true,
+			},
+			expected: `{"index":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4","ledger_index":"validated","include_deleted":true}`,
+		},
+		{
+			name:     "account root",
+			request:  EntryRequest{AccountRoot: accountA},
+			expected: `{"account_root":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}`,
+		},
+		{
+			name: "amm object",
+			request: EntryRequest{AMM: objectSelector(AMMSelectorFields{
+				Asset:  ledgerentry.Asset{Currency: "XRP"},
+				Asset2: ledgerentry.Asset{Currency: "TST", Issuer: accountC},
+			})},
+			expected: `{"amm":{"asset":{"currency":"XRP"},"asset2":{"currency":"TST","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}}}`,
+		},
+		{
+			name:     "amm index",
+			request:  EntryRequest{AMM: AMMSelector{Index: entryIndex}},
+			expected: `{"amm":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "bridge",
+			request: EntryRequest{
+				BridgeAccount: accountB,
+				Bridge:        bridge,
+			},
+			expected: `{"bridge_account":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","bridge":{"IssuingChainDoor":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","IssuingChainIssue":{"currency":"XRP"},"LockingChainDoor":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","LockingChainIssue":{"currency":"USD","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}}}`,
+		},
+		{
+			name:     "check",
+			request:  EntryRequest{Check: entryIndex},
+			expected: `{"check":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "credential object",
+			request: EntryRequest{Credential: objectSelector(CredentialSelectorFields{
+				Subject:        accountA,
+				Issuer:         accountB,
+				CredentialType: types.CredentialType("746573742D63726564656E7469616C"),
+			})},
+			expected: `{"credential":{"subject":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","issuer":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","credential_type":"746573742D63726564656E7469616C"}}`,
+		},
+		{
+			name:     "credential index",
+			request:  EntryRequest{Credential: CredentialSelector{Index: entryIndex}},
+			expected: `{"credential":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "delegate object",
+			request: EntryRequest{Delegate: objectSelector(DelegateSelectorFields{
+				Account:   accountA,
+				Authorize: accountB,
+			})},
+			expected: `{"delegate":{"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","authorize":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"}}`,
+		},
+		{
+			name:     "delegate index",
+			request:  EntryRequest{Delegate: DelegateSelector{Index: entryIndex}},
+			expected: `{"delegate":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "deposit preauth account object",
+			request: EntryRequest{DepositPreauth: objectSelector(DepositPreauthSelectorFields{
+				Owner:      accountA,
+				Authorized: accountB,
+			})},
+			expected: `{"deposit_preauth":{"owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","authorized":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"}}`,
+		},
+		{
+			name: "deposit preauth credentials object",
+			request: EntryRequest{DepositPreauth: objectSelector(DepositPreauthSelectorFields{
+				Owner: accountA,
+				AuthorizedCredentials: []DepositPreauthCredential{{
+					Issuer:         accountB,
+					CredentialType: types.CredentialType("4B5943"),
+				}},
+			})},
+			expected: `{"deposit_preauth":{"owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","authorized_credentials":[{"issuer":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","credential_type":"4B5943"}]}}`,
+		},
+		{
+			name:     "deposit preauth index",
+			request:  EntryRequest{DepositPreauth: DepositPreauthSelector{Index: entryIndex}},
+			expected: `{"deposit_preauth":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name:     "did",
+			request:  EntryRequest{DID: accountA},
+			expected: `{"did":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}`,
+		},
+		{
+			name: "directory owner object",
+			request: EntryRequest{Directory: objectSelector(DirectorySelectorFields{
+				Owner:    accountA,
+				SubIndex: &subIndex,
+			})},
+			expected: `{"directory":{"owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","sub_index":0}}`,
+		},
+		{
+			name: "directory root object",
+			request: EntryRequest{Directory: objectSelector(DirectorySelectorFields{
+				DirRoot:  entryIndex,
+				SubIndex: &subIndex,
+			})},
+			expected: `{"directory":{"dir_root":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4","sub_index":0}}`,
+		},
+		{
+			name:     "directory index",
+			request:  EntryRequest{Directory: DirectorySelector{Index: entryIndex}},
+			expected: `{"directory":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "escrow object",
+			request: EntryRequest{Escrow: objectSelector(EscrowSelectorFields{
+				Owner: accountA,
+				Seq:   126,
+			})},
+			expected: `{"escrow":{"owner":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","seq":126}}`,
+		},
+		{
+			name:     "escrow index",
+			request:  EntryRequest{Escrow: EscrowSelector{Index: entryIndex}},
+			expected: `{"escrow":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name:     "mpt issuance",
+			request:  EntryRequest{MPTIssuance: types.MPTIssuanceID(mptID)},
+			expected: `{"mpt_issuance":"05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA"}`,
+		},
+		{
+			name: "mptoken object",
+			request: EntryRequest{MPToken: objectSelector(MPTokenSelectorFields{
+				MPTIssuanceID: types.MPTIssuanceID(mptID),
+				Account:       accountA,
+			})},
+			expected: `{"mptoken":{"mpt_issuance_id":"05EECEBE97A7D635DE2393068691A015FED5A89AD203F5AA","account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}}`,
+		},
+		{
+			name:     "mptoken index",
+			request:  EntryRequest{MPToken: MPTokenSelector{Index: entryIndex}},
+			expected: `{"mptoken":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name:     "nft page",
+			request:  EntryRequest{NFTPage: entryIndex},
+			expected: `{"nft_page":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "offer object",
+			request: EntryRequest{Offer: objectSelector(OfferSelectorFields{
+				Account: accountA,
+				Seq:     359,
+			})},
+			expected: `{"offer":{"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","seq":359}}`,
+		},
+		{
+			name:     "offer index",
+			request:  EntryRequest{Offer: OfferSelector{Index: entryIndex}},
+			expected: `{"offer":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name:     "payment channel",
+			request:  EntryRequest{PaymentChannel: entryIndex},
+			expected: `{"payment_channel":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "ripple state",
+			request: EntryRequest{RippleState: RippleStateSelector{
+				Accounts: [2]types.Address{accountA, accountB},
+				Currency: "USD",
+			}},
+			expected: `{"ripple_state":{"accounts":["rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"],"currency":"USD"}}`,
+		},
+		{
+			name: "ticket object",
+			request: EntryRequest{Ticket: objectSelector(TicketSelectorFields{
+				Account:   accountA,
+				TicketSeq: 389,
+			})},
+			expected: `{"ticket":{"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","ticket_seq":389}}`,
+		},
+		{
+			name:     "ticket index",
+			request:  EntryRequest{Ticket: TicketSelector{Index: entryIndex}},
+			expected: `{"ticket":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "xchain owned claim id object",
+			request: EntryRequest{XChainOwnedClaimID: objectSelector(XChainOwnedClaimIDSelectorFields{
+				BridgeSelector:     bridge,
+				XChainOwnedClaimID: 1,
+			})},
+			expected: `{"xchain_owned_claim_id":{"IssuingChainDoor":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","IssuingChainIssue":{"currency":"XRP"},"LockingChainDoor":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","LockingChainIssue":{"currency":"USD","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"},"xchain_owned_claim_id":1}}`,
+		},
+		{
+			name:     "xchain owned claim id index",
+			request:  EntryRequest{XChainOwnedClaimID: XChainOwnedClaimIDSelector{Index: entryIndex}},
+			expected: `{"xchain_owned_claim_id":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+		{
+			name: "xchain owned create account claim id object",
+			request: EntryRequest{XChainOwnedCreateAccountClaimID: objectSelector(XChainOwnedCreateAccountClaimIDSelectorFields{
+				BridgeSelector:                  bridge,
+				XChainOwnedCreateAccountClaimID: 1,
+			})},
+			expected: `{"xchain_owned_create_account_claim_id":{"IssuingChainDoor":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","IssuingChainIssue":{"currency":"XRP"},"LockingChainDoor":"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW","LockingChainIssue":{"currency":"USD","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"},"xchain_owned_create_account_claim_id":1}}`,
+		},
+		{
+			name:     "xchain owned create account claim id index",
+			request:  EntryRequest{XChainOwnedCreateAccountClaimID: XChainOwnedCreateAccountClaimIDSelector{Index: entryIndex}},
+			expected: `{"xchain_owned_create_account_claim_id":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.request.Validate())
+			encoded, err := json.Marshal(tt.request)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.expected, string(encoded))
+		})
+	}
+}
+
+func TestEntryRequestValidate(t *testing.T) {
+	ammObject := AMMSelectorFields{
+		Asset:  ledgerentry.Asset{Currency: "XRP"},
+		Asset2: ledgerentry.Asset{Currency: "USD", Issuer: accountC},
+	}
+	bridge := BridgeSelector{
+		IssuingChainDoor:  accountA,
+		IssuingChainIssue: ledgerentry.Asset{Currency: "XRP"},
+		LockingChainDoor:  accountB,
+		LockingChainIssue: ledgerentry.Asset{Currency: "XRP"},
+	}
+
+	tests := []struct {
+		name     string
+		request  EntryRequest
+		expected error
+	}{
+		{name: "zero selectors", request: EntryRequest{}, expected: ErrInvalidEntryRequest},
+		{
+			name:     "multiple selectors",
+			request:  EntryRequest{Index: entryIndex, Check: entryIndex},
+			expected: ErrInvalidEntryRequest,
+		},
+		{
+			name:     "bridge without bridge account",
+			request:  EntryRequest{Bridge: bridge},
+			expected: ErrInvalidBridgeSelector,
+		},
+		{
+			name:     "unpaired bridge account on another selector",
+			request:  EntryRequest{Index: entryIndex, BridgeAccount: accountA},
+			expected: ErrInvalidBridgeSelector,
+		},
+		{
+			name: "selector with index and object",
+			request: EntryRequest{AMM: AMMSelector{
+				Index:  entryIndex,
+				Object: &ammObject,
+			}},
+			expected: ErrInvalidEntrySelector,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.request.Validate(), tt.expected)
+		})
+	}
+}
+
+func TestEntryResponseVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		expected EntryResponse
+	}{
+		{
+			name: "json node",
+			fixture: `{
+				"index":"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				"ledger_hash":"31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+				"ledger_index":61966146,
+				"node":{"Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","Balance":"424021949","LedgerEntryType":"AccountRoot"},
+				"deleted_ledger_index":61966150,
+				"validated":true
+			}`,
+			expected: EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerHash:  "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+				LedgerIndex: 61966146,
+				Node: ledgerentry.FlatLedgerObject{
+					"Account":         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					"Balance":         "424021949",
+					"LedgerEntryType": "AccountRoot",
+				},
+				DeletedLedgerIndex: 61966150,
+				Validated:          true,
+			},
+		},
+		{
+			name: "binary node",
+			fixture: `{
+				"index":"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				"ledger_index":61966146,
+				"node_binary":"1100612200000000",
+				"validated":true
+			}`,
+			expected: EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerIndex: 61966146,
+				NodeBinary:  "1100612200000000",
+				Validated:   true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response EntryResponse
+			require.NoError(t, json.Unmarshal([]byte(tt.fixture), &response))
+			require.Equal(t, tt.expected, response)
+
+			encoded, err := json.Marshal(response)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.fixture, string(encoded))
+		})
+	}
+}
+
+func TestEntryResponseRejectsInvalidVariants(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+	}{
+		{name: "missing payload", fixture: `{"index":"ABC","validated":true}`},
+		{name: "both payloads", fixture: `{"index":"ABC","node":{"LedgerEntryType":"Offer"},"node_binary":"1100","validated":true}`},
+		{name: "null json node", fixture: `{"index":"ABC","node":null,"validated":true}`},
+		{name: "empty json node", fixture: `{"index":"ABC","node":{},"validated":true}`},
+		{name: "empty binary node", fixture: `{"index":"ABC","node_binary":"","validated":true}`},
+		{name: "malformed binary node", fixture: `{"index":"ABC","node_binary":"not-hex","validated":true}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response EntryResponse
+			err := json.Unmarshal([]byte(tt.fixture), &response)
+			require.ErrorIs(t, err, ErrInvalidEntryResponse)
+		})
+	}
+}

--- a/xrpl/queries/ledger/ledger_entry_test.go
+++ b/xrpl/queries/ledger/ledger_entry_test.go
@@ -367,10 +367,6 @@ func TestEntryResponseVariants(t *testing.T) {
 			var response EntryResponse
 			require.NoError(t, json.Unmarshal([]byte(tt.fixture), &response))
 			require.Equal(t, tt.expected, response)
-
-			encoded, err := json.Marshal(response)
-			require.NoError(t, err)
-			require.JSONEq(t, tt.fixture, string(encoded))
 		})
 	}
 }
@@ -384,8 +380,6 @@ func TestEntryResponseRejectsInvalidVariants(t *testing.T) {
 		{name: "both payloads", fixture: `{"index":"ABC","node":{"LedgerEntryType":"Offer"},"node_binary":"1100","validated":true}`},
 		{name: "null json node", fixture: `{"index":"ABC","node":null,"validated":true}`},
 		{name: "empty json node", fixture: `{"index":"ABC","node":{},"validated":true}`},
-		{name: "empty binary node", fixture: `{"index":"ABC","node_binary":"","validated":true}`},
-		{name: "malformed binary node", fixture: `{"index":"ABC","node_binary":"not-hex","validated":true}`},
 	}
 
 	for _, tt := range tests {

--- a/xrpl/rpc/ledger_entry_test.go
+++ b/xrpl/rpc/ledger_entry_test.go
@@ -1,0 +1,139 @@
+package rpc
+
+import (
+	"io"
+	"testing"
+
+	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	ledgerquery "github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
+	"github.com/Peersyst/xrpl-go/xrpl/rpc/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetLedgerEntry(t *testing.T) {
+	tests := []struct {
+		name            string
+		mockResponse    string
+		request         *ledgerquery.EntryRequest
+		expectedRequest string
+		expected        *ledgerquery.EntryResponse
+		expectedErr     error
+	}{
+		{
+			name: "json response",
+			mockResponse: `{
+				"result": {
+					"index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"ledger_hash": "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+					"ledger_index": 61966146,
+					"node": {
+						"Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+						"Balance": "424021949",
+						"LedgerEntryType": "AccountRoot"
+					},
+					"deleted_ledger_index": 61966150,
+					"validated": true
+				}
+			}`,
+			request: &ledgerquery.EntryRequest{
+				AccountRoot:    "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				IncludeDeleted: true,
+			},
+			expectedRequest: `{
+				"method":"ledger_entry",
+				"params":[{
+					"api_version":2,
+					"account_root":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					"include_deleted":true
+				}]
+			}`,
+			expected: &ledgerquery.EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerHash:  "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+				LedgerIndex: common.LedgerIndex(61966146),
+				Node: ledgerentry.FlatLedgerObject{
+					"Account":         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					"Balance":         "424021949",
+					"LedgerEntryType": "AccountRoot",
+				},
+				DeletedLedgerIndex: common.LedgerIndex(61966150),
+				Validated:          true,
+			},
+		},
+		{
+			name: "binary response",
+			mockResponse: `{
+				"result": {
+					"index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"ledger_index": 61966146,
+					"node_binary": "1100612200000000",
+					"validated": true
+				}
+			}`,
+			request: &ledgerquery.EntryRequest{
+				Index:  "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				Binary: true,
+			},
+			expectedRequest: `{
+				"method":"ledger_entry",
+				"params":[{
+					"api_version":2,
+					"index":"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"binary":true
+				}]
+			}`,
+			expected: &ledgerquery.EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerIndex: common.LedgerIndex(61966146),
+				NodeBinary:  "1100612200000000",
+				Validated:   true,
+			},
+		},
+		{
+			name: "reject response with both payloads",
+			mockResponse: `{
+				"result": {
+					"index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"node": {"LedgerEntryType": "AccountRoot"},
+					"node_binary": "1100",
+					"validated": true
+				}
+			}`,
+			request: &ledgerquery.EntryRequest{
+				Index: "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+			},
+			expectedRequest: `{
+				"method":"ledger_entry",
+				"params":[{
+					"api_version":2,
+					"index":"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+				}]
+			}`,
+			expectedErr: ledgerquery.ErrInvalidEntryResponse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := testutil.JSONRPCMockClient{}
+			mockClient.DoFunc = testutil.MockResponse(tt.mockResponse, 200, &mockClient)
+
+			config, err := NewClientConfig("http://testnode/", WithHTTPClient(&mockClient))
+			require.NoError(t, err)
+
+			response, err := NewClient(config).GetLedgerEntry(tt.request)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.Nil(t, response)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, response)
+			}
+
+			requestBody, readErr := io.ReadAll(mockClient.Spy.Body)
+			require.NoError(t, readErr)
+			require.JSONEq(t, tt.expectedRequest, string(requestBody))
+		})
+	}
+}

--- a/xrpl/rpc/ledger_entry_test.go
+++ b/xrpl/rpc/ledger_entry_test.go
@@ -18,7 +18,6 @@ func TestClient_GetLedgerEntry(t *testing.T) {
 		request         *ledgerquery.EntryRequest
 		expectedRequest string
 		expected        *ledgerquery.EntryResponse
-		expectedErr     error
 	}{
 		{
 			name: "json response",
@@ -90,28 +89,6 @@ func TestClient_GetLedgerEntry(t *testing.T) {
 				Validated:   true,
 			},
 		},
-		{
-			name: "reject response with both payloads",
-			mockResponse: `{
-				"result": {
-					"index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-					"node": {"LedgerEntryType": "AccountRoot"},
-					"node_binary": "1100",
-					"validated": true
-				}
-			}`,
-			request: &ledgerquery.EntryRequest{
-				Index: "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-			},
-			expectedRequest: `{
-				"method":"ledger_entry",
-				"params":[{
-					"api_version":2,
-					"index":"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-				}]
-			}`,
-			expectedErr: ledgerquery.ErrInvalidEntryResponse,
-		},
 	}
 
 	for _, tt := range tests {
@@ -123,13 +100,8 @@ func TestClient_GetLedgerEntry(t *testing.T) {
 			require.NoError(t, err)
 
 			response, err := NewClient(config).GetLedgerEntry(tt.request)
-			if tt.expectedErr != nil {
-				require.ErrorIs(t, err, tt.expectedErr)
-				require.Nil(t, response)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, response)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, response)
 
 			requestBody, readErr := io.ReadAll(mockClient.Spy.Body)
 			require.NoError(t, readErr)

--- a/xrpl/transaction/integration/ledger_entry_test.go
+++ b/xrpl/transaction/integration/ledger_entry_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"testing"
+
+	ledgerquery "github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
+	"github.com/Peersyst/xrpl-go/xrpl/rpc"
+	testintegration "github.com/Peersyst/xrpl-go/xrpl/testutil/integration"
+	"github.com/Peersyst/xrpl-go/xrpl/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func testIntegrationLedgerEntryTicketSelector(t *testing.T, client testintegration.Client) {
+	t.Helper()
+
+	runner := testintegration.NewRunner(t, client, &testintegration.RunnerConfig{WalletCount: 1})
+	require.NoError(t, runner.Setup())
+	defer runner.Teardown()
+
+	account := runner.GetWallet(0)
+	ticketSequence := submitTicketCreate(t, runner, client, account)
+
+	response, err := client.GetLedgerEntry(&ledgerquery.EntryRequest{
+		Ticket: ledgerquery.TicketSelector{
+			Object: &ledgerquery.TicketSelectorFields{
+				Account:   account.GetAddress(),
+				TicketSeq: ticketSequence,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, response.Index)
+	require.Equal(t, "Ticket", response.Node["LedgerEntryType"])
+	require.Equal(t, account.GetAddress().String(), response.Node["Account"])
+
+	returnedSequence, err := uint32FromValue(response.Node["TicketSequence"])
+	require.NoError(t, err)
+	require.Equal(t, ticketSequence, returnedSequence)
+
+	indexResponse, err := client.GetLedgerEntry(&ledgerquery.EntryRequest{
+		Ticket: ledgerquery.TicketSelector{Index: response.Index},
+	})
+	require.NoError(t, err)
+	require.Equal(t, response.Index, indexResponse.Index)
+}
+
+func TestIntegrationLedgerEntryTicketSelector_Websocket(t *testing.T) {
+	env := testintegration.GetWebsocketEnv(t)
+	client := websocket.NewClient(websocket.NewClientConfig().WithHost(env.Host).WithFaucetProvider(env.FaucetProvider))
+	testIntegrationLedgerEntryTicketSelector(t, client)
+}
+
+func TestIntegrationLedgerEntryTicketSelector_RPCClient(t *testing.T) {
+	env := testintegration.GetRPCEnv(t)
+	clientCfg, err := rpc.NewClientConfig(env.Host, rpc.WithFaucetProvider(env.FaucetProvider))
+	require.NoError(t, err)
+	client := rpc.NewClient(clientCfg)
+	testIntegrationLedgerEntryTicketSelector(t, client)
+}

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -2,6 +2,7 @@
 package websocket
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -545,16 +546,30 @@ func (c *Client) submitRequest(req *requests.SubmitRequest) (*requests.SubmitRes
 
 func (c *Client) formatRequest(req interfaces.Request, id uint64, marker any) ([]byte, error) {
 	m := make(map[string]any)
+	if _, ok := req.(json.Marshaler); ok {
+		requestJSON, err := json.Marshal(req)
+		if err != nil {
+			return nil, err
+		}
+		// UseNumber preserves numeric fidelity through the map round trip
+		// (plain Unmarshal would coerce every number to float64).
+		dec := json.NewDecoder(bytes.NewReader(requestJSON))
+		dec.UseNumber()
+		if err := dec.Decode(&m); err != nil {
+			return nil, err
+		}
+	} else {
+		dec, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &m})
+		if err := dec.Decode(req); err != nil {
+			return nil, err
+		}
+	}
+
 	m["id"] = id
 	m["command"] = req.Method()
 	m["api_version"] = req.APIVersion()
 	if marker != nil {
 		m["marker"] = marker
-	}
-	dec, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &m})
-	err := dec.Decode(req)
-	if err != nil {
-		return nil, err
 	}
 
 	return json.Marshal(m)

--- a/xrpl/websocket/client_test.go
+++ b/xrpl/websocket/client_test.go
@@ -11,8 +11,10 @@ import (
 
 	commonconstants "github.com/Peersyst/xrpl-go/xrpl/common"
 	clientconfigtestutil "github.com/Peersyst/xrpl-go/xrpl/internal/clientconfig/testutil"
+	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/account"
 	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	ledgerquery "github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction"
 	"github.com/Peersyst/xrpl-go/xrpl/transaction/types"
 	"github.com/Peersyst/xrpl-go/xrpl/wallet"
@@ -421,6 +423,45 @@ func TestClient_formatRequest(t *testing.T) {
 				"destination_account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				"limit":70,
 				"marker":"hdsohdaoidhadasd"
+			}`,
+			expectedErr: nil,
+		},
+		{
+			description: "json.Marshaler request with object selector overrides embedded API version",
+			req: &ledgerquery.EntryRequest{
+				BaseRequest: common.BaseRequest{Version: 1},
+				AMM: ledgerquery.AMMSelector{
+					Object: &ledgerquery.AMMSelectorFields{
+						Asset:  ledgerentry.Asset{Currency: "XRP"},
+						Asset2: ledgerentry.Asset{Currency: "USD", Issuer: "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"},
+					},
+				},
+			},
+			id:     1,
+			marker: nil,
+			expected: `{
+				"id":1,
+				"command":"ledger_entry",
+				"api_version":2,
+				"amm":{
+					"asset":{"currency":"XRP"},
+					"asset2":{"currency":"USD","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}
+				}
+			}`,
+			expectedErr: nil,
+		},
+		{
+			description: "json.Marshaler request with string selector",
+			req: &ledgerquery.EntryRequest{AMM: ledgerquery.AMMSelector{
+				Index: "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
+			}},
+			id:     1,
+			marker: nil,
+			expected: `{
+				"id":1,
+				"command":"ledger_entry",
+				"api_version":2,
+				"amm":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"
 			}`,
 			expectedErr: nil,
 		},

--- a/xrpl/websocket/client_test.go
+++ b/xrpl/websocket/client_test.go
@@ -383,7 +383,6 @@ func TestClient_formatRequest(t *testing.T) {
 		id          uint64
 		marker      any
 		expected    string
-		expectedErr error
 	}{
 		{
 			description: "valid request",
@@ -403,7 +402,6 @@ func TestClient_formatRequest(t *testing.T) {
 				"destination_account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 				"limit":70
 			}`,
-			expectedErr: nil,
 		},
 		{
 			description: "valid request with marker",
@@ -424,7 +422,6 @@ func TestClient_formatRequest(t *testing.T) {
 				"limit":70,
 				"marker":"hdsohdaoidhadasd"
 			}`,
-			expectedErr: nil,
 		},
 		{
 			description: "json.Marshaler request with object selector overrides embedded API version",
@@ -448,35 +445,14 @@ func TestClient_formatRequest(t *testing.T) {
 					"asset2":{"currency":"USD","issuer":"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"}
 				}
 			}`,
-			expectedErr: nil,
-		},
-		{
-			description: "json.Marshaler request with string selector",
-			req: &ledgerquery.EntryRequest{AMM: ledgerquery.AMMSelector{
-				Index: "7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4",
-			}},
-			id:     1,
-			marker: nil,
-			expected: `{
-				"id":1,
-				"command":"ledger_entry",
-				"api_version":2,
-				"amm":"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4"
-			}`,
-			expectedErr: nil,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.description, func(t *testing.T) {
 			a, err := ws.formatRequest(tc.req, tc.id, tc.marker)
-
-			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
-			} else {
-				require.NoError(t, err)
-				require.JSONEq(t, tc.expected, string(a))
-			}
+			require.NoError(t, err)
+			require.JSONEq(t, tc.expected, string(a))
 		})
 	}
 }

--- a/xrpl/websocket/ledger_entry_test.go
+++ b/xrpl/websocket/ledger_entry_test.go
@@ -1,0 +1,109 @@
+package websocket
+
+import (
+	"testing"
+
+	ledgerentry "github.com/Peersyst/xrpl-go/xrpl/ledger-entry-types"
+	"github.com/Peersyst/xrpl-go/xrpl/queries/common"
+	ledgerquery "github.com/Peersyst/xrpl-go/xrpl/queries/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetLedgerEntry(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     map[string]any
+		request     *ledgerquery.EntryRequest
+		expected    *ledgerquery.EntryResponse
+		expectedErr error
+	}{
+		{
+			name: "json response",
+			message: map[string]any{
+				"id": 1,
+				"result": map[string]any{
+					"index":        "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"ledger_hash":  "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+					"ledger_index": uint32(61966146),
+					"node": map[string]any{
+						"Account":         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+						"Balance":         "424021949",
+						"LedgerEntryType": "AccountRoot",
+					},
+					"deleted_ledger_index": uint32(61966150),
+					"validated":            true,
+				},
+			},
+			request: &ledgerquery.EntryRequest{
+				AccountRoot:    "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+				IncludeDeleted: true,
+			},
+			expected: &ledgerquery.EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerHash:  "31850E8E48E76D1064651DF39DF4E9542E8C90A9A9B629F4DE339EB3FA74F726",
+				LedgerIndex: common.LedgerIndex(61966146),
+				Node: ledgerentry.FlatLedgerObject{
+					"Account":         "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+					"Balance":         "424021949",
+					"LedgerEntryType": "AccountRoot",
+				},
+				DeletedLedgerIndex: common.LedgerIndex(61966150),
+				Validated:          true,
+			},
+		},
+		{
+			name: "binary response",
+			message: map[string]any{
+				"id": 1,
+				"result": map[string]any{
+					"index":        "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"ledger_index": uint32(61966146),
+					"node_binary":  "1100612200000000",
+					"validated":    true,
+				},
+			},
+			request: &ledgerquery.EntryRequest{
+				Index:  "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				Binary: true,
+			},
+			expected: &ledgerquery.EntryResponse{
+				Index:       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+				LedgerIndex: common.LedgerIndex(61966146),
+				NodeBinary:  "1100612200000000",
+				Validated:   true,
+			},
+		},
+		{
+			name: "reject response with both payloads",
+			message: map[string]any{
+				"id": 1,
+				"result": map[string]any{
+					"index":       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+					"node":        map[string]any{"LedgerEntryType": "AccountRoot"},
+					"node_binary": "1100",
+					"validated":   true,
+				},
+			},
+			request: &ledgerquery.EntryRequest{
+				Index: "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+			},
+			expectedErr: ledgerquery.ErrInvalidEntryResponse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, cleanup := setupTestClient(t, []map[string]any{tt.message})
+			defer cleanup()
+
+			response, err := client.GetLedgerEntry(tt.request)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.Nil(t, response)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, response)
+			}
+		})
+	}
+}

--- a/xrpl/websocket/ledger_entry_test.go
+++ b/xrpl/websocket/ledger_entry_test.go
@@ -11,11 +11,10 @@ import (
 
 func TestClient_GetLedgerEntry(t *testing.T) {
 	tests := []struct {
-		name        string
-		message     map[string]any
-		request     *ledgerquery.EntryRequest
-		expected    *ledgerquery.EntryResponse
-		expectedErr error
+		name     string
+		message  map[string]any
+		request  *ledgerquery.EntryRequest
+		expected *ledgerquery.EntryResponse
 	}{
 		{
 			name: "json response",
@@ -73,22 +72,6 @@ func TestClient_GetLedgerEntry(t *testing.T) {
 				Validated:   true,
 			},
 		},
-		{
-			name: "reject response with both payloads",
-			message: map[string]any{
-				"id": 1,
-				"result": map[string]any{
-					"index":       "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-					"node":        map[string]any{"LedgerEntryType": "AccountRoot"},
-					"node_binary": "1100",
-					"validated":   true,
-				},
-			},
-			request: &ledgerquery.EntryRequest{
-				Index: "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
-			},
-			expectedErr: ledgerquery.ErrInvalidEntryResponse,
-		},
 	}
 
 	for _, tt := range tests {
@@ -97,13 +80,8 @@ func TestClient_GetLedgerEntry(t *testing.T) {
 			defer cleanup()
 
 			response, err := client.GetLedgerEntry(tt.request)
-			if tt.expectedErr != nil {
-				require.ErrorIs(t, err, tt.expectedErr)
-				require.Nil(t, response)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, response)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, response)
 		})
 	}
 }


### PR DESCRIPTION
# feat: expand `ledger_entry` request selectors and response variants

## Description

This PR adds typed `ledger_entry` selectors for the request forms covered by this change. It also preserves JSON, binary, and deleted-entry response data.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Add typed request selectors and require exactly one top-level selector.
- Add JSON and binary response fields, with Clio deleted-entry data.
- Preserve custom JSON fields when the WebSocket client formats a request.
- Add query, RPC, and WebSocket tests.
