### PR TITLE
ci: measure API compatibility against the latest release tag

### DIFF
--- a/.github/workflows/ci-api-compatibility.yml
+++ b/.github/workflows/ci-api-compatibility.yml
@@ -48,21 +48,51 @@ jobs:
             exit 1
           fi
 
-          base_directory="$RUNNER_TEMP/api-base"
+          # Compatibility is measured against the newest stable release rather
+          # than against the base commit, because only an API that users can
+          # already import can be broken. Exported API that the base branch
+          # gained after that release has never shipped, so reshaping it is not
+          # a breaking change. Prerelease tags are skipped, matching the stable
+          # tag format that the release workflow accepts.
+          baseline_ref=$(
+            git tag --merged "$BASE_SHA" --sort=-v:refname |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              head -n 1
+          ) || true
+
+          if [[ -z "$baseline_ref" ]]; then
+            baseline_ref=$BASE_SHA
+            echo "::notice title=No release to compare against::No stable release tag is reachable from the base branch, so the base commit is used as the baseline."
+          fi
+
+          export_api() {
+            local ref=$1 destination=$2 worktree
+            worktree=$(mktemp -d "$RUNNER_TEMP/api-tree-XXXXXX")
+            git archive "$ref" | tar -x -C "$worktree"
+            (
+              cd "$worktree"
+              apidiff -m -w "$destination" "$MODULE_PATH"
+            )
+          }
+
+          baseline_api="$RUNNER_TEMP/api-baseline.export"
           base_api="$RUNNER_TEMP/api-base.export"
           head_api="$RUNNER_TEMP/api-head.export"
           api_changes="$RUNNER_TEMP/api-changes.txt"
+          baseline_to_base="$RUNNER_TEMP/api-baseline-to-base.txt"
+          baseline_to_head="$RUNNER_TEMP/api-baseline-to-head.txt"
           incompatible_changes="$RUNNER_TEMP/api-incompatible.txt"
 
-          mkdir -p "$base_directory"
-          git archive "$BASE_SHA" | tar -x -C "$base_directory"
-
-          (
-            cd "$base_directory"
-            apidiff -m -w "$base_api" "$MODULE_PATH"
-          )
+          export_api "$baseline_ref" "$baseline_api"
+          export_api "$BASE_SHA" "$base_api"
           apidiff -m -w "$head_api" "$MODULE_PATH"
-          apidiff -m "$base_api" "$head_api" > "$api_changes"
-          apidiff -m -incompatible "$base_api" "$head_api" > "$incompatible_changes"
 
-          scripts/report-api-compatibility.sh "$api_changes" "$incompatible_changes"
+          apidiff -m "$base_api" "$head_api" > "$api_changes"
+          apidiff -m -incompatible "$baseline_api" "$base_api" | sort > "$baseline_to_base"
+          apidiff -m -incompatible "$baseline_api" "$head_api" | sort > "$baseline_to_head"
+
+          # Breakage that the base branch already carries was acknowledged when
+          # it merged, so report only what this pull request adds on top of it.
+          comm -23 "$baseline_to_head" "$baseline_to_base" > "$incompatible_changes"
+
+          BASELINE_REF=$baseline_ref scripts/report-api-compatibility.sh "$api_changes" "$incompatible_changes"

--- a/scripts/report-api-compatibility.sh
+++ b/scripts/report-api-compatibility.sh
@@ -20,8 +20,15 @@ if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
 	exit 2
 fi
 
+if [[ -z "${BASELINE_REF:-}" ]]; then
+	echo "BASELINE_REF is not set." >&2
+	exit 2
+fi
+
 {
 	echo "## Exported API changes"
+	echo "What this pull request changes relative to the base branch."
+	echo
 	if [[ -s "$api_changes_file" ]]; then
 		echo '```text'
 		cat "$api_changes_file"
@@ -31,6 +38,8 @@ fi
 	fi
 	echo
 	echo "## Compatibility result"
+	echo "Measured against \`$BASELINE_REF\`. Exported API added after that point has never been released, so changing it is not breaking."
+	echo
 } >>"$GITHUB_STEP_SUMMARY"
 
 if [[ ! -s "$incompatible_changes_file" ]]; then


### PR DESCRIPTION
# ci: measure API compatibility against the latest release tag

## Description
This PR aims to stop the API Compatibility check from flagging breaking changes to exported API that was added to the base branch after the latest release and has therefore never shipped.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Changes

- Resolve the compatibility baseline as the newest stable `vX.Y.Z` tag reachable from the pull request base instead of the base commit. Prerelease tags are skipped, matching the stable tag format the release workflow accepts.
- Fall back to the base commit, with a `::notice`, when no stable release tag is reachable.
- Subtract the breakage the base branch already carries from the breakage the head branch carries, so a break that was acknowledged when it merged does not fail every later pull request.
- Report the baseline ref in the job summary and label the `Exported API changes` block as relative to the base branch, since that block can list incompatible changes while the check still passes.
