### PR TITLE
fix(binary-codec): align XLS-96 wire definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### binary-codec
 
-- Added XLS-96 confidential MPT fields and transaction definitions for `ConfidentialMPTSend`, `ConfidentialMPTConvert`, `ConfidentialMPTConvertBack`, `ConfidentialMPTMergeInbox`, and `ConfidentialMPTClawback`.
+- Synced the embedded `definitions.json` with the rippled 3.3.0 protocol definitions.
+- Added XLS-96 confidential MPT fields and transaction definitions for `ConfidentialMPTSend`, `ConfidentialMPTConvert`, `ConfidentialMPTConvertBack`, `ConfidentialMPTMergeInbox`, and `ConfidentialMPTClawback`, with `ConfidentialOutstandingAmount` serialized as a decimal string like the other MPT amount fields.
+- Added the `tecBAD_PROOF`, `tecNO_SPONSOR_PERMISSION`, `temBAD_CIPHERTEXT`, `tefBAD_PATH_COUNT`, `tefNO_DST_PARTIAL`, and `terNO_PERMISSION` transaction results, which previously could not be encoded by name.
 
 #### confidential
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .PHONY: test-integration-localnet test-integration-localnet-ci test-integration-devnet test-integration-testnet
 .PHONY: coverage-unit coverage-unit-ci test-report-summary benchmark
 .PHONY: test-confidential update-mpt-crypto
+.PHONY: update-definitions
 
 UNIT_TEST_PACKAGES = $(shell go list ./... | grep -v /faucet | grep -v /examples | grep -v /testutil | grep -v /interfaces | grep -v /confidential) ./xrpl/testutil/integration/...
 EXCLUDED_TEST_PACKAGES = $(shell go list ./... | grep -v /faucet | grep -v /examples | grep -v /testutil | grep -v /interfaces | grep -v /confidential)
@@ -159,3 +160,12 @@ test-confidential:
 
 update-mpt-crypto:
 	@bash confidential/deps/update.sh
+
+################################################################################
+######################### PROTOCOL DEFINITIONS #################################
+################################################################################
+
+# Refreshes binary-codec/definitions/definitions.json from a node's
+# server_definitions response. Override the node with NODE_URL=<url>.
+update-definitions:
+	@bash scripts/update-definitions.sh $(if $(NODE_URL),--node "$(NODE_URL)")

--- a/binary-codec/README.md
+++ b/binary-codec/README.md
@@ -32,7 +32,20 @@ The codec is split into three sub-packages, each with a distinct responsibility:
 
 ### `definitions/`
 
-The schema registry for the entire codec. At startup it embeds and parses `definitions.json` — the authoritative XRPL protocol document — into a singleton `Definitions` struct. Everything the serializer and parser need to know about a field lives here:
+The schema registry for the entire codec. At startup it embeds and parses `definitions.json`, the authoritative XRPL protocol document, into a singleton `Definitions` struct.
+
+The embedded copy is a verbatim snapshot of the `server_definitions` response of a xrpld node. Its top-level `hash` identifies that snapshot. Refresh it with the maintainer target instead of editing entries by hand, so the document keeps matching the network:
+
+```bash
+make update-definitions                                     # mainnet
+make update-definitions NODE_URL=http://127.0.0.1:5005/     # localnet
+```
+
+The target re-fetches `server_definitions`, unwraps the JSON-RPC `result` envelope, drops the request-scoped `status` key, and rewrites the file with sorted keys and two-space indentation, so re-running it against an unchanged node produces no diff. It also reports the version of the node it fetched from, so the snapshot can be traced back to a build.
+
+The response covers everything the node's build can parse, not what its network has activated. Field and type definitions therefore land in the codec ahead of mainnet activation.
+
+Everything the serializer and parser need to know about a field lives here:
 
 - **`Types`** — maps type names (e.g. `"UInt32"`, `"Amount"`) to their numeric type codes.
 - **`Fields`** — maps field names (e.g. `"Fee"`, `"Destination"`) to a `FieldInstance`, which contains:

--- a/binary-codec/codec_test.go
+++ b/binary-codec/codec_test.go
@@ -53,6 +53,36 @@ func TestDefinitionFieldsRoundTrip(t *testing.T) {
 			expected: "11007E5027A738A1E6E8505E1FC77BBB9FEF84FF9A9C609F2739E0F9573CDD6367100A0AA9",
 		},
 		{
+			name: "ConfidentialMPTConvert BlindingFactor uses Hash256 field 40",
+			input: map[string]any{
+				"TransactionType": "ConfidentialMPTConvert",
+				"Account":         "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+				"MPTAmount":       "100",
+				"BlindingFactor":  "1E617B6FA885D8F2C1F22AFED8053BAACDEFEEEA4813EEDA30B6DF517851A509",
+			},
+			expected: "120055301A000000000000006450281E617B6FA885D8F2C1F22AFED8053BAACDEFEEEA4813EEDA30B6DF517851A509811495F14B0E44F78A264E41713C64B5F89242540EE2",
+		},
+		{
+			name: "ConfidentialMPTSend commitments use Blob fields 45 and 46",
+			input: map[string]any{
+				"TransactionType":   "ConfidentialMPTSend",
+				"Account":           "rNCFjv8Ek5oDrNiMJ3pw6eLLFtMjZLJnf2",
+				"AmountCommitment":  "02E65F6CAA5D1F1910EB95345B222D906874BE7A6E75B1AD7CCF52C6A767089BFA",
+				"BalanceCommitment": "03596B2A176A8255A62FE5718A054A6B3E318B122F3F2FD783D551E0F17F628BB6",
+			},
+			expected: "120058702D2102E65F6CAA5D1F1910EB95345B222D906874BE7A6E75B1AD7CCF52C6A767089BFA702E2103596B2A176A8255A62FE5718A054A6B3E318B122F3F2FD783D551E0F17F628BB6811495F14B0E44F78A264E41713C64B5F89242540EE2",
+		},
+		{
+			name: "MPTokenIssuance confidential encryption keys and outstanding amount",
+			input: map[string]any{
+				"LedgerEntryType":               "MPTokenIssuance",
+				"ConfidentialOutstandingAmount": "100",
+				"IssuerEncryptionKey":           "0287729B8FC5820EA0264CCB119D831913CF186E3B575B23B277127FDBD5F15897",
+				"AuditorEncryptionKey":          "0351E792649D0108D02C7138ED2C77548276C563646CC250A28D6A312D8D78F3D2",
+			},
+			expected: "11007E302000000000000000647023210287729B8FC5820EA0264CCB119D831913CF186E3B575B23B277127FDBD5F15897702C210351E792649D0108D02C7138ED2C77548276C563646CC250A28D6A312D8D78F3D2",
+		},
+		{
 			name: "DirectoryNode MPT book assets",
 			input: map[string]any{
 				"LedgerEntryType": "DirectoryNode",
@@ -488,6 +518,7 @@ func TestMPTUInt64FieldsUseDecimalJSON(t *testing.T) {
 		{field: "OutstandingAmount", header: "3019"},
 		{field: "MPTAmount", header: "301A"},
 		{field: "LockedAmount", header: "301D"},
+		{field: "ConfidentialOutstandingAmount", header: "3020"},
 	}
 
 	for _, tt := range tests {

--- a/binary-codec/definitions/definitions.json
+++ b/binary-codec/definitions/definitions.json
@@ -879,6 +879,56 @@
       }
     ],
     [
+      "SponsoredOwnerCount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 70,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "SponsoringOwnerCount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 71,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "SponsoringAccountCount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 72,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "RemainingOwnerCount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 73,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "SponsorFlags",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 74,
+        "type": "UInt32"
+      }
+    ],
+    [
       "IndexNext",
       {
         "isSerialized": true,
@@ -1175,6 +1225,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 32,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "SponseeNode",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 33,
         "type": "UInt64"
       }
     ],
@@ -1559,6 +1619,26 @@
       }
     ],
     [
+      "BlindingFactor",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 40,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "ObjectID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 41,
+        "type": "Hash256"
+      }
+    ],
+    [
       "hash",
       {
         "isSerialized": false,
@@ -1845,6 +1925,36 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 31,
+        "type": "Amount"
+      }
+    ],
+    [
+      "FeeAmount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 32,
+        "type": "Amount"
+      }
+    ],
+    [
+      "MaxFee",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 33,
+        "type": "Amount"
+      }
+    ],
+    [
+      "FeeAmountDelta",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 34,
         "type": "Amount"
       }
     ],
@@ -2279,7 +2389,7 @@
       }
     ],
     [
-      "BlindingFactor",
+      "AmountCommitment",
       {
         "isSerialized": true,
         "isSigningField": true,
@@ -2289,22 +2399,12 @@
       }
     ],
     [
-      "AmountCommitment",
-      {
-        "isSerialized": true,
-        "isSigningField": true,
-        "isVLEncoded": true,
-        "nth": 46,
-        "type": "Blob"
-      }
-    ],
-    [
       "BalanceCommitment",
       {
         "isSerialized": true,
         "isSigningField": true,
         "isVLEncoded": true,
-        "nth": 47,
+        "nth": 46,
         "type": "Blob"
       }
     ],
@@ -2519,6 +2619,56 @@
       }
     ],
     [
+      "Sponsor",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 27,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "HighSponsor",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 28,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "LowSponsor",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 29,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "CounterpartySponsor",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 30,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "Sponsee",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 31,
+        "type": "AccountID"
+      }
+    ],
+    [
       "Number",
       {
         "isSerialized": true,
@@ -2695,6 +2845,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 1,
+        "type": "Int32"
+      }
+    ],
+    [
+      "RemainingOwnerCountDelta",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "Int32"
       }
     ],
@@ -3045,6 +3205,16 @@
         "isSigningField": false,
         "isVLEncoded": false,
         "nth": 37,
+        "type": "STObject"
+      }
+    ],
+    [
+      "SponsorSignature",
+      {
+        "isSerialized": true,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 38,
         "type": "STObject"
       }
     ],
@@ -3728,6 +3898,10 @@
     "SignerList": {
       "lsfOneOwnerCount": 65536
     },
+    "Sponsorship": {
+      "lsfSponsorshipRequireSignForFee": 65536,
+      "lsfSponsorshipRequireSignForReserve": 131072
+    },
     "Vault": {
       "lsfVaultPrivate": 65536
     }
@@ -3855,6 +4029,18 @@
       {
         "name": "FirstNFTokenSequence",
         "optionality": 1
+      },
+      {
+        "name": "SponsoredOwnerCount",
+        "optionality": 2
+      },
+      {
+        "name": "SponsoringOwnerCount",
+        "optionality": 2
+      },
+      {
+        "name": "SponsoringAccountCount",
+        "optionality": 2
       },
       {
         "name": "AMMID",
@@ -4491,6 +4677,30 @@
       {
         "name": "PreviousTxnLgrSeq",
         "optionality": 0
+      },
+      {
+        "name": "ConfidentialBalanceInbox",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialBalanceSpending",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialBalanceVersion",
+        "optionality": 2
+      },
+      {
+        "name": "IssuerEncryptedBalance",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptedBalance",
+        "optionality": 1
+      },
+      {
+        "name": "HolderEncryptionKey",
+        "optionality": 1
       }
     ],
     "MPTokenIssuance": [
@@ -4549,6 +4759,18 @@
       {
         "name": "ReferenceHolding",
         "optionality": 1
+      },
+      {
+        "name": "IssuerEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "ConfidentialOutstandingAmount",
+        "optionality": 2
       }
     ],
     "NFTokenOffer": [
@@ -4857,6 +5079,14 @@
       {
         "name": "HighQualityOut",
         "optionality": 1
+      },
+      {
+        "name": "HighSponsor",
+        "optionality": 1
+      },
+      {
+        "name": "LowSponsor",
+        "optionality": 1
       }
     ],
     "SignerList": [
@@ -4886,6 +5116,44 @@
       },
       {
         "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      }
+    ],
+    "Sponsorship": [
+      {
+        "name": "PreviousTxnID",
+        "optionality": 0
+      },
+      {
+        "name": "PreviousTxnLgrSeq",
+        "optionality": 0
+      },
+      {
+        "name": "Owner",
+        "optionality": 0
+      },
+      {
+        "name": "Sponsee",
+        "optionality": 0
+      },
+      {
+        "name": "FeeAmount",
+        "optionality": 1
+      },
+      {
+        "name": "MaxFee",
+        "optionality": 1
+      },
+      {
+        "name": "RemainingOwnerCount",
+        "optionality": 2
+      },
+      {
+        "name": "OwnerNode",
+        "optionality": 0
+      },
+      {
+        "name": "SponseeNode",
         "optionality": 0
       }
     ],
@@ -5053,6 +5321,10 @@
       {
         "name": "Flags",
         "optionality": 0
+      },
+      {
+        "name": "Sponsor",
+        "optionality": 1
       }
     ]
   },
@@ -5084,6 +5356,7 @@
     "PermissionedDomain": 130,
     "RippleState": 114,
     "SignerList": 83,
+    "Sponsorship": 144,
     "Ticket": 84,
     "Vault": 132,
     "XChainOwnedClaimID": 113,
@@ -5183,11 +5456,24 @@
     "Payment": {
       "tfLimitQuality": 262144,
       "tfNoRippleDirect": 65536,
-      "tfPartialPayment": 131072
+      "tfPartialPayment": 131072,
+      "tfSponsorCreatedAccount": 524288
     },
     "PaymentChannelClaim": {
       "tfClose": 131072,
       "tfRenew": 65536
+    },
+    "SponsorshipSet": {
+      "tfDeleteObject": 1048576,
+      "tfSponsorshipClearRequireSignForFee": 131072,
+      "tfSponsorshipClearRequireSignForReserve": 524288,
+      "tfSponsorshipSetRequireSignForFee": 65536,
+      "tfSponsorshipSetRequireSignForReserve": 262144
+    },
+    "SponsorshipTransfer": {
+      "tfSponsorshipCreate": 131072,
+      "tfSponsorshipEnd": 65536,
+      "tfSponsorshipReassign": 262144
     },
     "TrustSet": {
       "tfClearDeepFreeze": 8388608,
@@ -5460,6 +5746,144 @@
       },
       {
         "name": "Holder",
+        "optionality": 1
+      }
+    ],
+    "ConfidentialMPTClawback": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Holder",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTConvert": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "HolderEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "HolderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "BlindingFactor",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 1
+      }
+    ],
+    "ConfidentialMPTConvertBack": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "MPTAmount",
+        "optionality": 0
+      },
+      {
+        "name": "HolderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "BlindingFactor",
+        "optionality": 0
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      },
+      {
+        "name": "BalanceCommitment",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTMergeInbox": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      }
+    ],
+    "ConfidentialMPTSend": [
+      {
+        "name": "MPTokenIssuanceID",
+        "optionality": 0
+      },
+      {
+        "name": "Destination",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
+        "name": "SenderEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "DestinationEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "IssuerEncryptedAmount",
+        "optionality": 0
+      },
+      {
+        "name": "AuditorEncryptedAmount",
+        "optionality": 1
+      },
+      {
+        "name": "ZKProof",
+        "optionality": 0
+      },
+      {
+        "name": "AmountCommitment",
+        "optionality": 0
+      },
+      {
+        "name": "BalanceCommitment",
+        "optionality": 0
+      },
+      {
+        "name": "CredentialIDs",
         "optionality": 1
       }
     ],
@@ -5862,6 +6286,14 @@
       {
         "name": "ImmutableFlags",
         "optionality": 1
+      },
+      {
+        "name": "IssuerEncryptionKey",
+        "optionality": 1
+      },
+      {
+        "name": "AuditorEncryptionKey",
+        "optionality": 1
       }
     ],
     "NFTokenAcceptOffer": [
@@ -6190,6 +6622,38 @@
         "optionality": 1
       }
     ],
+    "SponsorshipSet": [
+      {
+        "name": "CounterpartySponsor",
+        "optionality": 1
+      },
+      {
+        "name": "Sponsee",
+        "optionality": 1
+      },
+      {
+        "name": "FeeAmountDelta",
+        "optionality": 1
+      },
+      {
+        "name": "MaxFee",
+        "optionality": 1
+      },
+      {
+        "name": "RemainingOwnerCountDelta",
+        "optionality": 1
+      }
+    ],
+    "SponsorshipTransfer": [
+      {
+        "name": "ObjectID",
+        "optionality": 1
+      },
+      {
+        "name": "Sponsee",
+        "optionality": 1
+      }
+    ],
     "TicketCreate": [
       {
         "name": "TicketCount",
@@ -6272,6 +6736,10 @@
       {
         "name": "VaultID",
         "optionality": 0
+      },
+      {
+        "name": "MemoData",
+        "optionality": 1
       }
     ],
     "VaultDeposit": [
@@ -6576,6 +7044,18 @@
       {
         "name": "Delegate",
         "optionality": 1
+      },
+      {
+        "name": "Sponsor",
+        "optionality": 1
+      },
+      {
+        "name": "SponsorFlags",
+        "optionality": 1
+      },
+      {
+        "name": "SponsorSignature",
+        "optionality": 1
       }
     ]
   },
@@ -6589,6 +7069,7 @@
     "tecARRAY_EMPTY": 190,
     "tecARRAY_TOO_LARGE": 191,
     "tecBAD_CREDENTIALS": 193,
+    "tecBAD_PROOF": 199,
     "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
     "tecCLAIM": 100,
     "tecCRYPTOCONDITION_ERROR": 146,
@@ -6628,6 +7109,7 @@
     "tecNO_LINE_REDUNDANT": 127,
     "tecNO_PERMISSION": 139,
     "tecNO_REGULAR_KEY": 131,
+    "tecNO_SPONSOR_PERMISSION": 200,
     "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
     "tecNO_TARGET": 138,
     "tecOBJECT_NOT_FOUND": 160,
@@ -6662,12 +7144,12 @@
     "tecXCHAIN_SELF_COMMIT": 184,
     "tecXCHAIN_SENDING_ACCOUNT_MISMATCH": 179,
     "tecXCHAIN_WRONG_CHAIN": 176,
-
     "tefALREADY": -198,
     "tefBAD_ADD_AUTH": -197,
     "tefBAD_AUTH": -196,
     "tefBAD_AUTH_MASTER": -183,
     "tefBAD_LEDGER": -195,
+    "tefBAD_PATH_COUNT": -176,
     "tefBAD_QUORUM": -185,
     "tefBAD_SIGNATURE": -186,
     "tefCREATED": -194,
@@ -6681,11 +7163,11 @@
     "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
     "tefNOT_MULTI_SIGNING": -184,
     "tefNO_AUTH_REQUIRED": -191,
+    "tefNO_DST_PARTIAL": -177,
     "tefNO_TICKET": -180,
     "tefPAST_SEQ": -190,
     "tefTOO_BIG": -181,
     "tefWRONG_PRIOR": -189,
-
     "telBAD_DOMAIN": -398,
     "telBAD_PATH_COUNT": -397,
     "telBAD_PUBLIC_KEY": -396,
@@ -6703,11 +7185,11 @@
     "telNO_DST_PARTIAL": -393,
     "telREQUIRES_NETWORK_ID": -385,
     "telWRONG_NETWORK": -386,
-
     "temARRAY_EMPTY": -253,
     "temARRAY_TOO_LARGE": -252,
     "temBAD_AMM_TOKENS": -261,
     "temBAD_AMOUNT": -298,
+    "temBAD_CIPHERTEXT": -248,
     "temBAD_CURRENCY": -297,
     "temBAD_EXPIRATION": -296,
     "temBAD_FEE": -295,
@@ -6755,7 +7237,6 @@
     "temXCHAIN_BRIDGE_BAD_REWARD_AMOUNT": -255,
     "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
     "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
-
     "terADDRESS_COLLISION": -86,
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
@@ -6766,13 +7247,13 @@
     "terNO_AUTH": -95,
     "terNO_DELEGATE_PERMISSION": -85,
     "terNO_LINE": -94,
+    "terNO_PERMISSION": -83,
     "terNO_RIPPLE": -90,
     "terOWNERS": -93,
     "terPRE_SEQ": -92,
     "terPRE_TICKET": -88,
     "terQUEUED": -89,
     "terRETRY": -99,
-
     "tesSUCCESS": 0
   },
   "TRANSACTION_TYPES": {
@@ -6840,6 +7321,8 @@
     "SetFee": 101,
     "SetRegularKey": 5,
     "SignerListSet": 12,
+    "SponsorshipSet": 91,
+    "SponsorshipTransfer": 90,
     "TicketCreate": 10,
     "TrustSet": 20,
     "UNLModify": 102,
@@ -6891,5 +7374,5 @@
     "Vector256": 19,
     "XChainBridge": 25
   },
-  "hash": "0F2AE080CAED01060B32CCFA9B8BEA653176490D9FB3513FD3CB6CD475BE09C8"
+  "hash": "F3DCCAD774156538A6AB3E6003A41273D5AE394A90989204838AE52A006F245B"
 }

--- a/binary-codec/definitions/definitions_test.go
+++ b/binary-codec/definitions/definitions_test.go
@@ -13,10 +13,15 @@ func TestLoadDefinitions(t *testing.T) {
 	require.Equal(t, int32(22), definitions.Types["Hash384"])
 	require.Equal(t, int32(23), definitions.Types["Hash512"])
 	require.Equal(t, int32(97), definitions.LedgerEntryTypes["AccountRoot"])
+	require.Equal(t, int32(144), definitions.LedgerEntryTypes["Sponsorship"])
 	require.Equal(t, int32(-399), definitions.TransactionResults["telLOCAL_ERROR"])
 	require.Equal(t, int32(-249), definitions.TransactionResults["temBAD_MPT"])
+	require.Equal(t, int32(-248), definitions.TransactionResults["temBAD_CIPHERTEXT"])
+	require.Equal(t, int32(199), definitions.TransactionResults["tecBAD_PROOF"])
 	require.Equal(t, int32(-84), definitions.TransactionResults["terLOCKED"])
+	require.Equal(t, int32(-83), definitions.TransactionResults["terNO_PERMISSION"])
 	require.Equal(t, int32(1), definitions.TransactionTypes["EscrowCreate"])
+	require.Equal(t, int32(91), definitions.TransactionTypes["SponsorshipSet"])
 	require.Equal(t, &FieldInfo{Nth: 0, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "Unknown"}, definitions.Fields["Generic"].FieldInfo)
 	require.Equal(t, &FieldInfo{Nth: 28, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "Hash256"}, definitions.Fields["NFTokenBuyOffer"].FieldInfo)
 	require.Equal(t, &FieldInfo{Nth: 16, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "UInt8"}, definitions.Fields["TickSize"].FieldInfo)
@@ -33,7 +38,7 @@ func TestLoadDefinitions(t *testing.T) {
 	require.Equal(t, int32(65537), definitions.GranularPermissions["TrustlineAuthorize"])
 	require.Equal(t, int32(1), definitions.DelegatablePermissions["Payment"])
 
-	mptFields := []struct {
+	fields := []struct {
 		name    string
 		info    *FieldInfo
 		header  *FieldHeader
@@ -63,8 +68,38 @@ func TestLoadDefinitions(t *testing.T) {
 			header:  &FieldHeader{TypeCode: 21, FieldCode: 4},
 			ordinal: 1376260,
 		},
+		{
+			name:    "BlindingFactor",
+			info:    &FieldInfo{Nth: 40, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "Hash256"},
+			header:  &FieldHeader{TypeCode: 5, FieldCode: 40},
+			ordinal: 327720,
+		},
+		{
+			name:    "AmountCommitment",
+			info:    &FieldInfo{Nth: 45, IsVLEncoded: true, IsSerialized: true, IsSigningField: true, Type: "Blob"},
+			header:  &FieldHeader{TypeCode: 7, FieldCode: 45},
+			ordinal: 458797,
+		},
+		{
+			name:    "BalanceCommitment",
+			info:    &FieldInfo{Nth: 46, IsVLEncoded: true, IsSerialized: true, IsSigningField: true, Type: "Blob"},
+			header:  &FieldHeader{TypeCode: 7, FieldCode: 46},
+			ordinal: 458798,
+		},
+		{
+			name:    "ObjectID",
+			info:    &FieldInfo{Nth: 41, IsVLEncoded: false, IsSerialized: true, IsSigningField: true, Type: "Hash256"},
+			header:  &FieldHeader{TypeCode: 5, FieldCode: 41},
+			ordinal: 327721,
+		},
+		{
+			name:    "Sponsor",
+			info:    &FieldInfo{Nth: 27, IsVLEncoded: true, IsSerialized: true, IsSigningField: true, Type: "AccountID"},
+			header:  &FieldHeader{TypeCode: 8, FieldCode: 27},
+			ordinal: 524315,
+		},
 	}
-	for _, field := range mptFields {
+	for _, field := range fields {
 		t.Run(field.name, func(t *testing.T) {
 			require.Equal(t, field.info, definitions.Fields[field.name].FieldInfo)
 			require.Equal(t, field.header, definitions.Fields[field.name].FieldHeader)

--- a/binary-codec/types/uint64.go
+++ b/binary-codec/types/uint64.go
@@ -20,7 +20,7 @@ const (
 // not available in the definitions consumed by the codec.
 func uint64JSONBaseForField(fieldName string) int {
 	switch fieldName {
-	case "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount":
+	case "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount", "ConfidentialOutstandingAmount":
 		return uint64JSONBaseDecimal
 	default:
 		return uint64JSONBaseHex

--- a/docs/changelog/v0.3.x/998_unreleased.md
+++ b/docs/changelog/v0.3.x/998_unreleased.md
@@ -6,31 +6,39 @@ title: Unreleased
 
 #### binary-codec
 
-- Added XLS-96 confidential MPT fields and transaction definitions for `ConfidentialMPTSend`, `ConfidentialMPTConvert`, `ConfidentialMPTConvertBack`, `ConfidentialMPTMergeInbox`, and `ConfidentialMPTClawback`.
+- Synced the embedded `definitions.json` with the rippled 3.3.0 protocol definitions.
+- Added XLS-96 confidential MPT fields and transaction definitions for `ConfidentialMPTSend`, `ConfidentialMPTConvert`, `ConfidentialMPTConvertBack`, `ConfidentialMPTMergeInbox`, and `ConfidentialMPTClawback`, with `ConfidentialOutstandingAmount` serialized as a decimal string like the other MPT amount fields.
+- Added the `tecBAD_PROOF`, `tecNO_SPONSOR_PERMISSION`, `temBAD_CIPHERTEXT`, `tefBAD_PATH_COUNT`, `tefNO_DST_PARTIAL`, and `terNO_PERMISSION` transaction results, which previously could not be encoded by name.
 
 #### confidential
 
-- Added CGo bindings and vendored native libraries for XRPLF `mpt-crypto`, with a no-CGo fallback and maintainer tooling for dependency updates.
+- Added CGo bindings and vendored native libraries for XRPLF `mpt-crypto`, with a `!cgo` fallback and maintainer tooling for dependency updates.
 - Added hex-string APIs for ElGamal encryption, Pedersen commitments, context hashes, and zero-knowledge proof generation and verification.
+- Added `test-confidential` and `update-mpt-crypto` Makefile targets and an automated dependency-update workflow.
 
 #### confidential/builder
 
-- Added online and offline helpers for confidential MPT send, convert, convert-back, clawback, and inbox-merge transactions.
+- Added online `Build*` and offline `Prepare*` helpers for confidential MPT send, convert, convert-back, clawback, and inbox-merge transactions.
 
 #### docs
 
-- Added confidential MPT documentation for package layout, supported platforms, transaction types, and high-level builders.
+- Added confidential MPT documentation covering the CGo requirement, package layout, transaction types, and high-level builders.
+
+#### pkg/hexutil
+
+- Added `DecodeFixedHex()` to decode hexadecimal values and enforce their decoded byte length.
 
 #### xrpl
 
-- Added confidential MPT transaction and ledger-entry models, issuance flags and encryption keys, and ledger-entry index helpers.
+- Added confidential-transfer flags and encryption-key fields to MPT issuance transaction and ledger-entry models.
+- Added confidential balance fields to `MPToken`, five confidential MPT transaction models, and supporting amount, encryption-key, hex-blob, blinding-factor, and proof validation helpers.
+
+#### xrpl/hash
+
+- Added `MPToken()` and `MPTokenIssuance()` helpers for computing MPT ledger-entry keylet indexes.
 
 ### Fixed
 
-#### confidential
+#### dependencies
 
-- Tightened participant and fixed-size proof validation before invoking the native verifier.
-
-#### xrpl/transaction
-
-- Corrected confidential transaction key encoding and proof-size validation.
+- Raised the minimum Go version from 1.25.12 to 1.25.13 to fix the `net/url` quadratic path-resolution vulnerability (GO-2026-6218).

--- a/scripts/update-definitions.sh
+++ b/scripts/update-definitions.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Maintainer script: refreshes binary-codec/definitions/definitions.json from a
+# node's server_definitions response.
+#
+# The embedded document must stay a verbatim snapshot of what a node reports, so
+# this script never edits entries. It unwraps the JSON-RPC `result` envelope,
+# drops the request-scoped `status` key, and writes the rest back with sorted
+# keys and two-space indentation.
+#
+# Prerequisites:
+#   - curl
+#   - jq
+#
+# Usage:
+#   bash scripts/update-definitions.sh                                        # mainnet
+#   bash scripts/update-definitions.sh --node http://127.0.0.1:5005/          # localnet
+#   NODE_URL=https://s.devnet.rippletest.net:51234/ bash scripts/update-definitions.sh
+
+set -euo pipefail
+
+NODE_URL="${NODE_URL:-https://s1.ripple.com:51234/}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEFINITIONS_FILE="$REPO_ROOT/binary-codec/definitions/definitions.json"
+
+usage() {
+	echo "Usage: bash scripts/update-definitions.sh [--node URL]"
+	echo
+	echo "  --node URL  node to fetch server_definitions from (default: $NODE_URL)"
+	echo "              also settable through the NODE_URL environment variable"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--node)
+		NODE_URL="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+done
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "Missing required command: $1" >&2
+		exit 1
+	fi
+}
+
+require_command curl
+require_command jq
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+rpc() {
+	curl --silent --show-error --fail --max-time 60 \
+		-X POST "$NODE_URL" \
+		-H 'Content-Type: application/json' \
+		-d "{\"method\":\"$1\",\"params\":[{}]}"
+}
+
+echo "Fetching server_definitions from $NODE_URL..."
+rpc server_definitions >"$TMP_DIR/response.json"
+
+# A node that rejects the request still answers with HTTP 200, so the payload
+# decides whether the response is usable.
+if ! jq -e '.result | (has("FIELDS") and has("TYPES") and has("hash"))' "$TMP_DIR/response.json" >/dev/null; then
+	echo "Unexpected server_definitions response:" >&2
+	head -c 500 "$TMP_DIR/response.json" >&2
+	echo >&2
+	exit 1
+fi
+
+jq -S '.result | del(.status)' "$TMP_DIR/response.json" >"$TMP_DIR/definitions.json"
+
+OLD_HASH="$(jq -r '.hash // "none"' "$DEFINITIONS_FILE" 2>/dev/null || echo "none")"
+NEW_HASH="$(jq -r '.hash' "$TMP_DIR/definitions.json")"
+
+# Reporting the build the snapshot came from is a convenience, so a node that
+# does not answer server_info must not discard the definitions already fetched.
+NODE_VERSION="$(rpc server_info | jq -r '.result.info.rippled_version // .result.info.build_version // "unknown"' || echo "unknown")"
+
+mv "$TMP_DIR/definitions.json" "$DEFINITIONS_FILE"
+
+echo "Node version: $NODE_VERSION"
+if [ "$OLD_HASH" = "$NEW_HASH" ]; then
+	echo "Definitions unchanged (hash $NEW_HASH)."
+else
+	echo "Definitions updated: $OLD_HASH -> $NEW_HASH"
+	echo "Review the diff and run 'make test-binary-codec'."
+fi


### PR DESCRIPTION
# fix(binary-codec): align XLS-96 wire definitions

## Description
This PR aims to align the binary-codec wire definitions with the rippled 3.3.0 protocol.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Changes

- Sync the embedded `definitions.json` with the rippled 3.3.0 `server_definitions` response, keeping the XLS-96 confidential MPT definitions and adding previously missing transaction results
- Serialize `ConfidentialOutstandingAmount` as a decimal string like the other MPT amount fields
- Add an `update-definitions` Makefile target backed by `scripts/update-definitions.sh` to refresh the definitions from a node
