### PR TITLE
fix: secure authenticated RPC transport and fix WebSocket stream dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concurrent callers now share one in-flight network identity discovery result, including failures, while later independent operations can retry.
 - Rippled prerelease versions with numeric suffixes now compare the suffix numerically.
 - Made autofill and unsigned signing fail closed when network identity discovery or validation fails, unless `WithNetworkIdentity` supplies an explicit trusted identity.
-- Redacted percent-encoded URL passwords from authorized RPC request errors.
+- Rejected nil custom HTTP clients during configuration and request-time revalidation with `ErrNilHTTPClient` instead of allowing request-time panics.
+- Redacted bare authorization credentials and percent-encoded URL passwords from authorized RPC request errors.
+- Authorized RPC redirects now reject an HTTPS-to-HTTP downgrade before invoking the caller's `CheckRedirect`, so a callback never observes `Authorization` on a plaintext target.
 - Corrected fee precision and rounding with shared exact rational arithmetic, including fractional base fees and load factors, rippled-compatible integer `EscrowFinish` fulfillment scaling, final whole-drop ceiling, validated-ledger `LoanSet` signer data, and presence-aware zero base and owner-reserve fees.
 - Made submit options nil-safe without enabling autofill by default. Forced `fail_hard` for `AccountDelete`. Used the normal network fee for `VaultCreate` instead of the incremental owner reserve. The standard `maxFeeXRP` cap now applies. Normalized Payment `DeliverMax` to wire `Amount`. Prevented autofill and submission failures from changing caller-owned maps.
 - `AutofillMultisigned` now preserves a supplied `Fee`; when absent, it calculates the fee once with the signer count.
@@ -283,8 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closed and invalidated WebSocket connections after write or write-deadline failures. The active read loop now attempts reconnection after any read error, not only close errors, within the existing `WithMaxReconnects` budget.
 - Made manual disconnect claim an in-progress reconnect socket before lifecycle cancellation so cancellation-driven invalidation cannot cause a false not-connected error.
 - Made reconnect backoff configuration immutable per client to prevent concurrent clients and reconnect tests from racing over shared delay state.
-- Dispatched `transaction` notifications to the exported order-book handler and `bookChanges` notifications to the exported book-changes handler, with typed decoding and no duplicate handler delivery across reconnects. Automatic reconnects do not replay subscriptions, so callers must resubscribe.
-- Authorized RPC redirects now reject an HTTPS-to-HTTP downgrade before invoking the caller's `CheckRedirect`, so a callback never observes `Authorization` on a plaintext target.
+- Dispatched `bookChanges` notifications to the exported book-changes handler with typed decoding and no duplicate handler delivery across reconnects. Automatic reconnects do not replay subscriptions, so callers must resubscribe.
 
 ## [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closed and invalidated WebSocket connections after write or write-deadline failures. The active read loop now attempts reconnection after any read error, not only close errors, within the existing `WithMaxReconnects` budget.
 - Made manual disconnect claim an in-progress reconnect socket before lifecycle cancellation so cancellation-driven invalidation cannot cause a false not-connected error.
 - Made reconnect backoff configuration immutable per client to prevent concurrent clients and reconnect tests from racing over shared delay state.
-- Dispatched `transaction` notifications to the exported order-book handler and `bookChanges` notifications to the exported book-changes handler, with typed decoding and single delivery across reconnects.
+- Dispatched `transaction` notifications to the exported order-book handler and `bookChanges` notifications to the exported book-changes handler, with typed decoding and no duplicate handler delivery across reconnects. Automatic reconnects do not replay subscriptions, so callers must resubscribe.
+- Authorized RPC redirects now reject an HTTPS-to-HTTP downgrade before invoking the caller's `CheckRedirect`, so a callback never observes `Authorization` on a plaintext target.
 
 ## [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concurrent callers now share one in-flight network identity discovery result, including failures, while later independent operations can retry.
 - Rippled prerelease versions with numeric suffixes now compare the suffix numerically.
 - Made autofill and unsigned signing fail closed when network identity discovery or validation fails, unless `WithNetworkIdentity` supplies an explicit trusted identity.
+- Redacted percent-encoded URL passwords from authorized RPC request errors.
 - Corrected fee precision and rounding with shared exact rational arithmetic, including fractional base fees and load factors, rippled-compatible integer `EscrowFinish` fulfillment scaling, final whole-drop ceiling, validated-ledger `LoanSet` signer data, and presence-aware zero base and owner-reserve fees.
 - Made submit options nil-safe without enabling autofill by default. Forced `fail_hard` for `AccountDelete`. Used the normal network fee for `VaultCreate` instead of the incremental owner reserve. The standard `maxFeeXRP` cap now applies. Normalized Payment `DeliverMax` to wire `Amount`. Prevented autofill and submission failures from changing caller-owned maps.
 - `AutofillMultisigned` now preserves a supplied `Fee`; when absent, it calculates the fee once with the signer count.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `ledger_hash` and `ledger_index` fields to `InfoRequest`, and `ledger_current_index` to `InfoResponse` for open-ledger responses.
 
+#### xrpl/queries/subscription/types
+
+- Added `BookChangesStreamType` for the `bookChanges` subscription notification discriminator.
+
 #### xrpl/transaction
 
 - Added centralized transaction type constants and `IsPseudoTransactionType` classification for `EnableAmendment`, `SetFee`, and `UNLModify`.
@@ -124,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ErrInvalidMaxRetries` and `ErrInvalidLastLedgerSequence` for non-positive retry limits and zero ledger boundaries.
 - Added `ErrInvalidFeeValue` and `ErrFeeHasTooManyDecimals` for fee validation.
 - Added `ErrResponseErrorFieldIsNotAString` for malformed RPC error responses.
+- Added `ErrInsecureAuthorization` and `ErrAuthorizationRequestFailed` for secure, redaction-safe authorized transport failures.
 
 #### xrpl/transaction/integration
 
@@ -165,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The client now discovers and caches network identity with `server_info` before an identity-dependent operation. A discovery failure fails the operation without mutation and is retried by a later operation.
 - Client-side submission helpers now discover and validate network identity before they sign an unsigned transaction, including when autofill is disabled. Use `wallet.Sign` for fully offline signing, or `WithNetworkIdentity` when trusted deployment configuration supplies the identity.
 - Network identity discovery now uses Clio `rippled_version` only when `build_version` is absent.
+- Authorized RPC requests now require a parsed HTTPS endpoint and a redirect-safe `*http.Client`, reject authenticated plaintext redirects, recognize header names case-insensitively and URL userinfo, and redact credential material from returned diagnostics.
 
 #### xrpl/transaction
 
@@ -178,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing network identity or required build-version data now makes `Connect`, autofill, and unsigned signing fail closed instead of omitting `NetworkID`.
 - Client-side signing now applies network identity policy when autofill is disabled.
 - Network identity discovery now uses Clio `rippled_version` only when `build_version` is absent.
+- Documented the stream-handler concurrency, per-stream ordering, and unbuffered backpressure contract.
 
 ### Fixed
 
@@ -275,6 +282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closed and invalidated WebSocket connections after write or write-deadline failures. The active read loop now attempts reconnection after any read error, not only close errors, within the existing `WithMaxReconnects` budget.
 - Made manual disconnect claim an in-progress reconnect socket before lifecycle cancellation so cancellation-driven invalidation cannot cause a false not-connected error.
 - Made reconnect backoff configuration immutable per client to prevent concurrent clients and reconnect tests from racing over shared delay state.
+- Dispatched `transaction` notifications to the exported order-book handler and `bookChanges` notifications to the exported book-changes handler, with typed decoding and single delivery across reconnects.
 
 ## [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The client now discovers and caches network identity with `server_info` before an identity-dependent operation. A discovery failure fails the operation without mutation and is retried by a later operation.
 - Client-side submission helpers now discover and validate network identity before they sign an unsigned transaction, including when autofill is disabled. Use `wallet.Sign` for fully offline signing, or `WithNetworkIdentity` when trusted deployment configuration supplies the identity.
 - Network identity discovery now uses Clio `rippled_version` only when `build_version` is absent.
-- Authorized RPC requests now require a parsed HTTPS endpoint and a redirect-safe `*http.Client`, reject authenticated plaintext redirects, recognize header names case-insensitively and URL userinfo, and redact credential material from returned diagnostics.
+- Authorized RPC requests now require a parsed HTTPS endpoint for every HTTP client, recognize header names case-insensitively and URL userinfo, and redact credential material from returned diagnostics. Standard `*http.Client` requests also reject authenticated plaintext redirects, while custom `HTTPClient` implementations remain supported on HTTPS and control their own redirects.
 
 #### xrpl/transaction
 

--- a/xrpl/queries/subscription/types/type.go
+++ b/xrpl/queries/subscription/types/type.go
@@ -5,12 +5,13 @@ package types
 // Type represents a subscription stream type for server events.
 type Type string
 
-// Stream types used in subscription requests.
+// Stream message types returned by subscription notifications.
 const (
 	LedgerStreamType      Type = "ledgerClosed"
 	ValidationStreamType  Type = "validationReceived"
 	TransactionStreamType Type = "transaction"
 	PeerStatusStreamType  Type = "peerStatusChange"
 	OrderBookStreamType   Type = TransactionStreamType
+	BookChangesStreamType Type = "bookChanges"
 	ConsensusStreamType   Type = "consensusPhase"
 )

--- a/xrpl/queries/subscription/types/type.go
+++ b/xrpl/queries/subscription/types/type.go
@@ -11,6 +11,8 @@ const (
 	ValidationStreamType  Type = "validationReceived"
 	TransactionStreamType Type = "transaction"
 	PeerStatusStreamType  Type = "peerStatusChange"
+	// OrderBookStreamType aliases TransactionStreamType because rippled sends
+	// order-book subscription updates as transaction messages.
 	OrderBookStreamType   Type = TransactionStreamType
 	BookChangesStreamType Type = "bookChanges"
 	ConsensusStreamType   Type = "consensusPhase"

--- a/xrpl/rpc/client.go
+++ b/xrpl/rpc/client.go
@@ -112,6 +112,8 @@ func (c *Client) request(ctx context.Context, reqParams XRPLRequest) (XRPLRespon
 			return nil, redactAuthorizationError(err, requestURL, headers)
 		}
 
+		// Keep the config snapshot unchanged for redaction and later retries.
+		// A custom HTTPClient can mutate request headers, so each attempt gets a clone.
 		req.Header = headers.Clone()
 
 		response, err = requestHTTPClient.Do(req)

--- a/xrpl/rpc/client.go
+++ b/xrpl/rpc/client.go
@@ -72,6 +72,14 @@ func (c *Client) request(ctx context.Context, reqParams XRPLRequest) (XRPLRespon
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+
+	requestURL := c.cfg.URL
+	headers := http.Header(c.cfg.Headers).Clone()
+	requestHTTPClient, err := validateAuthorizationTransport(requestURL, headers, c.cfg.HTTPClient)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := reqParams.Validate(); err != nil {
 		return nil, err
 	}
@@ -96,17 +104,17 @@ func (c *Client) request(ctx context.Context, reqParams XRPLRequest) (XRPLRespon
 		req, err := http.NewRequestWithContext(
 			requestCtx,
 			http.MethodPost,
-			c.cfg.URL,
+			requestURL,
 			bytes.NewReader(body),
 		)
 		if err != nil {
 			cancel()
-			return nil, err
+			return nil, redactAuthorizationError(err, requestURL, headers)
 		}
 
-		req.Header = c.cfg.Headers
+		req.Header = headers.Clone()
 
-		response, err = c.cfg.HTTPClient.Do(req)
+		response, err = requestHTTPClient.Do(req)
 		if err != nil {
 			// net/http documents response as nil when Do returns an error, but
 			// custom HTTPClient impls may not follow that contract.
@@ -117,7 +125,7 @@ func (c *Client) request(ctx context.Context, reqParams XRPLRequest) (XRPLRespon
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			return nil, err
+			return nil, redactAuthorizationError(err, requestURL, headers)
 		}
 
 		// HTTPClient is an interface, custom impls may return (nil, nil),
@@ -156,7 +164,7 @@ func (c *Client) request(ctx context.Context, reqParams XRPLRequest) (XRPLRespon
 	var jr Response
 	jr, err = checkForError(response, c.cfg.maxResponseSize)
 	if err != nil {
-		return nil, err
+		return nil, redactAuthorizationError(err, requestURL, headers)
 	}
 
 	return &jr, nil

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -57,6 +57,9 @@ type Config struct {
 type ConfigOpt func(c *Config)
 
 // WithHTTPClient returns a ConfigOpt that sets a custom HTTPClient.
+// Configured authorization requires an HTTPS endpoint. XRPL Go adds redirect
+// protection to *http.Client values. Other implementations control their own
+// redirects and any credentials that they add.
 func WithHTTPClient(cl HTTPClient) ConfigOpt {
 	return func(c *Config) {
 		c.HTTPClient = cl

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -163,6 +163,10 @@ func NewClientConfig(url string, opts ...ConfigOpt) (*Config, error) {
 		opt(cfg)
 	}
 
+	if _, err := validateAuthorizationTransport(cfg.URL, cfg.Headers, cfg.HTTPClient); err != nil {
+		return nil, err
+	}
+
 	clientconfig.WarnIfInsecureScheme("rpc", cfg.URL)
 
 	// Keep the default HTTP client aligned with the config timeout.

--- a/xrpl/rpc/config.go
+++ b/xrpl/rpc/config.go
@@ -57,9 +57,10 @@ type Config struct {
 type ConfigOpt func(c *Config)
 
 // WithHTTPClient returns a ConfigOpt that sets a custom HTTPClient.
-// Configured authorization requires an HTTPS endpoint. XRPL Go adds redirect
-// protection to *http.Client values. Other implementations control their own
-// redirects and any credentials that they add.
+// Configured authorization requires an HTTPS endpoint. For *http.Client values,
+// XRPL Go rejects every authenticated HTTPS-to-HTTP redirect, including a
+// cross-host redirect where net/http would remove Authorization. Other
+// implementations control their own redirects and any credentials that they add.
 func WithHTTPClient(cl HTTPClient) ConfigOpt {
 	return func(c *Config) {
 		c.HTTPClient = cl
@@ -130,7 +131,7 @@ func WithNetworkIdentity(networkID uint32, buildVersion string) ConfigOpt {
 func WithTimeout(timeout time.Duration) ConfigOpt {
 	return func(c *Config) {
 		c.timeout = timeout
-		if hc, ok := c.HTTPClient.(*http.Client); ok {
+		if hc, ok := c.HTTPClient.(*http.Client); ok && hc != nil {
 			hc.Timeout = timeout
 		}
 	}

--- a/xrpl/rpc/errors.go
+++ b/xrpl/rpc/errors.go
@@ -143,6 +143,8 @@ var (
 	ErrEmptyURL = errors.New("empty port and IP provided")
 	// ErrResponseErrorFieldIsNotAString is returned when an RPC response contains a non-string error field.
 	ErrResponseErrorFieldIsNotAString = errors.New("rpc response error field must be a string")
+	// errTooManyRedirects matches the net/http default redirect limit error.
+	errTooManyRedirects = errors.New("stopped after 10 redirects")
 	// ErrInsecureAuthorization is returned when RPC authorization cannot be guaranteed to use HTTPS across redirects.
 	ErrInsecureAuthorization = errors.New("rpc authorization requires an HTTPS endpoint and redirect-safe HTTP client")
 	// ErrAuthorizationRequestFailed replaces an authorized request error whose diagnostic exposed credential material.

--- a/xrpl/rpc/errors.go
+++ b/xrpl/rpc/errors.go
@@ -143,6 +143,10 @@ var (
 	ErrEmptyURL = errors.New("empty port and IP provided")
 	// ErrResponseErrorFieldIsNotAString is returned when an RPC response contains a non-string error field.
 	ErrResponseErrorFieldIsNotAString = errors.New("rpc response error field must be a string")
+	// ErrInsecureAuthorization is returned when RPC authorization cannot be guaranteed to use HTTPS across redirects.
+	ErrInsecureAuthorization = errors.New("rpc authorization requires an HTTPS endpoint and redirect-safe HTTP client")
+	// ErrAuthorizationRequestFailed replaces an authorized request error whose diagnostic exposed credential material.
+	ErrAuthorizationRequestFailed = errors.New("authorized RPC request failed")
 	// ErrResponseTooLarge is returned when an RPC response body exceeds the configured limit.
 	ErrResponseTooLarge = errors.New("rpc response body exceeds maximum size")
 )

--- a/xrpl/rpc/errors.go
+++ b/xrpl/rpc/errors.go
@@ -141,6 +141,8 @@ var (
 
 	// ErrEmptyURL is returned when the provided URL is empty (no port or IP specified).
 	ErrEmptyURL = errors.New("empty port and IP provided")
+	// ErrNilHTTPClient is returned when RPC configuration contains a nil HTTP client.
+	ErrNilHTTPClient = errors.New("rpc HTTP client must not be nil")
 	// ErrResponseErrorFieldIsNotAString is returned when an RPC response contains a non-string error field.
 	ErrResponseErrorFieldIsNotAString = errors.New("rpc response error field must be a string")
 	// errTooManyRedirects matches the net/http default redirect limit error.

--- a/xrpl/rpc/network_identity_test.go
+++ b/xrpl/rpc/network_identity_test.go
@@ -131,6 +131,33 @@ func TestClientBeginNetworkIdentityDiscoveryResult(t *testing.T) {
 	require.False(t, ready.leader)
 }
 
+func TestClientNetworkIdentityDiscoveryFailure(t *testing.T) {
+	cfg, err := NewClientConfig("http://localhost/")
+	require.NoError(t, err)
+	cl := NewClient(cfg)
+
+	leader := cl.beginNetworkIdentityDiscovery()
+	require.True(t, leader.leader)
+	waiting := cl.beginNetworkIdentityDiscovery()
+	require.False(t, waiting.leader)
+	require.Same(t, leader.discovery, waiting.discovery)
+
+	discoveryErr := errors.New("server_info unavailable")
+	cl.finishNetworkIdentityDiscovery(clientinternal.NetworkIdentity{}, discoveryErr, false)
+	select {
+	case <-leader.discovery.done:
+	case <-time.After(time.Second):
+		t.Fatal("identity discovery failure did not release waiters")
+	}
+	require.ErrorIs(t, leader.discovery.err, discoveryErr)
+	require.ErrorIs(t, waiting.discovery.err, discoveryErr)
+
+	retry := cl.beginNetworkIdentityDiscovery()
+	require.True(t, retry.leader)
+	require.NotSame(t, leader.discovery, retry.discovery)
+	cl.finishNetworkIdentityDiscovery(clientinternal.NetworkIdentity{}, discoveryErr, false)
+}
+
 func TestClientEnsureNetworkIdentitySingleflight(t *testing.T) {
 	const callerCount = 8
 
@@ -224,7 +251,6 @@ func TestClientEnsureNetworkIdentitySingleflight(t *testing.T) {
 		for _, result := range collectNetworkIdentityResults(t, results, callerCount) {
 			require.ErrorIs(t, result.err, requestFailure)
 		}
-		require.Equal(t, int32(1), requestCount.Load())
 	})
 }
 

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"encoding/base64"
-	"errors"
 	"net/http"
 	"net/url"
 	"slices"
@@ -10,8 +9,6 @@ import (
 )
 
 const authorizationHeader = "Authorization"
-
-var errTooManyRedirects = errors.New("stopped after 10 redirects")
 
 // validateAuthorizationTransport enforces the authorization transport policy
 // for rawURL and headers, and returns the HTTP client that requests carrying

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -75,17 +75,22 @@ func authorizationHTTPClient(client HTTPClient, hasAuthorization bool) (HTTPClie
 
 func authorizationRedirectPolicy(previousCheckRedirect func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
+		if !isHTTPSURL(req.URL) && redirectChainHasAuthorization(req, via) {
+			return ErrInsecureAuthorization
+		}
+
 		if previousCheckRedirect != nil {
 			if err := previousCheckRedirect(req, via); err != nil {
 				return err
+			}
+			// Check again because a caller callback may mutate the redirect target.
+			if !isHTTPSURL(req.URL) && redirectChainHasAuthorization(req, via) {
+				return ErrInsecureAuthorization
 			}
 		} else if len(via) >= 10 {
 			return errTooManyRedirects
 		}
 
-		if !isHTTPSURL(req.URL) && redirectChainHasAuthorization(req, via) {
-			return ErrInsecureAuthorization
-		}
 		return nil
 	}
 }

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -1,0 +1,133 @@
+package rpc
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+const authorizationHeader = "Authorization"
+
+var errTooManyRedirects = errors.New("stopped after 10 redirects")
+
+// validateAuthorizationTransport enforces the authorization transport policy
+// for rawURL and headers, and returns the HTTP client that requests carrying
+// authorization must use. It is the single entry point shared by config-time
+// and request-time validation.
+func validateAuthorizationTransport(rawURL string, headers map[string][]string, client HTTPClient) (HTTPClient, error) {
+	hasAuthorization, err := validateAuthorizationEndpoint(rawURL, headers)
+	if err != nil {
+		return nil, err
+	}
+	return authorizationHTTPClient(client, hasAuthorization)
+}
+
+func hasAuthorizationHeader(headers map[string][]string) bool {
+	for name := range headers {
+		if strings.EqualFold(name, authorizationHeader) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAuthorizationEndpoint(rawURL string, headers map[string][]string) (bool, error) {
+	hasHeader := hasAuthorizationHeader(headers)
+	endpoint, err := url.Parse(rawURL)
+	if err != nil {
+		if hasHeader {
+			return true, ErrInsecureAuthorization
+		}
+		return false, nil
+	}
+
+	hasAuthorization := hasHeader || endpoint.User != nil
+	if hasAuthorization && !isHTTPSURL(endpoint) {
+		return true, ErrInsecureAuthorization
+	}
+	return hasAuthorization, nil
+}
+
+func isHTTPSURL(endpoint *url.URL) bool {
+	return endpoint != nil && endpoint.IsAbs() && endpoint.Host != "" && strings.EqualFold(endpoint.Scheme, "https")
+}
+
+func authorizationHTTPClient(client HTTPClient, hasAuthorization bool) (HTTPClient, error) {
+	if !hasAuthorization {
+		return client, nil
+	}
+
+	baseClient, ok := client.(*http.Client)
+	if !ok || baseClient == nil {
+		return nil, ErrInsecureAuthorization
+	}
+
+	return &http.Client{
+		Transport:     baseClient.Transport,
+		CheckRedirect: authorizationRedirectPolicy(baseClient.CheckRedirect),
+		Jar:           baseClient.Jar,
+		Timeout:       baseClient.Timeout,
+	}, nil
+}
+
+func authorizationRedirectPolicy(previousCheckRedirect func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if previousCheckRedirect != nil {
+			if err := previousCheckRedirect(req, via); err != nil {
+				return err
+			}
+		} else if len(via) >= 10 {
+			return errTooManyRedirects
+		}
+
+		if !isHTTPSURL(req.URL) && redirectChainHasAuthorization(req, via) {
+			return ErrInsecureAuthorization
+		}
+		return nil
+	}
+}
+
+func redirectChainHasAuthorization(req *http.Request, via []*http.Request) bool {
+	if requestHasAuthorization(req) {
+		return true
+	}
+	return slices.ContainsFunc(via, requestHasAuthorization)
+}
+
+func requestHasAuthorization(req *http.Request) bool {
+	return req != nil && (hasAuthorizationHeader(req.Header) || req.URL != nil && req.URL.User != nil)
+}
+
+func redactAuthorizationError(err error, rawURL string, headers map[string][]string) error {
+	if err == nil {
+		return nil
+	}
+
+	var secrets []string
+	for name, values := range headers {
+		if strings.EqualFold(name, authorizationHeader) {
+			secrets = append(secrets, values...)
+		}
+	}
+	if endpoint, parseErr := url.Parse(rawURL); parseErr == nil && endpoint.User != nil {
+		username := endpoint.User.Username()
+		password, _ := endpoint.User.Password()
+		secrets = append(secrets,
+			username,
+			password,
+			endpoint.User.String(),
+			"Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
+		)
+	}
+
+	errorMessage := err.Error()
+	for _, secret := range secrets {
+		if secret != "" && strings.Contains(errorMessage, secret) {
+			return ErrAuthorizationRequestFailed
+		}
+	}
+	return err
+}

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -126,14 +126,19 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 	} else if endpoint.User != nil {
 		username := endpoint.User.Username()
 		encodedUsername := url.User(username).String()
-		password, _ := endpoint.User.Password()
+		password, hasPassword := endpoint.User.Password()
+		userInfo := endpoint.User.String()
 		secrets = append(secrets,
 			username,
 			encodedUsername,
 			password,
-			endpoint.User.String(),
+			userInfo,
 			"Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
 		)
+		if hasPassword {
+			encodedPassword := strings.TrimPrefix(userInfo, encodedUsername+":")
+			secrets = append(secrets, encodedPassword)
+		}
 	}
 
 	errorMessage := err.Error()

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -10,10 +10,10 @@ import (
 
 const authorizationHeader = "Authorization"
 
-// validateAuthorizationTransport enforces the authorization transport policy
-// for rawURL and headers, and returns the HTTP client that requests carrying
-// authorization must use. It is the single entry point shared by config-time
-// and request-time validation.
+// validateAuthorizationTransport rejects configured authorization on insecure
+// endpoints. It adds redirect protection to a standard *http.Client and leaves
+// other HTTPClient implementations responsible for their own redirects. It is
+// the single entry point shared by config-time and request-time validation.
 func validateAuthorizationTransport(rawURL string, headers map[string][]string, client HTTPClient) (HTTPClient, error) {
 	hasAuthorization, err := validateAuthorizationEndpoint(rawURL, headers)
 	if err != nil {
@@ -59,7 +59,10 @@ func authorizationHTTPClient(client HTTPClient, hasAuthorization bool) (HTTPClie
 	}
 
 	baseClient, ok := client.(*http.Client)
-	if !ok || baseClient == nil {
+	if !ok {
+		return client, nil
+	}
+	if baseClient == nil {
 		return nil, ErrInsecureAuthorization
 	}
 

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -26,7 +26,8 @@ func validateAuthorizationEndpoint(rawURL string, headers map[string][]string) (
 	hasHeader := hasAuthorizationHeader(headers)
 	endpoint, err := url.Parse(rawURL)
 	if err != nil {
-		if hasHeader {
+		hasAuthorization := hasHeader || malformedURLHasUserinfo(rawURL)
+		if hasAuthorization {
 			return true, ErrInsecureAuthorization
 		}
 		return false, nil
@@ -114,7 +115,12 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 			secrets = append(secrets, values...)
 		}
 	}
-	if endpoint, parseErr := url.Parse(rawURL); parseErr == nil && endpoint.User != nil {
+	endpoint, parseErr := url.Parse(rawURL)
+	if parseErr != nil {
+		if malformedURLHasUserinfo(rawURL) {
+			return ErrAuthorizationRequestFailed
+		}
+	} else if endpoint.User != nil {
 		username := endpoint.User.Username()
 		password, _ := endpoint.User.Password()
 		secrets = append(secrets,
@@ -132,4 +138,21 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 		}
 	}
 	return err
+}
+
+func malformedURLHasUserinfo(rawURL string) bool {
+	authority := rawURL
+	if strings.HasPrefix(authority, "//") {
+		authority = authority[2:]
+	} else {
+		var found bool
+		_, authority, found = strings.Cut(authority, "://")
+		if !found {
+			return false
+		}
+	}
+	if end := strings.IndexAny(authority, "/?#"); end >= 0 {
+		authority = authority[:end]
+	}
+	return strings.Contains(authority, "@")
 }

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -122,9 +122,11 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 		}
 	} else if endpoint.User != nil {
 		username := endpoint.User.Username()
+		encodedUsername := url.User(username).String()
 		password, _ := endpoint.User.Password()
 		secrets = append(secrets,
 			username,
+			encodedUsername,
 			password,
 			endpoint.User.String(),
 			"Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)),

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -22,15 +22,6 @@ func validateAuthorizationTransport(rawURL string, headers map[string][]string, 
 	return authorizationHTTPClient(client, hasAuthorization)
 }
 
-func hasAuthorizationHeader(headers map[string][]string) bool {
-	for name := range headers {
-		if strings.EqualFold(name, authorizationHeader) {
-			return true
-		}
-	}
-	return false
-}
-
 func validateAuthorizationEndpoint(rawURL string, headers map[string][]string) (bool, error) {
 	hasHeader := hasAuthorizationHeader(headers)
 	endpoint, err := url.Parse(rawURL)
@@ -46,6 +37,15 @@ func validateAuthorizationEndpoint(rawURL string, headers map[string][]string) (
 		return true, ErrInsecureAuthorization
 	}
 	return hasAuthorization, nil
+}
+
+func hasAuthorizationHeader(headers map[string][]string) bool {
+	for name := range headers {
+		if strings.EqualFold(name, authorizationHeader) {
+			return true
+		}
+	}
+	return false
 }
 
 func isHTTPSURL(endpoint *url.URL) bool {

--- a/xrpl/rpc/transport_security.go
+++ b/xrpl/rpc/transport_security.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/url"
+	"reflect"
 	"slices"
 	"strings"
 )
@@ -15,11 +16,31 @@ const authorizationHeader = "Authorization"
 // other HTTPClient implementations responsible for their own redirects. It is
 // the single entry point shared by config-time and request-time validation.
 func validateAuthorizationTransport(rawURL string, headers map[string][]string, client HTTPClient) (HTTPClient, error) {
+	if isNilHTTPClient(client) {
+		return nil, ErrNilHTTPClient
+	}
+
 	hasAuthorization, err := validateAuthorizationEndpoint(rawURL, headers)
 	if err != nil {
 		return nil, err
 	}
 	return authorizationHTTPClient(client, hasAuthorization)
+}
+
+func isNilHTTPClient(client HTTPClient) bool {
+	if client == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(client)
+	kind := value.Kind()
+	isNilable := kind == reflect.Chan ||
+		kind == reflect.Func ||
+		kind == reflect.Interface ||
+		kind == reflect.Map ||
+		kind == reflect.Pointer ||
+		kind == reflect.Slice
+	return isNilable && value.IsNil()
 }
 
 func validateAuthorizationEndpoint(rawURL string, headers map[string][]string) (bool, error) {
@@ -107,6 +128,10 @@ func requestHasAuthorization(req *http.Request) bool {
 	return req != nil && (hasAuthorizationHeader(req.Header) || req.URL != nil && req.URL.User != nil)
 }
 
+// redactAuthorizationError replaces an error when its diagnostic contains a
+// known credential representation. A bare sentinel prevents error unwrapping
+// and structured logging from recovering the original text. Detection is
+// limited to the text returned by Error().
 func redactAuthorizationError(err error, rawURL string, headers map[string][]string) error {
 	if err == nil {
 		return nil
@@ -115,7 +140,7 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 	var secrets []string
 	for name, values := range headers {
 		if strings.EqualFold(name, authorizationHeader) {
-			secrets = append(secrets, values...)
+			secrets = append(secrets, authorizationHeaderSecrets(values)...)
 		}
 	}
 	endpoint, parseErr := url.Parse(rawURL)
@@ -148,6 +173,23 @@ func redactAuthorizationError(err error, rawURL string, headers map[string][]str
 		}
 	}
 	return err
+}
+
+func authorizationHeaderSecrets(values []string) []string {
+	secrets := make([]string, 0, len(values)*3)
+	for _, value := range values {
+		secrets = append(secrets, value)
+
+		trimmed := strings.TrimSpace(value)
+		secrets = append(secrets, trimmed)
+		if separator := strings.IndexAny(trimmed, " \t"); separator >= 0 {
+			credentials := strings.TrimSpace(trimmed[separator:])
+			if credentials != "" {
+				secrets = append(secrets, credentials)
+			}
+		}
+	}
+	return secrets
 }
 
 func malformedURLHasUserinfo(rawURL string) bool {

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -31,12 +31,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type opaqueHTTPClient struct {
-	called *atomic.Bool
+	called            *atomic.Bool
+	authorizationSeen *atomic.Bool
 }
 
-func (c opaqueHTTPClient) Do(*http.Request) (*http.Response, error) {
+func (c opaqueHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.called.Store(true)
-	return nil, nil
+	if c.authorizationSeen != nil {
+		c.authorizationSeen.Store(hasAuthorizationHeader(req.Header))
+	}
+	return successfulHTTPResponse(req), nil
 }
 
 type credentialEchoError string
@@ -108,9 +112,26 @@ func TestNewClientConfigAuthorizationTransport(t *testing.T) {
 			url:  testUserinfoURL("https", "node.example"),
 		},
 		{
-			name:       "rejects opaque HTTP client",
+			name:       "accepts opaque HTTP client over HTTPS",
 			url:        "https://node.example",
 			headerName: "Authorization",
+			httpClient: opaqueHTTPClient{called: &atomic.Bool{}},
+		},
+		{
+			name:       "rejects opaque HTTP client over plaintext",
+			url:        "http://node.example",
+			headerName: "Authorization",
+			httpClient: opaqueHTTPClient{called: &atomic.Bool{}},
+			wantErr:    true,
+		},
+		{
+			name:       "accepts opaque HTTP client with HTTPS URL userinfo",
+			url:        testUserinfoURL("https", "node.example"),
+			httpClient: opaqueHTTPClient{called: &atomic.Bool{}},
+		},
+		{
+			name:       "rejects opaque HTTP client with plaintext URL userinfo",
+			url:        testUserinfoURL("http", "node.example"),
 			httpClient: opaqueHTTPClient{called: &atomic.Bool{}},
 			wantErr:    true,
 		},
@@ -185,11 +206,17 @@ func TestClient_RequestAuthorizationTransport(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:       "rejects opaque HTTP client",
-			url:        "https://node.example/",
+			name:       "rejects mutated plaintext endpoint for opaque HTTP client",
+			url:        "http://node.example/",
 			headerName: "authorization",
 			opaque:     true,
 			wantErr:    true,
+		},
+		{
+			name:       "executes HTTPS request with opaque HTTP client",
+			url:        "https://node.example/",
+			headerName: "authorization",
+			opaque:     true,
 		},
 		{
 			name:       "executes HTTPS header request",
@@ -214,7 +241,10 @@ func TestClient_RequestAuthorizationTransport(t *testing.T) {
 
 			var httpClient HTTPClient = standardClient
 			if tt.opaque {
-				httpClient = opaqueHTTPClient{called: &called}
+				httpClient = opaqueHTTPClient{
+					called:            &called,
+					authorizationSeen: &authorizationSeen,
+				}
 			}
 			cfg, err := NewClientConfig("https://initial.example/", WithHTTPClient(httpClient))
 			require.NoError(t, err)

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -33,12 +33,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 type opaqueHTTPClient struct {
 	called            *atomic.Bool
 	authorizationSeen *atomic.Bool
+	err               error
 }
 
 func (c opaqueHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.called.Store(true)
 	if c.authorizationSeen != nil {
 		c.authorizationSeen.Store(hasAuthorizationHeader(req.Header))
+	}
+	if c.err != nil {
+		return nil, c.err
 	}
 	return successfulHTTPResponse(req), nil
 }
@@ -324,6 +328,31 @@ func TestRedactAuthorizationErrorPercentEncodedUsername(t *testing.T) {
 	err := redactAuthorizationError(credentialEchoError("request failure: "+endpoint.Redacted()), rawURL, nil)
 
 	require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
+}
+
+func TestClient_RequestRedactsPercentEncodedPassword(t *testing.T) {
+	const (
+		password        = "p@ss"
+		encodedPassword = "p%40ss"
+	)
+	endpoint := &url.URL{
+		Scheme: "https",
+		Host:   "node.example",
+		User:   url.UserPassword(testURLUsername, password),
+	}
+	var called atomic.Bool
+	httpClient := opaqueHTTPClient{
+		called: &called,
+		err:    credentialEchoError("transport failure: " + encodedPassword),
+	}
+	cfg, err := NewClientConfig(endpoint.String(), WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	_, err = NewClient(cfg).Request(validTransportSecurityRequest())
+
+	require.True(t, called.Load())
+	require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
+	require.NotContains(t, err.Error(), encodedPassword)
 }
 
 func TestClient_AuthorizationRedirectDowngrade(t *testing.T) {

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -284,6 +284,18 @@ func TestRedactAuthorizationErrorMalformedURLUserinfo(t *testing.T) {
 	require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
 }
 
+func TestRedactAuthorizationErrorPercentEncodedUsername(t *testing.T) {
+	endpoint := &url.URL{
+		Scheme: "https",
+		Host:   "node.example",
+		User:   url.UserPassword("user@domain", testURLPassword),
+	}
+	rawURL := endpoint.String()
+	err := redactAuthorizationError(credentialEchoError("request failure: "+endpoint.Redacted()), rawURL, nil)
+
+	require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
+}
+
 func TestClient_AuthorizationRedirectDowngrade(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -94,6 +94,11 @@ func TestNewClientConfigAuthorizationTransport(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name:    "rejects malformed URL userinfo",
+			url:     malformedTestUserinfoURL(),
+			wantErr: true,
+		},
+		{
 			name:    "rejects plaintext URL userinfo",
 			url:     testUserinfoURL("http", "node.example"),
 			wantErr: true,
@@ -168,6 +173,11 @@ func TestClient_RequestAuthorizationTransport(t *testing.T) {
 			url:        "https://[::1/",
 			headerName: "Authorization",
 			wantErr:    true,
+		},
+		{
+			name:    "rejects mutated malformed URL userinfo",
+			url:     malformedTestUserinfoURL(),
+			wantErr: true,
 		},
 		{
 			name:    "rejects mutated plaintext URL userinfo",
@@ -264,6 +274,14 @@ func TestClient_RequestRedactsTransportError(t *testing.T) {
 	if !errors.Is(err, ErrAuthorizationRequestFailed) {
 		t.Fatal("expected redacted authorization request error")
 	}
+}
+
+func TestRedactAuthorizationErrorMalformedURLUserinfo(t *testing.T) {
+	rawURL := malformedTestUserinfoURL()
+	err := redactAuthorizationError(credentialEchoError("request failure: "+rawURL), rawURL, nil)
+
+	assertAuthorizationErrorRedacted(t, err)
+	require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
 }
 
 func TestClient_AuthorizationRedirectDowngrade(t *testing.T) {
@@ -392,6 +410,10 @@ func testUserinfoURL(scheme, host string) string {
 		Host:   host,
 		User:   url.UserPassword(testURLUsername, testURLPassword),
 	}).String()
+}
+
+func malformedTestUserinfoURL() string {
+	return "https://" + url.UserPassword(testURLUsername, testURLPassword).String() + "@[::1"
 }
 
 func addTestUserinfo(t *testing.T, rawURL string) string {

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -1,0 +1,389 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Peersyst/xrpl-go/xrpl/internal/clientconfig"
+	account "github.com/Peersyst/xrpl-go/xrpl/queries/account"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testHeaderValue = strings.Repeat("x", 24)
+	testURLUsername = strings.Repeat("u", 12)
+	testURLPassword = strings.Repeat("p", 12)
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type opaqueHTTPClient struct {
+	called *atomic.Bool
+}
+
+func (c opaqueHTTPClient) Do(*http.Request) (*http.Response, error) {
+	c.called.Store(true)
+	return nil, nil
+}
+
+type credentialEchoError string
+
+func (e credentialEchoError) Error() string {
+	return string(e)
+}
+
+func TestNewClientConfigAuthorizationTransport(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		headerName string
+		httpClient HTTPClient
+		wantErr    bool
+	}{
+		{
+			name:       "rejects plaintext HTTP",
+			url:        "http://node.example",
+			headerName: "Authorization",
+			wantErr:    true,
+		},
+		{
+			name:       "matches lowercase header",
+			url:        "http://node.example",
+			headerName: "authorization",
+			wantErr:    true,
+		},
+		{
+			name:       "matches mixed-case header",
+			url:        "http://node.example",
+			headerName: "aUtHoRiZaTiOn",
+			wantErr:    true,
+		},
+		{
+			name:       "accepts HTTPS",
+			url:        "https://node.example",
+			headerName: "Authorization",
+		},
+		{
+			name:       "accepts case-insensitive HTTPS scheme",
+			url:        "HTTPS://node.example",
+			headerName: "Authorization",
+		},
+		{
+			name:       "rejects scheme prefix lookalike",
+			url:        "https.not-secure://node.example",
+			headerName: "Authorization",
+			wantErr:    true,
+		},
+		{
+			name:       "rejects malformed URL",
+			url:        "https://[::1",
+			headerName: "Authorization",
+			wantErr:    true,
+		},
+		{
+			name:    "rejects plaintext URL userinfo",
+			url:     testUserinfoURL("http", "node.example"),
+			wantErr: true,
+		},
+		{
+			name: "accepts HTTPS URL userinfo",
+			url:  testUserinfoURL("https", "node.example"),
+		},
+		{
+			name:       "rejects opaque HTTP client",
+			url:        "https://node.example",
+			headerName: "Authorization",
+			httpClient: opaqueHTTPClient{called: &atomic.Bool{}},
+			wantErr:    true,
+		},
+		{
+			name: "allows plaintext without authorization",
+			url:  "http://node.example",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []ConfigOpt
+			if tt.headerName != "" {
+				opts = append(opts, withTestAuthorizationHeader(tt.headerName))
+			}
+			if tt.httpClient != nil {
+				opts = append(opts, WithHTTPClient(tt.httpClient))
+			}
+
+			cfg, err := NewClientConfig(tt.url, opts...)
+			assertAuthorizationErrorRedacted(t, err)
+			if tt.wantErr {
+				if !errors.Is(err, ErrInsecureAuthorization) {
+					t.Fatal("expected insecure authorization error")
+				}
+				require.Nil(t, cfg)
+				return
+			}
+
+			if err != nil {
+				t.Fatal("unexpected config error")
+			}
+			require.NotNil(t, cfg)
+		})
+	}
+}
+
+func TestClient_RequestAuthorizationTransport(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		headerName string
+		opaque     bool
+		wantErr    bool
+	}{
+		{
+			name:       "rejects mutated plaintext endpoint",
+			url:        "http://node.example/",
+			headerName: "Authorization",
+			wantErr:    true,
+		},
+		{
+			name:       "matches mutated mixed-case header",
+			url:        "http://node.example/",
+			headerName: "aUtHoRiZaTiOn",
+			wantErr:    true,
+		},
+		{
+			name:       "rejects mutated malformed endpoint",
+			url:        "https://[::1/",
+			headerName: "Authorization",
+			wantErr:    true,
+		},
+		{
+			name:    "rejects mutated plaintext URL userinfo",
+			url:     testUserinfoURL("http", "node.example"),
+			wantErr: true,
+		},
+		{
+			name:       "rejects opaque HTTP client",
+			url:        "https://node.example/",
+			headerName: "authorization",
+			opaque:     true,
+			wantErr:    true,
+		},
+		{
+			name:       "executes HTTPS header request",
+			url:        "https://node.example/",
+			headerName: "authorization",
+		},
+		{
+			name: "executes HTTPS URL userinfo request",
+			url:  testUserinfoURL("https", "node.example"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called atomic.Bool
+			var authorizationSeen atomic.Bool
+			standardClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				called.Store(true)
+				authorizationSeen.Store(hasAuthorizationHeader(req.Header))
+				return successfulHTTPResponse(req), nil
+			})}
+
+			var httpClient HTTPClient = standardClient
+			if tt.opaque {
+				httpClient = opaqueHTTPClient{called: &called}
+			}
+			cfg, err := NewClientConfig("https://initial.example/", WithHTTPClient(httpClient))
+			require.NoError(t, err)
+			cfg.URL = tt.url
+			if tt.headerName != "" {
+				cfg.Headers[tt.headerName] = []string{testHeaderValue}
+			}
+
+			_, err = NewClient(cfg).Request(validTransportSecurityRequest())
+			assertAuthorizationErrorRedacted(t, err)
+			if tt.wantErr {
+				if !errors.Is(err, ErrInsecureAuthorization) {
+					t.Fatal("expected insecure authorization error")
+				}
+				require.False(t, called.Load())
+				return
+			}
+
+			if err != nil {
+				t.Fatal("unexpected request error")
+			}
+			require.True(t, called.Load())
+			require.True(t, authorizationSeen.Load())
+		})
+	}
+}
+
+func TestAuthorizationDiagnosticsRedactHeaderValues(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := clientconfig.SetLogger(log.New(&logs, "", 0))
+	t.Cleanup(func() { clientconfig.SetLogger(previousLogger) })
+
+	_, err := NewClientConfig(
+		"http://node.example",
+		withTestAuthorizationHeader("Authorization"),
+	)
+	assertAuthorizationErrorRedacted(t, err)
+	if !errors.Is(err, ErrInsecureAuthorization) {
+		t.Fatal("expected insecure authorization error")
+	}
+	assertAuthorizationTextRedacted(t, logs.String(), "authorization warning exposed credential material")
+}
+
+func TestClient_RequestRedactsTransportError(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, credentialEchoError("transport failure: " + req.Header.Get(authorizationHeader))
+	})}
+	cfg, err := NewClientConfig(
+		"https://node.example",
+		WithHTTPClient(httpClient),
+		withTestAuthorizationHeader("Authorization"),
+	)
+	require.NoError(t, err)
+
+	_, err = NewClient(cfg).Request(validTransportSecurityRequest())
+	assertAuthorizationErrorRedacted(t, err)
+	if !errors.Is(err, ErrAuthorizationRequestFailed) {
+		t.Fatal("expected redacted authorization request error")
+	}
+}
+
+func TestClient_AuthorizationRedirectDowngrade(t *testing.T) {
+	tests := []struct {
+		name             string
+		useURLUserinfo   bool
+		mutateInCallback bool
+	}{
+		{name: "header"},
+		{name: "URL userinfo", useURLUserinfo: true},
+		{name: "callback URL mutation", mutateInCallback: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var plaintextRequestReceived atomic.Bool
+			plaintextServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				plaintextRequestReceived.Store(true)
+			}))
+			defer plaintextServer.Close()
+
+			var tlsServer *httptest.Server
+			tlsServer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !hasAuthorizationHeader(r.Header) {
+					t.Error("TLS request did not carry authorization header")
+					return
+				}
+				redirectURL := plaintextServer.URL
+				if tt.mutateInCallback {
+					redirectURL = tlsServer.URL + "/secure-redirect"
+				}
+				http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+			}))
+			defer tlsServer.Close()
+
+			httpClient := tlsServer.Client()
+			if tt.mutateInCallback {
+				httpClient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+					redirectURL, err := url.Parse(plaintextServer.URL)
+					if err != nil {
+						return err
+					}
+					req.URL = redirectURL
+					return nil
+				}
+			}
+
+			serverURL := tlsServer.URL
+			var opts []ConfigOpt
+			opts = append(opts, WithHTTPClient(httpClient))
+			if tt.useURLUserinfo {
+				serverURL = addTestUserinfo(t, serverURL)
+			} else {
+				opts = append(opts, withTestAuthorizationHeader("Authorization"))
+			}
+			cfg, err := NewClientConfig(serverURL, opts...)
+			require.NoError(t, err)
+
+			_, err = NewClient(cfg).Request(validTransportSecurityRequest())
+			assertAuthorizationErrorRedacted(t, err)
+			if !errors.Is(err, ErrInsecureAuthorization) {
+				t.Fatal("expected authenticated redirect downgrade to be refused")
+			}
+			require.False(t, plaintextRequestReceived.Load())
+		})
+	}
+}
+
+func withTestAuthorizationHeader(name string) ConfigOpt {
+	return func(cfg *Config) {
+		cfg.Headers[name] = []string{testHeaderValue}
+	}
+}
+
+func validTransportSecurityRequest() *account.ChannelsRequest {
+	return &account.ChannelsRequest{
+		Account: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+	}
+}
+
+func successfulHTTPResponse(req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Request:    req,
+	}
+}
+
+func testUserinfoURL(scheme, host string) string {
+	return (&url.URL{
+		Scheme: scheme,
+		Host:   host,
+		User:   url.UserPassword(testURLUsername, testURLPassword),
+	}).String()
+}
+
+func addTestUserinfo(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal("failed to prepare authenticated test URL")
+	}
+	parsedURL.User = url.UserPassword(testURLUsername, testURLPassword)
+	return parsedURL.String()
+}
+
+func assertAuthorizationErrorRedacted(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		assertAuthorizationTextRedacted(t, err.Error(), "authorization error exposed credential material")
+	}
+}
+
+func assertAuthorizationTextRedacted(t *testing.T, text, failureMessage string) {
+	t.Helper()
+	basicAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(testURLUsername+":"+testURLPassword))
+	for _, value := range []string{testHeaderValue, testURLUsername, testURLPassword, basicAuthorization} {
+		if strings.Contains(text, value) {
+			t.Fatal(failureMessage)
+		}
+	}
+}

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -332,6 +332,39 @@ func TestClient_AuthorizationRedirectDowngrade(t *testing.T) {
 	}
 }
 
+func TestAuthorizationRedirectPolicyChecksDowngradeBeforeCaller(t *testing.T) {
+	sourceRequest := httptest.NewRequest(http.MethodGet, "https://example.com/source", nil)
+	sourceRequest.Header.Set("Authorization", testHeaderValue)
+
+	t.Run("rejects downgrade without calling caller policy", func(t *testing.T) {
+		redirectRequest := httptest.NewRequest(http.MethodGet, "http://example.com/target", nil)
+		var callerInvoked atomic.Bool
+		policy := authorizationRedirectPolicy(func(*http.Request, []*http.Request) error {
+			callerInvoked.Store(true)
+			return nil
+		})
+
+		err := policy(redirectRequest, []*http.Request{sourceRequest})
+
+		require.ErrorIs(t, err, ErrInsecureAuthorization)
+		require.False(t, callerInvoked.Load())
+	})
+
+	t.Run("calls caller policy for HTTPS redirect", func(t *testing.T) {
+		redirectRequest := httptest.NewRequest(http.MethodGet, "https://example.com/target", nil)
+		var callerInvoked atomic.Bool
+		policy := authorizationRedirectPolicy(func(*http.Request, []*http.Request) error {
+			callerInvoked.Store(true)
+			return nil
+		})
+
+		err := policy(redirectRequest, []*http.Request{sourceRequest})
+
+		require.NoError(t, err)
+		require.True(t, callerInvoked.Load())
+	})
+}
+
 func withTestAuthorizationHeader(name string) ConfigOpt {
 	return func(cfg *Config) {
 		cfg.Headers[name] = []string{testHeaderValue}

--- a/xrpl/rpc/transport_security_test.go
+++ b/xrpl/rpc/transport_security_test.go
@@ -173,6 +173,63 @@ func TestNewClientConfigAuthorizationTransport(t *testing.T) {
 	}
 }
 
+func TestNewClientConfigRejectsNilHTTPClient(t *testing.T) {
+	var typedNil *http.Client
+	tests := []struct {
+		name              string
+		httpClient        HTTPClient
+		withAuthorization bool
+		withTimeout       bool
+	}{
+		{name: "nil interface"},
+		{name: "nil interface with authorization", withAuthorization: true},
+		{name: "typed nil pointer", httpClient: typedNil},
+		{name: "typed nil pointer with authorization", httpClient: typedNil, withAuthorization: true},
+		{name: "typed nil pointer before timeout", httpClient: typedNil, withTimeout: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []ConfigOpt{WithHTTPClient(tt.httpClient)}
+			if tt.withAuthorization {
+				opts = append(opts, withTestAuthorizationHeader("Authorization"))
+			}
+			if tt.withTimeout {
+				opts = append(opts, WithTimeout(0))
+			}
+
+			cfg, err := NewClientConfig("https://node.example", opts...)
+
+			require.ErrorIs(t, err, ErrNilHTTPClient)
+			require.Nil(t, cfg)
+		})
+	}
+}
+
+func TestClient_RequestRejectsMutatedNilHTTPClient(t *testing.T) {
+	var typedNil *http.Client
+	tests := []struct {
+		name       string
+		httpClient HTTPClient
+	}{
+		{name: "nil interface"},
+		{name: "typed nil pointer", httpClient: typedNil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewClientConfig("https://node.example")
+			require.NoError(t, err)
+			client := NewClient(cfg)
+			cfg.HTTPClient = tt.httpClient
+
+			_, err = client.Request(validTransportSecurityRequest())
+
+			require.ErrorIs(t, err, ErrNilHTTPClient)
+		})
+	}
+}
+
 func TestClient_RequestAuthorizationTransport(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -276,7 +333,7 @@ func TestClient_RequestAuthorizationTransport(t *testing.T) {
 	}
 }
 
-func TestAuthorizationDiagnosticsRedactHeaderValues(t *testing.T) {
+func TestNewClientConfig_AuthorizationValidationPrecedesInsecureSchemeWarning(t *testing.T) {
 	var logs bytes.Buffer
 	previousLogger := clientconfig.SetLogger(log.New(&logs, "", 0))
 	t.Cleanup(func() { clientconfig.SetLogger(previousLogger) })
@@ -289,12 +346,14 @@ func TestAuthorizationDiagnosticsRedactHeaderValues(t *testing.T) {
 	if !errors.Is(err, ErrInsecureAuthorization) {
 		t.Fatal("expected insecure authorization error")
 	}
-	assertAuthorizationTextRedacted(t, logs.String(), "authorization warning exposed credential material")
+	require.Empty(t, logs.String())
 }
 
-func TestClient_RequestRedactsTransportError(t *testing.T) {
+func TestClient_RequestRedactsTransportErrorAfterHeaderMutation(t *testing.T) {
 	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return nil, credentialEchoError("transport failure: " + req.Header.Get(authorizationHeader))
+		authorization := req.Header.Get(authorizationHeader)
+		req.Header.Del(authorizationHeader)
+		return nil, credentialEchoError("transport failure: " + authorization)
 	})}
 	cfg, err := NewClientConfig(
 		"https://node.example",
@@ -307,6 +366,58 @@ func TestClient_RequestRedactsTransportError(t *testing.T) {
 	assertAuthorizationErrorRedacted(t, err)
 	if !errors.Is(err, ErrAuthorizationRequestFailed) {
 		t.Fatal("expected redacted authorization request error")
+	}
+}
+
+func TestRedactAuthorizationErrorHeaderCredentials(t *testing.T) {
+	bearerToken := strings.Repeat("b", 32)
+	basicCredentials := base64.StdEncoding.EncodeToString([]byte("user:password"))
+	tests := []struct {
+		name               string
+		authorizationValue string
+		diagnostic         string
+		wantRedacted       bool
+	}{
+		{
+			name:               "complete Bearer value",
+			authorizationValue: "Bearer " + bearerToken,
+			diagnostic:         "transport failure: Bearer " + bearerToken,
+			wantRedacted:       true,
+		},
+		{
+			name:               "bare Bearer token",
+			authorizationValue: "Bearer " + bearerToken,
+			diagnostic:         "transport failure: " + bearerToken,
+			wantRedacted:       true,
+		},
+		{
+			name:               "bare Basic credentials",
+			authorizationValue: "Basic " + basicCredentials,
+			diagnostic:         "transport failure: " + basicCredentials,
+			wantRedacted:       true,
+		},
+		{
+			name:               "unrelated error",
+			authorizationValue: "Bearer " + bearerToken,
+			diagnostic:         "transport unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceErr := credentialEchoError(tt.diagnostic)
+			err := redactAuthorizationError(
+				sourceErr,
+				"https://node.example",
+				map[string][]string{authorizationHeader: {tt.authorizationValue}},
+			)
+
+			if tt.wantRedacted {
+				require.ErrorIs(t, err, ErrAuthorizationRequestFailed)
+				return
+			}
+			require.Equal(t, sourceErr, err)
+		})
 	}
 }
 
@@ -506,8 +617,20 @@ func assertAuthorizationErrorRedacted(t *testing.T, err error) {
 
 func assertAuthorizationTextRedacted(t *testing.T, text, failureMessage string) {
 	t.Helper()
-	basicAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(testURLUsername+":"+testURLPassword))
-	for _, value := range []string{testHeaderValue, testURLUsername, testURLPassword, basicAuthorization} {
+	encodedUsername := url.User(testURLUsername).String()
+	userInfo := url.UserPassword(testURLUsername, testURLPassword).String()
+	encodedPassword := strings.TrimPrefix(userInfo, encodedUsername+":")
+	basicCredentials := base64.StdEncoding.EncodeToString([]byte(testURLUsername + ":" + testURLPassword))
+	for _, value := range []string{
+		testHeaderValue,
+		testURLUsername,
+		encodedUsername,
+		testURLPassword,
+		encodedPassword,
+		userInfo,
+		basicCredentials,
+		"Basic " + basicCredentials,
+	} {
 		if strings.Contains(text, value) {
 			t.Fatal(failureMessage)
 		}

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -1042,14 +1042,6 @@ func (c *Client) handleStream(ctx context.Context, t streamtypes.Type, message [
 			return
 		}
 		c.reportTransaction(ctx, &transactionStream)
-
-		// Order-book subscriptions use the transaction wire type too. The
-		// message does not identify which subscription matched, so dispatch all
-		// transaction messages to both exported transaction handlers.
-		var orderBook streamtypes.OrderBookStream
-		if c.unmarshalMessage(ctx, message, &orderBook) {
-			c.reportOrderBook(ctx, &orderBook)
-		}
 	case streamtypes.ValidationStreamType:
 		var validation streamtypes.ValidationStream
 		if c.unmarshalMessage(ctx, message, &validation) {

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -95,7 +95,7 @@ func (p *pendingResponse) cancel() {
 // to the shared reader and can delay all stream and request dispatch. Handlers
 // should offload long-running work when that backpressure is undesirable.
 // Automatic reconnect preserves On* handler registrations but does not replay
-// server-side subscriptions; callers must resubscribe after reconnect.
+// server-side subscriptions. Callers must resubscribe after reconnect.
 type Client struct {
 	cfg  ClientConfig
 	conn *Connection

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -94,6 +94,8 @@ func (p *pendingResponse) cancel() {
 // event for that same handler, at which point that event applies backpressure
 // to the shared reader and can delay all stream and request dispatch. Handlers
 // should offload long-running work when that backpressure is undesirable.
+// Automatic reconnect preserves On* handler registrations but does not replay
+// server-side subscriptions; callers must resubscribe after reconnect.
 type Client struct {
 	cfg  ClientConfig
 	conn *Connection

--- a/xrpl/websocket/client.go
+++ b/xrpl/websocket/client.go
@@ -85,6 +85,15 @@ func (p *pendingResponse) cancel() {
 }
 
 // Client is a WebSocket client for interacting with an XRPL server.
+//
+// Each On* handler is invoked on its own per-stream delivery goroutine, not on
+// the socket reader goroutine. Calls to one handler are serialized in wire
+// order, while handlers for different streams may run concurrently and have no
+// global ordering guarantee. Delivery uses an unbuffered handoff with no event
+// queue: while a handler is running, the reader can continue until the next
+// event for that same handler, at which point that event applies backpressure
+// to the shared reader and can delay all stream and request dispatch. Handlers
+// should offload long-running work when that backpressure is undesirable.
 type Client struct {
 	cfg  ClientConfig
 	conn *Connection
@@ -987,7 +996,9 @@ func (c *Client) awaitResponse(ctx context.Context, response *pendingResponse) (
 
 func (c *Client) handleMessage(ctx context.Context, message []byte) {
 	var stream wstypes.Message
-	c.unmarshalMessage(ctx, message, &stream)
+	if !c.unmarshalMessage(ctx, message, &stream) {
+		return
+	}
 	if stream.IsRequest() {
 		c.handleRequest(ctx, message)
 	} else if stream.IsStream() {
@@ -997,7 +1008,9 @@ func (c *Client) handleMessage(ctx context.Context, message []byte) {
 
 func (c *Client) handleRequest(ctx context.Context, message []byte) {
 	var res ClientResponse
-	c.unmarshalMessage(ctx, message, &res)
+	if !c.unmarshalMessage(ctx, message, &res) {
+		return
+	}
 	response, ok := c.lookupPendingResponse(res.ID)
 	if !ok {
 		return
@@ -1006,34 +1019,55 @@ func (c *Client) handleRequest(ctx context.Context, message []byte) {
 	response.complete(pendingResponseResult{response: &res})
 }
 
-func (c *Client) unmarshalMessage(ctx context.Context, message []byte, v any) {
+func (c *Client) unmarshalMessage(ctx context.Context, message []byte, v any) bool {
 	if err := json.Unmarshal(message, v); err != nil {
 		c.reportError(ctx, err)
+		return false
 	}
+	return true
 }
 
 func (c *Client) handleStream(ctx context.Context, t streamtypes.Type, message []byte) {
 	switch t {
 	case streamtypes.LedgerStreamType:
 		var ledger streamtypes.LedgerStream
-		c.unmarshalMessage(ctx, message, &ledger)
-		c.reportLedgerClosed(ctx, &ledger)
+		if c.unmarshalMessage(ctx, message, &ledger) {
+			c.reportLedgerClosed(ctx, &ledger)
+		}
 	case streamtypes.TransactionStreamType:
 		var transactionStream streamtypes.TransactionStream
-		c.unmarshalMessage(ctx, message, &transactionStream)
+		if !c.unmarshalMessage(ctx, message, &transactionStream) {
+			return
+		}
 		c.reportTransaction(ctx, &transactionStream)
+
+		// Order-book subscriptions use the transaction wire type too. The
+		// message does not identify which subscription matched, so dispatch all
+		// transaction messages to both exported transaction handlers.
+		var orderBook streamtypes.OrderBookStream
+		if c.unmarshalMessage(ctx, message, &orderBook) {
+			c.reportOrderBook(ctx, &orderBook)
+		}
 	case streamtypes.ValidationStreamType:
 		var validation streamtypes.ValidationStream
-		c.unmarshalMessage(ctx, message, &validation)
-		c.reportValidationReceived(ctx, &validation)
+		if c.unmarshalMessage(ctx, message, &validation) {
+			c.reportValidationReceived(ctx, &validation)
+		}
 	case streamtypes.PeerStatusStreamType:
 		var peerStatus streamtypes.PeerStatusStream
-		c.unmarshalMessage(ctx, message, &peerStatus)
-		c.reportPeerStatusChange(ctx, &peerStatus)
+		if c.unmarshalMessage(ctx, message, &peerStatus) {
+			c.reportPeerStatusChange(ctx, &peerStatus)
+		}
+	case streamtypes.BookChangesStreamType:
+		var bookChanges streamtypes.BookChangesStream
+		if c.unmarshalMessage(ctx, message, &bookChanges) {
+			c.reportBookChanges(ctx, &bookChanges)
+		}
 	case streamtypes.ConsensusStreamType:
 		var consensus streamtypes.ConsensusStream
-		c.unmarshalMessage(ctx, message, &consensus)
-		c.reportConsensusPhase(ctx, &consensus)
+		if c.unmarshalMessage(ctx, message, &consensus) {
+			c.reportConsensusPhase(ctx, &consensus)
+		}
 	default:
 		c.reportError(ctx, ErrUnknownStreamType{
 			Type: t,

--- a/xrpl/websocket/stream_dispatch_test.go
+++ b/xrpl/websocket/stream_dispatch_test.go
@@ -1,0 +1,300 @@
+package websocket
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	streamtypes "github.com/Peersyst/xrpl-go/xrpl/queries/subscription/types"
+	"github.com/Peersyst/xrpl-go/xrpl/websocket/testutil"
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_HandleMessageDispatchesExportedStreams(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		register func(*Client, chan<- bool)
+	}{
+		{
+			name:    "ledger closed",
+			message: `{"type":"ledgerClosed","ledger_index":11}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnLedgerClosed(func(event *streamtypes.LedgerStream) {
+					received <- event.Type == streamtypes.LedgerStreamType && event.LedgerIndex == 11
+				})
+			},
+		},
+		{
+			name:    "validation received",
+			message: `{"type":"validationReceived","ledger_index":12}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnValidationReceived(func(event *streamtypes.ValidationStream) {
+					received <- event.Type == streamtypes.ValidationStreamType && event.LedgerIndex == 12
+				})
+			},
+		},
+		{
+			name:    "transaction",
+			message: `{"type":"transaction","engine_result":"tesSUCCESS","tx_json":{"TransactionType":"OfferCreate"}}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnTransactions(func(event *streamtypes.TransactionStream) {
+					received <- event.Type == streamtypes.TransactionStreamType && event.EngineResult == "tesSUCCESS"
+				})
+			},
+		},
+		{
+			name:    "order book transaction",
+			message: `{"type":"transaction","engine_result":"tesSUCCESS","tx_json":{"TransactionType":"OfferCreate","owner_funds":"100"}}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnOrderBook(func(event *streamtypes.OrderBookStream) {
+					ownerFunds, ok := event.Transaction["owner_funds"]
+					received <- event.Type == streamtypes.OrderBookStreamType &&
+						event.EngineResult == "tesSUCCESS" && ok && ownerFunds == "100"
+				})
+			},
+		},
+		{
+			name:    "peer status change",
+			message: `{"type":"peerStatusChange","action":"ACCEPTED_LEDGER","ledger_index":13}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnPeerStatusChange(func(event *streamtypes.PeerStatusStream) {
+					received <- event.Type == streamtypes.PeerStatusStreamType && event.Action == streamtypes.PeerStatusAcceptedLedger && event.LedgerIndex == 13
+				})
+			},
+		},
+		{
+			name:    "book changes",
+			message: `{"type":"bookChanges","ledger_index":14,"changes":[{"currency_a":"XRP_drops","currency_b":"issuer/USD","volume_a":"1","volume_b":"2","high":"3","low":"4","open":"5","close":"6"}]}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnBookChanges(func(event *streamtypes.BookChangesStream) {
+					received <- event.Type == streamtypes.BookChangesStreamType &&
+						event.LedgerIndex == 14 && len(event.Changes) == 1 &&
+						event.Changes[0].CurrencyA == "XRP_drops" && event.Changes[0].VolumeA == "1"
+				})
+			},
+		},
+		{
+			name:    "consensus phase",
+			message: `{"type":"consensusPhase","consensus":"accepted"}`,
+			register: func(c *Client, received chan<- bool) {
+				c.OnConsensusPhase(func(event *streamtypes.ConsensusStream) {
+					received <- event.Type == streamtypes.ConsensusStreamType && event.Consensus == "accepted"
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(*NewClientConfig())
+			ctx := client.resetLifecycle()
+			defer client.cancelLifecycle()
+
+			received := make(chan bool, 1)
+			tt.register(client, received)
+			client.handleMessage(ctx, []byte(tt.message))
+
+			select {
+			case decoded := <-received:
+				require.True(t, decoded, "handler received incorrectly decoded event")
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for stream handler")
+			}
+		})
+	}
+}
+
+func TestClient_StreamHandlerOrderingAndBackpressure(t *testing.T) {
+	client := NewClient(*NewClientConfig())
+	ctx := client.resetLifecycle()
+	defer client.cancelLifecycle()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	}()
+	handled := make(chan uint64, 2)
+	client.OnLedgerClosed(func(event *streamtypes.LedgerStream) {
+		if event.LedgerIndex == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		handled <- uint64(event.LedgerIndex)
+	})
+
+	firstDispatchDone := make(chan struct{})
+	go func() {
+		client.handleMessage(ctx, []byte(`{"type":"ledgerClosed","ledger_index":1}`))
+		close(firstDispatchDone)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first handler call")
+	}
+	select {
+	case <-firstDispatchDone:
+	case <-time.After(time.Second):
+		t.Fatal("reader-side dispatch waited for the handler to finish")
+	}
+
+	secondDispatchDone := make(chan struct{})
+	go func() {
+		client.handleMessage(ctx, []byte(`{"type":"ledgerClosed","ledger_index":2}`))
+		close(secondDispatchDone)
+	}()
+
+	select {
+	case <-secondDispatchDone:
+		t.Fatal("second same-stream dispatch bypassed handler backpressure")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	select {
+	case <-secondDispatchDone:
+	case <-time.After(time.Second):
+		t.Fatal("second dispatch remained blocked after handler resumed")
+	}
+
+	handledInOrder := make([]uint64, 0, 2)
+	for range 2 {
+		select {
+		case ledgerIndex := <-handled:
+			handledInOrder = append(handledInOrder, ledgerIndex)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for ordered handler calls")
+		}
+	}
+	require.Equal(t, []uint64{1, 2}, handledInOrder)
+}
+
+func TestClient_StreamHandlersRunConcurrentlyAcrossStreams(t *testing.T) {
+	client := NewClient(*NewClientConfig())
+	ctx := client.resetLifecycle()
+	defer client.cancelLifecycle()
+
+	ledgerStarted := make(chan struct{})
+	releaseLedger := make(chan struct{})
+	defer close(releaseLedger)
+	client.OnLedgerClosed(func(*streamtypes.LedgerStream) {
+		close(ledgerStarted)
+		<-releaseLedger
+	})
+
+	bookChangesReceived := make(chan struct{})
+	client.OnBookChanges(func(*streamtypes.BookChangesStream) {
+		close(bookChangesReceived)
+	})
+
+	client.handleMessage(ctx, []byte(`{"type":"ledgerClosed","ledger_index":1}`))
+	select {
+	case <-ledgerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ledger handler")
+	}
+
+	client.handleMessage(ctx, []byte(`{"type":"bookChanges","ledger_index":2}`))
+	select {
+	case <-bookChangesReceived:
+	case <-time.After(time.Second):
+		t.Fatal("different stream handler was blocked by ledger handler")
+	}
+}
+
+func TestClient_StreamHandlerSingleDeliveryAcrossRepeatedReconnects(t *testing.T) {
+	const reconnectCount = 2
+	var connectionCount atomic.Int32
+	upgrader := gorillaws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionNumber := connectionCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		message := fmt.Appendf(nil, `{"type":"ledgerClosed","ledger_index":%d}`, connectionNumber)
+		if err := conn.WriteMessage(gorillaws.TextMessage, message); err != nil {
+			return
+		}
+		if connectionNumber <= reconnectCount {
+			_ = conn.WriteMessage(
+				gorillaws.CloseMessage,
+				gorillaws.FormatCloseMessage(gorillaws.CloseNormalClosure, ""),
+			)
+			return
+		}
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	url, err := testutil.ConvertHTTPToWS(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(withReconnectDelays(
+		NewClientConfig().
+			WithHost(url).
+			WithTimeout(time.Second).
+			WithMaxReconnects(reconnectCount).
+			WithNetworkIdentity(0, "2.0.0"),
+		time.Millisecond,
+		time.Millisecond,
+	))
+
+	received := make(chan uint64, reconnectCount+2)
+	client.OnLedgerClosed(func(event *streamtypes.LedgerStream) {
+		received <- uint64(event.LedgerIndex)
+	})
+
+	require.NoError(t, client.Connect())
+	defer client.Disconnect()
+
+	for expected := uint64(1); expected <= reconnectCount+1; expected++ {
+		select {
+		case actual := <-received:
+			require.Equal(t, expected, actual)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for reconnect stream event")
+		}
+	}
+
+	select {
+	case <-received:
+		t.Fatal("stream event was delivered more than once")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// An explicit reconnect restarts the reader and handler runners. The
+	// registration persists, but exactly one runner must receive the event.
+	require.NoError(t, client.Disconnect())
+	require.NoError(t, client.Connect())
+	select {
+	case actual := <-received:
+		require.Equal(t, uint64(reconnectCount+2), actual)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reader-restart stream event")
+	}
+	select {
+	case <-received:
+		t.Fatal("reader-restart stream event was delivered more than once")
+	case <-time.After(50 * time.Millisecond):
+	}
+	require.Equal(t, int32(reconnectCount+2), connectionCount.Load())
+}

--- a/xrpl/websocket/stream_dispatch_test.go
+++ b/xrpl/websocket/stream_dispatch_test.go
@@ -48,17 +48,6 @@ func TestClient_HandleMessageDispatchesExportedStreams(t *testing.T) {
 			},
 		},
 		{
-			name:    "order book transaction",
-			message: `{"type":"transaction","engine_result":"tesSUCCESS","tx_json":{"TransactionType":"OfferCreate","owner_funds":"100"}}`,
-			register: func(c *Client, received chan<- bool) {
-				c.OnOrderBook(func(event *streamtypes.OrderBookStream) {
-					ownerFunds, ok := event.Transaction["owner_funds"]
-					received <- event.Type == streamtypes.OrderBookStreamType &&
-						event.EngineResult == "tesSUCCESS" && ok && ownerFunds == "100"
-				})
-			},
-		},
-		{
 			name:    "peer status change",
 			message: `{"type":"peerStatusChange","action":"ACCEPTED_LEDGER","ledger_index":13}`,
 			register: func(c *Client, received chan<- bool) {
@@ -116,6 +105,8 @@ func TestClient_StreamHandlerOrderingAndBackpressure(t *testing.T) {
 
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
+	// Release the blocked handler after an early test failure. The normal path
+	// closes the channel first, so cleanup must not close it a second time.
 	defer func() {
 		select {
 		case <-releaseFirst:

--- a/xrpl/websocket/streams.go
+++ b/xrpl/websocket/streams.go
@@ -26,7 +26,7 @@ type lifecycleEvent[T any] struct {
 // activate it for a fresh client lifecycle. On atomically replaces any
 // previously registered handler on this stream rather than spawning an
 // additional runner. Handler replacement is best-effort: an event already
-// queued for delivery may still be dispatched to the previously registered
+// accepted for delivery may still be dispatched to the previously registered
 // handler.
 func (s *lifecycleStream[T]) On(ctx context.Context, handler func(T)) {
 	s.stateMu.Lock()
@@ -61,13 +61,11 @@ func (s *lifecycleStream[T]) Start(ctx context.Context) {
 	}
 }
 
-// Report delivers value to the runner. The send is synchronous on an
-// unbuffered channel so handlers apply backpressure rather than buffering
-// unbounded events. Because the caller is the single readMessages goroutine
-// (which also dispatches Request responses via handleRequest), a slow user
-// stream handler stalls request dispatch and can time out unrelated requests.
-// Callers that need request throughput in the presence of slow handlers
-// should offload work inside their handler.
+// Report hands value to the per-stream runner over an unbuffered channel. The
+// handoff returns when the runner accepts the event, not when the handler
+// finishes. A running handler therefore applies backpressure when the next
+// event for this stream is reported; if Report is called by readMessages, that
+// backpressure stalls all subsequent stream and request dispatch.
 func (s *lifecycleStream[T]) Report(ctx context.Context, value T) {
 	if ctx == nil || ctx.Err() != nil {
 		return
@@ -148,11 +146,8 @@ func (s *lifecycleStream[T]) run(ctx context.Context, ch <-chan lifecycleEvent[T
 }
 
 // registerLifecycleHandler atomically replaces the registered handler on
-// stream under streamHandlerStateMu. Handlers run on the single readMessages
-// goroutine that also dispatches Request responses, slow OnXxx handlers
-// therefore stall response dispatch and can time out unrelated Request calls.
-// Callers that need request throughput in the presence of slow stream work
-// should offload that work inside their handler.
+// stream under streamHandlerStateMu. See Client's godoc for the handler
+// concurrency, ordering, and backpressure contract.
 func registerLifecycleHandler[T any](c *Client, stream *lifecycleStream[T], handler func(T)) {
 	c.streamHandlerStateMu.Lock()
 	defer c.streamHandlerStateMu.Unlock()
@@ -168,7 +163,8 @@ func (c *Client) reportError(ctx context.Context, err error) {
 	c.errorStream.Report(ctx, err)
 }
 
-// OnError handles asynchronous client errors.
+// OnError handles asynchronous client errors. It follows the handler contract
+// documented on [Client].
 func (c *Client) OnError(errHandler func(err error)) {
 	registerLifecycleHandler(c, &c.errorStream, errHandler)
 }
@@ -177,7 +173,8 @@ func (c *Client) reportLedgerClosed(ctx context.Context, ledger *streamtypes.Led
 	c.ledgerClosedStream.Report(ctx, ledger)
 }
 
-// OnLedgerClosed handles "ledgerClosed" events.
+// OnLedgerClosed handles "ledgerClosed" events. It follows the handler
+// contract documented on [Client].
 func (c *Client) OnLedgerClosed(handler func(ledger *streamtypes.LedgerStream)) {
 	registerLifecycleHandler(c, &c.ledgerClosedStream, handler)
 }
@@ -186,7 +183,8 @@ func (c *Client) reportValidationReceived(ctx context.Context, validation *strea
 	c.validationStream.Report(ctx, validation)
 }
 
-// OnValidationReceived handles "validationReceived" events.
+// OnValidationReceived handles "validationReceived" events. It follows the
+// handler contract documented on [Client].
 func (c *Client) OnValidationReceived(handler func(validation *streamtypes.ValidationStream)) {
 	registerLifecycleHandler(c, &c.validationStream, handler)
 }
@@ -195,7 +193,9 @@ func (c *Client) reportTransaction(ctx context.Context, transaction *streamtypes
 	c.transactionStream.Report(ctx, transaction)
 }
 
-// OnTransactions handles "transactions" events.
+// OnTransactions handles "transaction" messages, including messages produced
+// by transaction, account, and order-book subscriptions. It follows the
+// handler contract documented on [Client].
 func (c *Client) OnTransactions(handler func(transactions *streamtypes.TransactionStream)) {
 	registerLifecycleHandler(c, &c.transactionStream, handler)
 }
@@ -204,7 +204,8 @@ func (c *Client) reportPeerStatusChange(ctx context.Context, peerStatus *streamt
 	c.peerStatusStream.Report(ctx, peerStatus)
 }
 
-// OnPeerStatusChange handles "peerStatus" events.
+// OnPeerStatusChange handles "peerStatusChange" events. It follows the handler
+// contract documented on [Client].
 func (c *Client) OnPeerStatusChange(handler func(peerStatus *streamtypes.PeerStatusStream)) {
 	registerLifecycleHandler(c, &c.peerStatusStream, handler)
 }
@@ -213,7 +214,10 @@ func (c *Client) reportOrderBook(ctx context.Context, orderbook *streamtypes.Ord
 	c.orderBookStream.Report(ctx, orderbook)
 }
 
-// OnOrderBook handles "orderbook" events.
+// OnOrderBook handles order-book notifications. The XRPL protocol sends these
+// as "transaction" messages without identifying which subscription matched,
+// so this handler receives every transaction message, as does OnTransactions.
+// It follows the handler contract documented on [Client].
 func (c *Client) OnOrderBook(handler func(orderbook *streamtypes.OrderBookStream)) {
 	registerLifecycleHandler(c, &c.orderBookStream, handler)
 }
@@ -222,7 +226,8 @@ func (c *Client) reportBookChanges(ctx context.Context, bookChanges *streamtypes
 	c.bookChangesStream.Report(ctx, bookChanges)
 }
 
-// OnBookChanges handles "bookChanges" events.
+// OnBookChanges handles "bookChanges" events. It follows the handler contract
+// documented on [Client].
 func (c *Client) OnBookChanges(handler func(bookChanges *streamtypes.BookChangesStream)) {
 	registerLifecycleHandler(c, &c.bookChangesStream, handler)
 }
@@ -231,7 +236,8 @@ func (c *Client) reportConsensusPhase(ctx context.Context, consensusPhase *strea
 	c.consensusStream.Report(ctx, consensusPhase)
 }
 
-// OnConsensusPhase handles "consensusPhase" events.
+// OnConsensusPhase handles "consensusPhase" events. It follows the handler
+// contract documented on [Client].
 func (c *Client) OnConsensusPhase(handler func(consensusPhase *streamtypes.ConsensusStream)) {
 	registerLifecycleHandler(c, &c.consensusStream, handler)
 }

--- a/xrpl/websocket/streams.go
+++ b/xrpl/websocket/streams.go
@@ -64,7 +64,7 @@ func (s *lifecycleStream[T]) Start(ctx context.Context) {
 // Report hands value to the per-stream runner over an unbuffered channel. The
 // handoff returns when the runner accepts the event, not when the handler
 // finishes. A running handler therefore applies backpressure when the next
-// event for this stream is reported; if Report is called by readMessages, that
+// event for this stream is reported. If Report is called by readMessages, that
 // backpressure stalls all subsequent stream and request dispatch.
 func (s *lifecycleStream[T]) Report(ctx context.Context, value T) {
 	if ctx == nil || ctx.Err() != nil {

--- a/xrpl/websocket/streams.go
+++ b/xrpl/websocket/streams.go
@@ -214,10 +214,11 @@ func (c *Client) reportOrderBook(ctx context.Context, orderbook *streamtypes.Ord
 	c.orderBookStream.Report(ctx, orderbook)
 }
 
-// OnOrderBook handles order-book notifications. The XRPL protocol sends these
-// as "transaction" messages without identifying which subscription matched,
-// so this handler receives every transaction message, as does OnTransactions.
-// It follows the handler contract documented on [Client].
+// OnOrderBook registers an order-book handler. Rippled sends order-book
+// subscription updates as "transaction" messages without identifying the
+// matched subscription, so wire notifications are delivered through
+// [Client.OnTransactions] instead. It follows the handler contract documented
+// on [Client].
 func (c *Client) OnOrderBook(handler func(orderbook *streamtypes.OrderBookStream)) {
 	registerLifecycleHandler(c, &c.orderBookStream, handler)
 }

--- a/xrpl/websocket/streams_test.go
+++ b/xrpl/websocket/streams_test.go
@@ -170,10 +170,6 @@ func TestClient_StreamHandlersReceiveReportedStreams(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no OrderBookStreamType case (it aliases
-			// TransactionStreamType in xrpl/queries/subscription/types), so this
-			// case exercises the handler runner via reportOrderBook directly and
-			// does not cover wire dispatch.
 			name: "orderBook",
 			register: func(c *Client, received chan struct{}) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {
@@ -185,10 +181,6 @@ func TestClient_StreamHandlersReceiveReportedStreams(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no BookChangesStreamType case (the type is
-			// not defined in xrpl/queries/subscription/types), so this case
-			// exercises the handler runner via reportBookChanges directly and
-			// does not cover wire dispatch.
 			name: "bookChanges",
 			register: func(c *Client, received chan struct{}) {
 				c.OnBookChanges(func(*streamtypes.BookChangesStream) {
@@ -283,10 +275,6 @@ func TestClient_StreamHandlersReplacePreviousHandler(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no OrderBookStreamType case (it aliases
-			// TransactionStreamType in xrpl/queries/subscription/types), so this
-			// case exercises the handler runner via reportOrderBook directly and
-			// does not cover wire dispatch.
 			name: "orderBook",
 			register: func(c *Client, handler func()) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {
@@ -298,10 +286,6 @@ func TestClient_StreamHandlersReplacePreviousHandler(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no BookChangesStreamType case (the type is
-			// not defined in xrpl/queries/subscription/types), so this case
-			// exercises the handler runner via reportBookChanges directly and
-			// does not cover wire dispatch.
 			name: "bookChanges",
 			register: func(c *Client, handler func()) {
 				c.OnBookChanges(func(*streamtypes.BookChangesStream) {
@@ -426,20 +410,12 @@ func TestClient_ReportStreamSkipsWhenChannelUnset(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no OrderBookStreamType case (it aliases
-			// TransactionStreamType in xrpl/queries/subscription/types), so this
-			// case exercises the handler runner via reportOrderBook directly and
-			// does not cover wire dispatch.
 			name: "orderBook",
 			report: func(c *Client) {
 				c.reportOrderBook(c.lifecycleContext(), &streamtypes.OrderBookStream{})
 			},
 		},
 		{
-			// TODO: handleStream has no BookChangesStreamType case (the type is
-			// not defined in xrpl/queries/subscription/types), so this case
-			// exercises the handler runner via reportBookChanges directly and
-			// does not cover wire dispatch.
 			name: "bookChanges",
 			report: func(c *Client) {
 				c.reportBookChanges(c.lifecycleContext(), &streamtypes.BookChangesStream{})
@@ -895,10 +871,6 @@ func TestClient_ReportStreamAfterDisconnectDoesNotBlock(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no OrderBookStreamType case (it aliases
-			// TransactionStreamType in xrpl/queries/subscription/types), so this
-			// case exercises the handler runner via reportOrderBook directly and
-			// does not cover wire dispatch.
 			name: "orderBook",
 			register: func(c *Client) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {})
@@ -908,10 +880,6 @@ func TestClient_ReportStreamAfterDisconnectDoesNotBlock(t *testing.T) {
 			},
 		},
 		{
-			// TODO: handleStream has no BookChangesStreamType case (the type is
-			// not defined in xrpl/queries/subscription/types), so this case
-			// exercises the handler runner via reportBookChanges directly and
-			// does not cover wire dispatch.
 			name: "bookChanges",
 			register: func(c *Client) {
 				c.OnBookChanges(func(*streamtypes.BookChangesStream) {})

--- a/xrpl/websocket/streams_test.go
+++ b/xrpl/websocket/streams_test.go
@@ -170,6 +170,8 @@ func TestClient_StreamHandlersReceiveReportedStreams(t *testing.T) {
 			},
 		},
 		{
+			// Order-book wire notifications use the transaction runner, so this
+			// case exercises only the retained order-book handler runner.
 			name: "orderBook",
 			register: func(c *Client, received chan struct{}) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {
@@ -275,6 +277,8 @@ func TestClient_StreamHandlersReplacePreviousHandler(t *testing.T) {
 			},
 		},
 		{
+			// Order-book wire notifications use the transaction runner, so this
+			// case exercises only the retained order-book handler runner.
 			name: "orderBook",
 			register: func(c *Client, handler func()) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {
@@ -410,6 +414,8 @@ func TestClient_ReportStreamSkipsWhenChannelUnset(t *testing.T) {
 			},
 		},
 		{
+			// Order-book wire notifications use the transaction runner, so this
+			// case exercises only the retained order-book handler runner.
 			name: "orderBook",
 			report: func(c *Client) {
 				c.reportOrderBook(c.lifecycleContext(), &streamtypes.OrderBookStream{})
@@ -871,6 +877,8 @@ func TestClient_ReportStreamAfterDisconnectDoesNotBlock(t *testing.T) {
 			},
 		},
 		{
+			// Order-book wire notifications use the transaction runner, so this
+			// case exercises only the retained order-book handler runner.
 			name: "orderBook",
 			register: func(c *Client) {
 				c.OnOrderBook(func(*streamtypes.OrderBookStream) {})


### PR DESCRIPTION
# fix: secure authenticated RPC transport and fix WebSocket stream dispatch

## Description
This PR aims to prevent credentials from being sent over insecure RPC connections and to dispatch `bookChanges` notifications while making WebSocket stream handlers safe.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

### RPC transport security
- Require a valid HTTPS URL for requests that contain credentials.
- Recheck the URL and credentials before each request.
- Reject nil HTTP client configurations during setup and request-time revalidation.
- Block redirects from HTTPS to insecure URLs without replacing the caller's redirect policy.
- Hide credential data in errors.

### WebSocket stream dispatch
- Dispatch `bookChanges` messages to `OnBookChanges`.
- Report invalid stream JSON instead of sending empty values to handlers.
- Keep messages ordered for each stream and permit different streams to run at the same time.
- Keep handler registrations after reconnects and prevent duplicate delivery.

## Notes (optional)

- `OnBookChanges` now receives callbacks.
- Order-book subscription updates continue to arrive through `OnTransactions`. Rippled does not identify which subscription produced a transaction message.
- Authenticated requests require HTTPS. XRPL Go adds redirect-downgrade protection to `*http.Client`. Other `HTTPClient` implementations control their own redirects and credential handling.
- Automatic subscription restore after a reconnect is not included.



